### PR TITLE
AMBARI-25770: Fix the service alert for zookeeper, add a new configur…

### DIFF
--- a/ambari-server/src/main/resources/stacks/BIGTOP/3.2.0/services/ZOOKEEPER/configuration/zoo.cfg.xml
+++ b/ambari-server/src/main/resources/stacks/BIGTOP/3.2.0/services/ZOOKEEPER/configuration/zoo.cfg.xml
@@ -90,4 +90,13 @@
       Set to a positive integer (1 and above) to enable the auto purging.</description>
     <on-ambari-upgrade add="true"/>
   </property>
+  <property>
+    <name>4lw.commands.whitelist</name>
+    <value>ruok</value>
+    <description>A list of comma separated Four Letter Words commands that user wants to use.
+      A valid Four Letter Words command must be put in this list else ZooKeeper server will not enable the command.
+      By default the whitelist only contains "srvr" command which zkServer.sh uses.
+      The rest of four letter word commands are disabled by default.</description>
+    <on-ambari-upgrade add="true"/>
+  </property>
 </configuration>


### PR DESCRIPTION
…ation for zookeeper.

## What changes were proposed in this pull request?

Add a configuration for zookeeper [The Four Letter Words](https://zookeeper.apache.org/doc/r3.6.3/zookeeperAdmin.html#sc_4lw)

## How was this patch tested?

Just Reinstall ZooKeeper, then Check alerts "ZooKeeper Server Process". 

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.