### PR TITLE
AMBARI-25294: Druid requires HDFS_CLIENT to be co-hosted, doesn't recognize ONEFS_CLIENT

### DIFF
--- a/ambari-server/src/main/resources/stacks/stack_advisor.py
+++ b/ambari-server/src/main/resources/stacks/stack_advisor.py
@@ -1964,6 +1964,9 @@ class DefaultStackAdvisor(StackAdvisor):
     component = next((component for component in componentsList
                               if component["component_name"] == componentName), None)
 
+    if component is None and componentName == 'HDFS_CLIENT':
+      component = next((component for component in componentsList if component["component_type"] == 'HCFS_CLIENT'), None)
+
     return component
 
   def getComponentAttribute(self, component, attribute):


### PR DESCRIPTION
AMBARI-25294: Druid requires HDFS_CLIENT to be co-hosted, doesn't recognize ONEFS_CLIENT

## What changes were proposed in this pull request?

(Please fill in changes proposed in this fix)

branch-2.7 backport commit: https://github.com/apache/ambari/pull/3079

## How was this patch tested?

(Please explain how this patch was tested. Ex: unit tests, manual tests)
(If this patch involves UI changes, please attach a screen-shot; otherwise, remove this)

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.