### PR TITLE
AMBARI-25273: Ambari-server uninstall removes ambari-python-wrap even…

### DIFF
--- a/ambari-server/conf/unix/install-helper.sh
+++ b/ambari-server/conf/unix/install-helper.sh
@@ -29,7 +29,7 @@ OLD_PYLIB_PATH="${ROOT}/usr/lib/python2.6/site-packages"
 OLD_PY_MODULES="ambari_commons;resource_management;ambari_jinja2;ambari_simplejson;ambari_server"
 
 AMBARI_SERVER_ROOT_DIR="${ROOT}/usr/lib/${AMBARI_UNIT}"
-AMBARI_AGENT_ROOT_DIR=="${ROOT}/usr/lib/ambari-agent"
+AMBARI_AGENT_ROOT_DIR="${ROOT}/usr/lib/ambari-agent"
 AMBARI_SERVER="${AMBARI_SERVER_ROOT_DIR}/lib/ambari_server"
 
 CA_CONFIG="${ROOT}/var/lib/${AMBARI_UNIT}/keys/ca.config"


### PR DESCRIPTION
… when agent is still installed

## What changes were proposed in this pull request?
Forward port commit [4c2748b](https://github.com/apache/ambari/commit/4c2748b42a9458ff9d4b646383273a78248e2d3e) on branch-2.7
(Please fill in changes proposed in this fix)

## How was this patch tested?

(Please explain how this patch was tested. Ex: unit tests, manual tests)
(If this patch involves UI changes, please attach a screen-shot; otherwise, remove this)

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.