### PR TITLE
AMBARI-25290: Custom timeout ignored, python script has been killed d…

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/ActionExecutionContext.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/ActionExecutionContext.java
@@ -39,7 +39,7 @@ public class ActionExecutionContext {
   private RequestOperationLevel operationLevel;
   private Map<String, String> parameters;
   private TargetHostType targetType;
-  private Short timeout;
+  private Integer timeout;
   private String expectedServiceName;
   private String expectedComponentName;
   private boolean hostsInMaintenanceModeExcluded = true;
@@ -68,7 +68,7 @@ public class ActionExecutionContext {
   public ActionExecutionContext(String clusterName, String actionName,
       List<RequestResourceFilter> resourceFilters,
       Map<String, String> parameters, TargetHostType targetType,
-      Short timeout, String expectedServiceName,
+      Integer timeout, String expectedServiceName,
       String expectedComponentName) {
 
     this.clusterName = clusterName;
@@ -113,11 +113,11 @@ public class ActionExecutionContext {
     return targetType;
   }
 
-  public Short getTimeout() {
+  public Integer getTimeout() {
     return timeout;
   }
 
-  public void setTimeout(Short timeout) {
+  public void setTimeout(Integer timeout) {
     this.timeout = timeout;
   }
 

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/AmbariCustomCommandExecutionHelper.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/AmbariCustomCommandExecutionHelper.java
@@ -420,7 +420,7 @@ public class AmbariCustomCommandExecutionHelper {
       commandParams.put(CUSTOM_COMMAND, commandName);
 
       boolean isInstallCommand = commandName.equals(RoleCommand.INSTALL.toString());
-      int commandTimeout = Short.valueOf(configs.getDefaultAgentTaskTimeout(isInstallCommand)).intValue();
+      int commandTimeout = Integer.valueOf(configs.getDefaultAgentTaskTimeout(isInstallCommand));
 
       ComponentInfo componentInfo = ambariMetaInfo.getComponent(
           stackId.getStackName(), stackId.getStackVersion(),

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/ClusterStackVersionResourceProvider.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/ClusterStackVersionResourceProvider.java
@@ -687,7 +687,7 @@ public class ClusterStackVersionResourceProvider extends AbstractControllerResou
         INSTALL_PACKAGES_ACTION, Collections.singletonList(filter), roleParams);
 
     actionContext.setStackId(repoVersion.getStackId());
-    actionContext.setTimeout(Short.valueOf(configuration.getDefaultAgentTaskTimeout(true)));
+    actionContext.setTimeout(Integer.valueOf(configuration.getDefaultAgentTaskTimeout(true)));
 
     repoVersionHelper.addCommandRepositoryToContext(actionContext, repoVersion, osEntity);
 

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/HostStackVersionResourceProvider.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/HostStackVersionResourceProvider.java
@@ -449,7 +449,7 @@ public class HostStackVersionResourceProvider extends AbstractControllerResource
             null, INSTALL_PACKAGES_ACTION,
             Collections.singletonList(filter),
             roleParams);
-    actionContext.setTimeout(Short.valueOf(configuration.getDefaultAgentTaskTimeout(true)));
+    actionContext.setTimeout(Integer.valueOf(configuration.getDefaultAgentTaskTimeout(true)));
     actionContext.setStackId(repoVersionEnt.getStackId());
 
     repoVersionHelper.addCommandRepositoryToContext(actionContext, repoVersionEnt, osEntity);
@@ -534,7 +534,7 @@ public class HostStackVersionResourceProvider extends AbstractControllerResource
       null, STACK_SELECT_ACTION,
       Collections.singletonList(filter),
       Collections.emptyMap());
-    actionContext.setTimeout(Short.valueOf(configuration.getDefaultAgentTaskTimeout(true)));
+    actionContext.setTimeout(Integer.valueOf(configuration.getDefaultAgentTaskTimeout(true)));
 
     try {
       actionExecutionHelper.get().addExecutionCommandsToStage(actionContext, stage, null, !forceInstallOnNonMemberHost);

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/UpgradeResourceProvider.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/UpgradeResourceProvider.java
@@ -1448,7 +1448,7 @@ public class UpgradeResourceProvider extends AbstractControllerResourceProvider 
 
     ActionExecutionContext actionContext = buildActionExecutionContext(cluster, context,
         Role.AMBARI_SERVER_ACTION.toString(), stackId, Collections.emptyList(),
-        commandParams, group.allowRetry, Short.valueOf((short) -1));
+        commandParams, group.allowRetry, -1);
 
     ExecuteCommandJson jsons = s_commandExecutionHelper.get().getCommandJson(actionContext,
         cluster, context.getRepositoryVersion().getStackId(), null);
@@ -1705,7 +1705,7 @@ public class UpgradeResourceProvider extends AbstractControllerResourceProvider 
   private ActionExecutionContext buildActionExecutionContext(Cluster cluster,
       UpgradeContext context, String role, StackId stackId,
       List<RequestResourceFilter> resourceFilters, Map<String, String> commandParams,
-      boolean allowRetry, short timeout) {
+      boolean allowRetry, int timeout) {
 
     ActionExecutionContext actionContext = new ActionExecutionContext(cluster.getClusterName(),
         role, resourceFilters, commandParams);

--- a/ambari-server/src/main/java/org/apache/ambari/server/customactions/ActionDefinition.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/customactions/ActionDefinition.java
@@ -36,7 +36,7 @@ public class ActionDefinition {
   private String targetComponent;
   private String description;
   private TargetHostType targetType;
-  private Short defaultTimeout;
+  private Integer defaultTimeout;
   private Set<RoleAuthorization> permissions;
 
   /**
@@ -54,7 +54,7 @@ public class ActionDefinition {
    */
   public ActionDefinition(String actionName, ActionType actionType, String inputs,
                           String targetService, String targetComponent, String description,
-                          TargetHostType targetType, Short defaultTimeout, Set<RoleAuthorization> permissions) {
+                          TargetHostType targetType, Integer defaultTimeout, Set<RoleAuthorization> permissions) {
     setActionName(actionName);
     setActionType(actionType);
     setInputs(inputs);
@@ -122,11 +122,11 @@ public class ActionDefinition {
     this.targetType = targetType;
   }
 
-  public Short getDefaultTimeout() {
+  public Integer getDefaultTimeout() {
     return defaultTimeout;
   }
 
-  public void setDefaultTimeout(Short defaultTimeout) {
+  public void setDefaultTimeout(Integer defaultTimeout) {
     this.defaultTimeout = defaultTimeout;
   }
 

--- a/ambari-server/src/main/java/org/apache/ambari/server/customactions/ActionDefinitionManager.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/customactions/ActionDefinitionManager.java
@@ -44,12 +44,12 @@ import org.slf4j.LoggerFactory;
  * Manages Action definitions read from XML files
  */
 public class ActionDefinitionManager {
-  public static final Short MIN_TIMEOUT = 60;
+  public static final Integer MIN_TIMEOUT = 60;
   private final static Logger LOG = LoggerFactory
       .getLogger(ActionDefinitionManager.class);
   private static final Map<Class<?>, JAXBContext> _jaxbContexts =
     new HashMap<>();
-  private static final Short MAX_TIMEOUT = Short.MAX_VALUE-1;
+  private static final Integer MAX_TIMEOUT = Integer.MAX_VALUE-1;
 
   static {
     try {
@@ -112,9 +112,9 @@ public class ActionDefinitionManager {
           TargetHostType targetType = safeValueOf(TargetHostType.class, ad.getTargetType(), errorReason);
           ActionType actionType = safeValueOf(ActionType.class, ad.getActionType(), errorReason);
 
-          Short defaultTimeout = MIN_TIMEOUT;
+          Integer defaultTimeout = MIN_TIMEOUT;
           if (ad.getDefaultTimeout() != null && !ad.getDefaultTimeout().isEmpty()) {
-            defaultTimeout = Short.parseShort(ad.getDefaultTimeout());
+            defaultTimeout = Integer.parseInt(ad.getDefaultTimeout());
           }
 
           if (isValidActionDefinition(ad, actionType, defaultTimeout, errorReason)) {
@@ -138,7 +138,7 @@ public class ActionDefinitionManager {
   }
 
   private boolean isValidActionDefinition(ActionDefinitionSpec ad, ActionType actionType,
-                                          Short defaultTimeout, StringBuilder reason) {
+                                          Integer defaultTimeout, StringBuilder reason) {
     if (isValidActionName(ad.getActionName(), reason)) {
 
       if (defaultTimeout < MIN_TIMEOUT || defaultTimeout > MAX_TIMEOUT) {

--- a/ambari-server/src/main/java/org/apache/ambari/server/stack/upgrade/orchestrate/StageWrapper.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/stack/upgrade/orchestrate/StageWrapper.java
@@ -192,7 +192,7 @@ public class StageWrapper {
    *                      this in.
    * @return the maximum timeout, or the default agent execution timeout if none are found.  Never {@code null}.
    */
-  public Short getMaxTimeout(Configuration configuration) {
+  public Integer getMaxTimeout(Configuration configuration) {
 
     Set<String> timeoutKeys = new HashSet<>();
 
@@ -201,20 +201,20 @@ public class StageWrapper {
       timeoutKeys.addAll(wrapper.getTimeoutKeys());
     }
 
-    Short defaultTimeout = Short.valueOf(configuration.getDefaultAgentTaskTimeout(false));
+    Integer defaultTimeout = Integer.valueOf(configuration.getDefaultAgentTaskTimeout(false));
 
     if (CollectionUtils.isEmpty(timeoutKeys)) {
       return defaultTimeout;
     }
 
-    Short timeout = null;
+    Integer timeout = null;
 
     for (String key : timeoutKeys) {
       String configValue = configuration.getProperty(key);
 
       if (StringUtils.isNotBlank(configValue)) {
         try {
-          Short configTimeout = Short.valueOf(configValue);
+          Integer configTimeout = Integer.valueOf(configValue);
 
           if (null == timeout || configTimeout > timeout) {
             timeout = configTimeout;

--- a/ambari-server/src/test/java/org/apache/ambari/server/controller/AmbariManagementControllerTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/controller/AmbariManagementControllerTest.java
@@ -3976,11 +3976,11 @@ public class AmbariManagementControllerTest {
 
 
     ActionDefinition a1 = new ActionDefinition(actionDef1, ActionType.SYSTEM,
-        "test,[optional1]", "", "", "Does file exist", TargetHostType.SPECIFIC, Short.valueOf("100"), null);
+        "test,[optional1]", "", "", "Does file exist", TargetHostType.SPECIFIC, Integer.valueOf("100"), null);
     controller.getAmbariMetaInfo().addActionDefinition(a1);
     controller.getAmbariMetaInfo().addActionDefinition(new ActionDefinition(
         actionDef2, ActionType.SYSTEM, "", "HDFS", "DATANODE", "Does file exist",
-        TargetHostType.ALL, Short.valueOf("1000"), null));
+        TargetHostType.ALL, Integer.valueOf("1000"), null));
 
     Map<String, String> params = new HashMap<String, String>() {{
       put("test", "test");
@@ -4033,7 +4033,7 @@ public class AmbariManagementControllerTest {
     Assert.assertEquals(requestProperties.get(REQUEST_CONTEXT_PROPERTY), response.getRequestContext());
 
     // !!! test that the action execution helper is using the right timeout
-    a1.setDefaultTimeout((short) 1800);
+    a1.setDefaultTimeout(1800);
     actionRequest = new ExecuteActionRequest(cluster1, null, actionDef1, resourceFilters, null, params, false);
     response = controller.createAction(actionRequest, requestProperties);
 
@@ -4353,23 +4353,23 @@ public class AmbariManagementControllerTest {
 
     controller.getAmbariMetaInfo().addActionDefinition(new ActionDefinition(
         actionDef1, ActionType.SYSTEM, "test,dirName", "", "", "Does file exist",
-        TargetHostType.SPECIFIC, Short.valueOf("100"), null));
+        TargetHostType.SPECIFIC, Integer.valueOf("100"), null));
 
     controller.getAmbariMetaInfo().addActionDefinition(new ActionDefinition(
         actionDef2, ActionType.SYSTEM, "", "HDFS", "DATANODE", "Does file exist",
-        TargetHostType.ANY, Short.valueOf("100"), null));
+        TargetHostType.ANY, Integer.valueOf("100"), null));
 
     controller.getAmbariMetaInfo().addActionDefinition(new ActionDefinition(
             "update_repo", ActionType.SYSTEM, "", "HDFS", "DATANODE", "Does file exist",
-            TargetHostType.ANY, Short.valueOf("100"), null));
+            TargetHostType.ANY, Integer.valueOf("100"), null));
 
     controller.getAmbariMetaInfo().addActionDefinition(new ActionDefinition(
         actionDef3, ActionType.SYSTEM, "", "MAPREDUCE", "MAPREDUCE_CLIENT", "Does file exist",
-        TargetHostType.ANY, Short.valueOf("100"), null));
+        TargetHostType.ANY, Integer.valueOf("100"), null));
 
     controller.getAmbariMetaInfo().addActionDefinition(new ActionDefinition(
         actionDef4, ActionType.SYSTEM, "", "HIVE", "", "Does file exist",
-        TargetHostType.ANY, Short.valueOf("100"), null));
+        TargetHostType.ANY, Integer.valueOf("100"), null));
 
     actionRequest = new ExecuteActionRequest(cluster1, null, actionDef1, null, null, null, false);
     expectActionCreationErrorWithMessage(actionRequest, requestProperties,
@@ -6101,7 +6101,7 @@ public class AmbariManagementControllerTest {
 
     controller.getAmbariMetaInfo().addActionDefinition(new ActionDefinition(
       action1, ActionType.SYSTEM, "", "HDFS", "", "Some custom action.",
-      TargetHostType.ALL, Short.valueOf("10010"), null));
+      TargetHostType.ALL, Integer.valueOf("10010"), null));
 
     Map<String, String> params = new HashMap<String, String>() {{
       put("test", "test");
@@ -9872,7 +9872,7 @@ public class AmbariManagementControllerTest {
 
     ambariMetaInfo.addActionDefinition(new ActionDefinition(action1, ActionType.SYSTEM,
         "", "", "", "action def description", TargetHostType.ANY,
-        Short.valueOf("60"), null));
+        Integer.valueOf("60"), null));
 
     Map<String, String> requestProperties = new HashMap<>();
     requestProperties.put(REQUEST_CONTEXT_PROPERTY, "Called from a test");

--- a/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/ActionResourceProviderTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/ActionResourceProviderTest.java
@@ -97,13 +97,13 @@ public class ActionResourceProviderTest {
     List<ActionDefinition> allDefinition = new ArrayList<>();
     allDefinition.add(new ActionDefinition(
         "a1", ActionType.SYSTEM, "fileName", "HDFS", "DATANODE", "Does file exist", TargetHostType.ANY,
-        Short.valueOf("100"), null));
+        Integer.valueOf("100"), null));
     allDefinition.add(new ActionDefinition(
         "a2", ActionType.SYSTEM, "fileName", "HDFS", "DATANODE", "Does file exist", TargetHostType.ANY,
-        Short.valueOf("100"), null));
+        Integer.valueOf("100"), null));
     allDefinition.add(new ActionDefinition(
         "a3", ActionType.SYSTEM, "fileName", "HDFS", "DATANODE", "Does file exist", TargetHostType.ANY,
-        Short.valueOf("100"), null));
+        Integer.valueOf("100"), null));
 
     Set<ActionResponse> allResponse = new HashSet<>();
     for (ActionDefinition definition : allDefinition) {
@@ -112,7 +112,7 @@ public class ActionResourceProviderTest {
 
     ActionDefinition namedDefinition = new ActionDefinition(
         "a1", ActionType.SYSTEM, "fileName", "HDFS", "DATANODE", "Does file exist", TargetHostType.ANY,
-        Short.valueOf("100"), null);
+        Integer.valueOf("100"), null);
 
     Set<ActionResponse> nameResponse = new HashSet<>();
     nameResponse.add(namedDefinition.convertToResponse());


### PR DESCRIPTION
…ue to timeout after waiting 2700 secs during upgrade

## What changes were proposed in this pull request?
Forward port commit [fb64138](https://github.com/apache/ambari/commit/fb64138a7159a837aec846777a33169109fba9cf) on branch-2.7
(Please fill in changes proposed in this fix)

## How was this patch tested?

(Please explain how this patch was tested. Ex: unit tests, manual tests)
(If this patch involves UI changes, please attach a screen-shot; otherwise, remove this)

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.