### PR TITLE
AMBARI-25776: The `Database Connectivity Warning` is incorrectly reported when Hive is installed in the initial cluster

### DIFF
--- a/ambari-web/app/views/common/configs/widgets/test_db_connection_widget_view.js
+++ b/ambari-web/app/views/common/configs/widgets/test_db_connection_widget_view.js
@@ -188,7 +188,7 @@ App.TestDbConnectionWidgetView = App.ConfigWidgetView.extend({
   connectToDatabase: function () {
     if (this.get('isBtnDisabled')) return;
     this.set('isRequestResolved', false);
-    App.db.set('tmp', this.get('parentView.service.serviceName') + '_connection', {});
+    App.db.set('tmp', this.get('db_connection_url.serviceName') + '_connection', {});
     this.setConnectingStatus(true);
     if (App.get('testMode')) {
       this.startPolling();
@@ -337,7 +337,7 @@ App.TestDbConnectionWidgetView = App.ConfigWidgetView.extend({
         });
         this.setResponseStatus('failed');
       } else {
-        App.db.set('tmp', this.get('parentView.service.serviceName') + '_connection', this.get('preparedDBProperties'));
+        App.db.set('tmp', this.get('db_connection_url.serviceName') + '_connection', this.get('preparedDBProperties'));
         this.setResponseStatus('success');
       }
     }


### PR DESCRIPTION
AMBARI-25776: The `Database Connectivity Warning` is incorrectly reported when Hive is installed in the initial cluster

## What changes were proposed in this pull request?

(Please fill in changes proposed in this fix)

## How was this patch tested?

(Please explain how this patch was tested. Ex: unit tests, manual tests)
(If this patch involves UI changes, please attach a screen-shot; otherwise, remove this)

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.