### PR TITLE
AMBARI-23469: HostCleanup.py script is failing with AttributeError: '…

### DIFF
--- a/ambari-agent/src/main/python/ambari_agent/HostCleanup.py
+++ b/ambari-agent/src/main/python/ambari_agent/HostCleanup.py
@@ -141,9 +141,14 @@ class HostCleanup:
       dirList = argMap.get(DIR_SECTION)
       repoList = argMap.get(REPO_SECTION)
       proc_map = argMap.get(PROCESS_SECTION)
-      procList = proc_map.get(PROCESS_KEY)
-      procUserList = proc_map.get(PROCESS_OWNER_KEY)
-      procIdentifierList = proc_map.get(PROCESS_IDENTIFIER_KEY)
+      if proc_map:
+        procList = proc_map.get(PROCESS_KEY)
+        procUserList = proc_map.get(PROCESS_OWNER_KEY)
+        procIdentifierList = proc_map.get(PROCESS_IDENTIFIER_KEY)
+      else:
+        procList = []
+        procUserList = []
+        procIdentifierList = []
       alt_map = argMap.get(ALT_SECTION)
       additionalDirList = self.get_additional_dirs()
 


### PR DESCRIPTION
…NoneType' object has no attribute 'get'

## What changes were proposed in this pull request?
Forward port commit [b059611](https://github.com/apache/ambari/commit/b05961104ea272a6885d03ce6978eb03422479d4) on branch-2.7
(Please fill in changes proposed in this fix)

## How was this patch tested?

(Please explain how this patch was tested. Ex: unit tests, manual tests)
(If this patch involves UI changes, please attach a screen-shot; otherwise, remove this)

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.