### PR TITLE
AMBARI-25421: SI Start failing when enabled from Hive>Configs tab

### DIFF
--- a/ambari-web/app/mixins/common/configs/enhanced_configs.js
+++ b/ambari-web/app/mixins/common/configs/enhanced_configs.js
@@ -221,7 +221,8 @@ App.EnhancedConfigsMixin = Em.Mixin.create(App.ConfigWithOverrideRecommendationP
     var updateDependencies = Em.isArray(changedConfigs) && changedConfigs.length > 0;
     var stepConfigs = this.get('stepConfigs');
     var requiredTags = [];
-    const isAutoComplete = Boolean(this.get('isRecommendationsAutoComplete'));
+    const isAutoComplete = !updateDependencies;
+    this.set('isRecommendationsAutoComplete', isAutoComplete);
 
     if (updateDependencies || Em.isNone(this.get('recommendationsConfigs'))) {
       var recommendations = isAutoComplete ? {} : this.get('hostGroups');


### PR DESCRIPTION
## What changes were proposed in this pull request?
Forward port commit [da6150c](https://github.com/apache/ambari/commit/da6150cb820bf74948e0e5aca62482e2f32cc929) on branch-2.7
(Please fill in changes proposed in this fix)

## How was this patch tested?

(Please explain how this patch was tested. Ex: unit tests, manual tests)
(If this patch involves UI changes, please attach a screen-shot; otherwise, remove this)

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.