### PR TITLE
AMBARI-25341: SmartSense API call fails with Unsupported Media Type

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/api/ContentTypeOverrideFilter.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/api/ContentTypeOverrideFilter.java
@@ -23,6 +23,7 @@ import java.util.Collections;
 import java.util.Enumeration;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.regex.Pattern;
 
 import javax.servlet.Filter;
 import javax.servlet.FilterChain;
@@ -61,7 +62,7 @@ public class ContentTypeOverrideFilter implements Filter {
 
     private static final Logger logger = LoggerFactory.getLogger(ContentTypeOverrideFilter.class);
 
-    private final Set<String> excludedUrls = new HashSet<>();
+    private final Set<Pattern> excludedUrls = new HashSet<>();
 
     class ContentTypeOverrideRequestWrapper extends HttpServletRequestWrapper {
 
@@ -132,7 +133,7 @@ public class ContentTypeOverrideFilter implements Filter {
             HttpServletRequest httpServletRequest = (HttpServletRequest) request;
             String contentType = httpServletRequest.getContentType();
 
-            if (contentType != null && contentType.startsWith(MediaType.APPLICATION_JSON) && !excludedUrls.contains(httpServletRequest.getPathInfo())) {
+            if (contentType != null && contentType.startsWith(MediaType.APPLICATION_JSON) && !isUrlExcluded(httpServletRequest.getPathInfo())) {
                 ContentTypeOverrideRequestWrapper requestWrapper = new ContentTypeOverrideRequestWrapper(httpServletRequest);
                 ContentTypeOverrideResponseWrapper responseWrapper = new ContentTypeOverrideResponseWrapper((HttpServletResponse) response);
 
@@ -160,7 +161,7 @@ public class ContentTypeOverrideFilter implements Filter {
                             Consumes consumesAnnotation = method.getAnnotation(Consumes.class);
                             for (String consume : consumesAnnotation.value()) {
                                 if (MediaType.APPLICATION_JSON.equals(consume)) {
-                                    excludedUrls.add(path.value());
+                                    excludedUrls.add(Pattern.compile(path.value()));
                                     continue restart;
                                 }
                             }
@@ -172,8 +173,14 @@ public class ContentTypeOverrideFilter implements Filter {
             logger.error("Failed to discover URLs that are excluded from Content-Type override. Falling back to pre-defined list of exluded URLs.", e);
 
             /* Do not fail here, but fallback to manual definition of excluded endpoints. */
-            excludedUrls.add("/bootstrap");
+            excludedUrls.add(Pattern.compile("/bootstrap"));
+        } finally {
+            excludedUrls.add(Pattern.compile("/views/.*"));
         }
+    }
+
+    private boolean isUrlExcluded(String pathInfo) {
+        return excludedUrls.stream().anyMatch(p -> p.matcher(pathInfo).matches());
     }
 
     @Override


### PR DESCRIPTION
## What changes were proposed in this pull request?
Forward port commit [dacfd92](https://github.com/apache/ambari/commit/dacfd92e07e2cedf7d172c637cfeeb1a39611d66) on branch-2.7
(Please fill in changes proposed in this fix)

## How was this patch tested?

(Please explain how this patch was tested. Ex: unit tests, manual tests)
(If this patch involves UI changes, please attach a screen-shot; otherwise, remove this)

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.