### PR TITLE
AMBARI-25440: Server sets blueprint_provisioning_state for component …

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/state/svccomphost/ServiceComponentHostImpl.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/svccomphost/ServiceComponentHostImpl.java
@@ -1020,7 +1020,7 @@ public class ServiceComponentHostImpl implements ServiceComponentHost {
           STOMPUpdatePublisher.publish(new HostComponentsUpdateEvent(Collections.singletonList(
               HostComponentUpdate.createHostComponentStatusUpdate(stateEntity, oldState))));
         }
-        if (event.getType().equals(ServiceComponentHostEventType.HOST_SVCCOMP_START)) {
+        if (event.getType().equals(ServiceComponentHostEventType.HOST_SVCCOMP_STARTED)) {
           HostComponentDesiredStateEntity desiredStateEntity = getDesiredStateEntity();
           if (desiredStateEntity.getBlueprintProvisioningState() == BlueprintProvisioningState.IN_PROGRESS) {
             desiredStateEntity.setBlueprintProvisioningState(BlueprintProvisioningState.FINISHED);


### PR DESCRIPTION
…to finished before start command execution

## What changes were proposed in this pull request?
Forward port commit [4a61abb](https://github.com/apache/ambari/commit/4a61abbe29c77ca3f101e7aea3767e11313eaf9b) on branch-2.7
(Please fill in changes proposed in this fix)

## How was this patch tested?

(Please explain how this patch was tested. Ex: unit tests, manual tests)
(If this patch involves UI changes, please attach a screen-shot; otherwise, remove this)

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.