### PR TITLE
AMBARI-25413: Ambari is changing the truststore permission from 444/6…

### DIFF
--- a/ambari-server/src/main/python/ambari_server/serverConfiguration.py
+++ b/ambari-server/src/main/python/ambari_server/serverConfiguration.py
@@ -412,7 +412,7 @@ class ServerConfigDefaults(object):
 
     self.MASTER_KEY_FILE_PERMISSIONS = "640"
     self.CREDENTIALS_STORE_FILE_PERMISSIONS = "640"
-    self.TRUST_STORE_LOCATION_PERMISSIONS = "640"
+    self.TRUST_STORE_LOCATION_PERMISSIONS = "644"
 
     self.DEFAULT_DB_NAME = "ambari"
 


### PR DESCRIPTION
…44 to 640

## What changes were proposed in this pull request?
Forward port commit [a4557c6](https://github.com/apache/ambari/commit/a4557c66df571a04ed4c4d487542c16960d9eadd) on branch-2.7
(Please fill in changes proposed in this fix)

## How was this patch tested?

(Please explain how this patch was tested. Ex: unit tests, manual tests)
(If this patch involves UI changes, please attach a screen-shot; otherwise, remove this)

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.