### PR TITLE
AMBARI-25779: Ambari server spi build error

### DIFF
--- a/ambari-admin/pom.xml
+++ b/ambari-admin/pom.xml
@@ -77,7 +77,7 @@
           </execution>
           <execution>
             <id>npm install</id>
-            <phase>none</phase>
+            <phase>generate-sources</phase>
             <goals>
               <goal>npm</goal>
             </goals>
@@ -93,7 +93,7 @@
         <executions>
           <execution>
             <id>Bower install</id>
-            <phase>none</phase>
+            <phase>generate-sources</phase>
             <goals>
               <goal>exec</goal>
             </goals>
@@ -109,7 +109,7 @@
           </execution>
           <execution>
             <id>Gulp build</id>
-            <phase>none</phase>
+            <phase>generate-sources</phase>
             <goals>
               <goal>exec</goal>
             </goals>

--- a/ambari-admin/pom.xml
+++ b/ambari-admin/pom.xml
@@ -77,7 +77,7 @@
           </execution>
           <execution>
             <id>npm install</id>
-            <phase>generate-sources</phase>
+            <phase>none</phase>
             <goals>
               <goal>npm</goal>
             </goals>
@@ -93,7 +93,7 @@
         <executions>
           <execution>
             <id>Bower install</id>
-            <phase>generate-sources</phase>
+            <phase>none</phase>
             <goals>
               <goal>exec</goal>
             </goals>
@@ -109,7 +109,7 @@
           </execution>
           <execution>
             <id>Gulp build</id>
-            <phase>generate-sources</phase>
+            <phase>none</phase>
             <goals>
               <goal>exec</goal>
             </goals>

--- a/ambari-server-spi/pom.xml
+++ b/ambari-server-spi/pom.xml
@@ -66,7 +66,7 @@
           </execution>
         </executions>
       </plugin>
-      
+
       <plugin>
         <groupId>org.apache.rat</groupId>
         <artifactId>apache-rat-plugin</artifactId>
@@ -96,7 +96,7 @@
           <argLine>${surefire.argLine}</argLine>
         </configuration>
       </plugin>
-      
+
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>build-helper-maven-plugin</artifactId>
@@ -122,36 +122,8 @@
               <failIfNoMatch>false</failIfNoMatch>
             </configuration>
           </execution>
-          <execution>
-            <id>parse-package-version</id>
-            <goals>
-              <goal>regex-property</goal>
-            </goals>
-            <configuration>
-              <name>package-version</name>
-              <value>${project.version}</value>
-              <regex>^([0-9]+)\.([0-9]+)\.([0-9]+)\.([0-9]+)(\.|-).*</regex>
-              <replacement>$1.$2.$3.$4</replacement>
-              <failIfNoMatch>true</failIfNoMatch>
-            </configuration>
-          </execution>
-          <execution>
-            <id>parse-package-release</id>
-            <goals>
-              <goal>regex-property</goal>
-            </goals>
-            <configuration>
-              <name>package-release</name>
-              <value>${project.version}</value>
-              <regex>
-                ^([0-9]+)\.([0-9]+)\.([0-9]+)\.([0-9]+)(\.|-)((([a-zA-Z]+)?([0-9]+))|(SNAPSHOT)).*
-              </regex>
-              <replacement>$7</replacement>
-              <failIfNoMatch>true</failIfNoMatch>
-            </configuration>
-          </execution>
         </executions>
-      </plugin>   
+      </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-checkstyle-plugin</artifactId>


### PR DESCRIPTION
## What changes were proposed in this pull request?

[INFO] --- rpm-maven-plugin:2.1.4:rpm (default-cli) @ ambari-server-spi ---
[INFO] Directory /root/ambari/ambari/ambari-server-spi/target/rpm/ambari-server-spi/BUILD already exists. Deleting all contents.
[INFO] Directory /root/ambari/ambari/ambari-server-spi/target/rpm/ambari-server-spi/RPMS already exists. Deleting all contents.
[INFO] Directory /root/ambari/ambari/ambari-server-spi/target/rpm/ambari-server-spi/SOURCES already exists. Deleting all contents.
[INFO] Directory /root/ambari/ambari/ambari-server-spi/target/rpm/ambari-server-spi/SPECS already exists. Deleting all contents.
[INFO] Directory /root/ambari/ambari/ambari-server-spi/target/rpm/ambari-server-spi/SRPMS already exists. Deleting all contents.
[INFO] Directory /root/ambari/ambari/ambari-server-spi/target/rpm/ambari-server-spi/tmp-buildroot already exists. Deleting all contents.
[INFO] Directory /root/ambari/ambari/ambari-server-spi/target/rpm/ambari-server-spi/buildroot already exists. Deleting all contents.
[INFO] Creating spec file /root/ambari/ambari/ambari-server-spi/target/rpm/ambari-server-spi/SPECS/ambari-server-spi.spec
[INFO] error: line 4: Empty tag: Release:
[INFO] Building target platforms: noarch-redhat-linux
[INFO] Building for target noarch-redhat-linux
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary:
[INFO] 
[INFO] Ambari Server SPI 3.0.0.0-SNAPSHOT ................. FAILURE [  6.598 s]
[INFO] Ambari Service Advisor 1.0.0.0-SNAPSHOT ............ SKIPPED
[INFO] Ambari Server 3.0.0.0-SNAPSHOT ..................... SKIPPED
[INFO] Ambari Functional Tests 3.0.0.0-SNAPSHOT ........... SKIPPED
[INFO] Ambari Agent 3.0.0.0-SNAPSHOT ...................... SKIPPED
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  7.262 s
[INFO] Finished at: 2022-11-16T20:16:31+08:00
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal org.codehaus.mojo:rpm-maven-plugin:2.1.4:rpm (default-cli) on project ambari-server-spi: RPM build execution returned: '1' executing '/bin/sh -c cd '/root/ambari/ambari/ambari-server-spi/target/rpm/ambari-server-spi/SPECS' && 'rpmbuild' '-bb' '--target' 'noarch-redhat-linux' '--buildroot' '/root/ambari/ambari/ambari-server-spi/target/rpm/ambari-server-spi/buildroot' '--define' '_topdir /root/ambari/ambari/ambari-server-spi/target/rpm/ambari-server-spi' '--define' '_build_name_fmt %%{ARCH}/%%{NAME}-%%{VERSION}-%%{RELEASE}.%%{ARCH}.rpm' '--define' '_builddir %{_topdir}/BUILD' '--define' '_rpmdir %{_topdir}/RPMS' '--define' '_sourcedir %{_topdir}/SOURCES' '--define' '_specdir %{_topdir}/SPECS' '--define' '_srcrpmdir %{_topdir}/SRPMS' 'ambari-server-spi.spec'' -> [Help 1]
[ERROR] 
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR] 
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoExecutionException


Seems caused by rpm-maven-plugin upgrade from 2.0.1 to 2.1.4 in [https://github.com/apache/ambari/pull/34](https://github.com/apache/ambari/pull/3492)`
## How was this patch tested?
Successully build  now




(Please explain how this patch was tested. Ex: unit tests, manual tests)
(If this patch involves UI changes, please attach a screen-shot; otherwise, remove this)

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.