### PR TITLE
AMBARI-25459: Ambari doesn't show versions page after invalid repo was added

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/utils/URLCredentialsHider.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/utils/URLCredentialsHider.java
@@ -45,9 +45,9 @@ public class URLCredentialsHider {
     String userInfo = url.getUserInfo();
     if (StringUtils.isNotEmpty(userInfo)) {
       if (userInfo.contains(":")) {
-        return urlString.replaceFirst(userInfo, HIDDEN_CREDENTIALS);
+        return StringUtils.replaceOnce(urlString, userInfo, HIDDEN_CREDENTIALS);
       } else {
-        return urlString.replaceFirst(userInfo, HIDDEN_USER);
+        return StringUtils.replaceOnce(urlString, userInfo, HIDDEN_USER);
       }
     }
     return urlString;

--- a/ambari-server/src/test/java/org/apache/ambari/server/utils/URLCredentialsHiderTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/utils/URLCredentialsHiderTest.java
@@ -37,5 +37,9 @@ public class URLCredentialsHiderTest {
 
     String invalidURL = "htt://user01:pass@host:8443/api/v1";
     Assert.assertEquals(URLCredentialsHider.INVALID_URL, URLCredentialsHider.hideCredentials(invalidURL));
+
+    String testURL3 = "http://***:***@host:8443/api/v1";
+    Assert.assertEquals(String.format("http://%s@host:8443/api/v1", URLCredentialsHider.HIDDEN_CREDENTIALS),
+                        URLCredentialsHider.hideCredentials(testURL3));
   }
 }


### PR DESCRIPTION
AMBARI-25459: Ambari doesn't show versions page after invalid repo was added

## What changes were proposed in this pull request?
Forward port commit https://github.com/apache/ambari/pull/3169 on branch-2.7.
(Please fill in changes proposed in this fix)

## How was this patch tested?

(Please explain how this patch was tested. Ex: unit tests, manual tests)
(If this patch involves UI changes, please attach a screen-shot; otherwise, remove this)

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.