### PR TITLE
AMBARI-25500: Hive Service Check Fails if the trustStorePassword has Special character $

### DIFF
--- a/ambari-common/src/main/python/resource_management/libraries/functions/hive_check.py
+++ b/ambari-common/src/main/python/resource_management/libraries/functions/hive_check.py
@@ -68,7 +68,7 @@ def check_thrift_port_sasl(address, port, hive_auth="NOSASL", key=None, kinitcmd
 
   # append url according to ssl configuration
   if ssl and ssl_keystore is not None and ssl_password is not None:
-    beeline_url.extend(['ssl={ssl_str}', 'sslTrustStore={ssl_keystore}', 'trustStorePassword={ssl_password!p}'])
+    beeline_url.extend(['ssl={ssl_str}', 'sslTrustStore={ssl_keystore}', "trustStorePassword='{ssl_password!p}'"])
 
   # append url according to principal and execute kinit
   if kinitcmd and hive_auth != "LDAP":


### PR DESCRIPTION
## What changes were proposed in this pull request?

Forward port commit https://github.com/apache/ambari/pull/3193 on branch-2.7.

(Please fill in changes proposed in this fix)

## How was this patch tested?

(Please explain how this patch was tested. Ex: unit tests, manual tests)
(If this patch involves UI changes, please attach a screen-shot; otherwise, remove this)

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.