### PR TITLE
AMBARI-25546: The maximum parameter on the heapmap page still supports negative numbers And NaN after parsing

### DIFF
--- a/ambari-web/app/controllers/main/charts/heatmap_metrics/heatmap_metric.js
+++ b/ambari-web/app/controllers/main/charts/heatmap_metrics/heatmap_metric.js
@@ -93,7 +93,7 @@ App.MainChartHeatmapMetric = Em.Object.extend({
    * 
    */
   slotDefinitions: function () {
-    var max = this.get('maximumValue') ? parseFloat(this.get('maximumValue')) : 0;
+    var max = this.getMaximumValue();
     var slotCount = this.get('numberOfSlots');
     var units = this.get('units');
     var delta = (max - this.get('minimumValue')) / slotCount;
@@ -172,6 +172,15 @@ App.MainChartHeatmapMetric = Em.Object.extend({
       }
     }
     return hatchStyle;
+  },
+
+  /**
+   * compatible with special input value, such as negative float number or string
+   * @return {float}
+   */
+  getMaximumValue: function getMaximumValue() {
+    var max = this.get('maximumValue') ? parseFloat(this.get('maximumValue')) : 0;
+    return isNaN(max) ? 0 : Math.max(0, max);
   },
 
   /**


### PR DESCRIPTION
## What changes were proposed in this pull request?

Forward port commit https://github.com/apache/ambari/pull/3223 on branch-2.7.

(Please fill in changes proposed in this fix)

## How was this patch tested?

(Please explain how this patch was tested. Ex: unit tests, manual tests)
(If this patch involves UI changes, please attach a screen-shot; otherwise, remove this)

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.