### PR TITLE
AMBARI-25565: ConfigHelper.java logging consumes most server logs for clusters with many hosts

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/state/ConfigHelper.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/ConfigHelper.java
@@ -2046,16 +2046,20 @@ public class ConfigHelper {
       }
       Map<String, Map<String, String>> configurations = new HashMap<>();
       Map<String, Map<String, Map<String, String>>> configurationAttributes = new HashMap<>();
-      if (LOG.isInfoEnabled()) {
-        LOG.info("For configs update on host {} will be used cluster entity {}", hostId, cl.getClusterEntity().toString());
+      if (LOG.isDebugEnabled()) {
+        LOG.debug("For configs update on host {} will be used cluster entity {}", hostId, cl.getClusterEntity().toString());
       }
       Map<String, DesiredConfig> clusterDesiredConfigs = cl.getDesiredConfigs(false);
-      LOG.info("For configs update on host {} will be used following cluster desired configs {}", hostId,
-          clusterDesiredConfigs.toString());
+      if (LOG.isDebugEnabled()) {
+        LOG.debug("For configs update on host {} will be used following cluster desired configs {}", hostId,
+            clusterDesiredConfigs.toString());
+      }
 
       Map<String, Map<String, String>> configTags =
           getEffectiveDesiredTags(cl, host.getHostName(), clusterDesiredConfigs);
-      LOG.info("For configs update on host {} will be used following effective desired tags {}", hostId, configTags.toString());
+      if (LOG.isDebugEnabled()) {
+        LOG.debug("For configs update on host {} will be used following effective desired tags {}", hostId, configTags.toString());
+      }
 
       getAndMergeHostConfigs(configurations, configTags, cl);
       configurations = unescapeConfigNames(configurations);


### PR DESCRIPTION

## What changes were proposed in this pull request?

Forward port commit https://github.com/apache/ambari/pull/3238 on branch-2.7.

(Please fill in changes proposed in this fix)

## How was this patch tested?

(Please explain how this patch was tested. Ex: unit tests, manual tests)
(If this patch involves UI changes, please attach a screen-shot; otherwise, remove this)

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.