### PR TITLE
AMBARI-25568: The 'NodeManager RAM Utilized' metric in the heatmap of YARN does not show the unit

### DIFF
--- a/ambari-server/src/main/resources/stacks/BIGTOP/3.2.0/services/YARN/YARN_widgets.json
+++ b/ambari-server/src/main/resources/stacks/BIGTOP/3.2.0/services/YARN/YARN_widgets.json
@@ -577,7 +577,7 @@
             }
           ],
           "properties": {
-            "display_unit": "",
+            "display_unit": "GB",
             "max_limit": "100"
           }
         },


### PR DESCRIPTION

## What changes were proposed in this pull request?

Forward port commit https://github.com/apache/ambari/pull/3241 on branch-2.7.

(Please fill in changes proposed in this fix)

## How was this patch tested?

(Please explain how this patch was tested. Ex: unit tests, manual tests)
(If this patch involves UI changes, please attach a screen-shot; otherwise, remove this)

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.