### PR TITLE
AMBARI-25781: Fix the Zookeeper AdminServer start faild.

### DIFF
--- a/ambari-server/src/main/resources/stacks/BIGTOP/3.2.0/services/ZOOKEEPER/configuration/zoo.cfg.xml
+++ b/ambari-server/src/main/resources/stacks/BIGTOP/3.2.0/services/ZOOKEEPER/configuration/zoo.cfg.xml
@@ -99,4 +99,19 @@
       The rest of four letter word commands are disabled by default.</description>
     <on-ambari-upgrade add="true"/>
   </property>
+  <property>
+    <name>admin.enableServer</name>
+    <value>true</value>
+    <description>Set to "false" to disable the AdminServer. By default the AdminServer is enabled.</description>
+    <value-attributes>
+      <type>boolean</type>
+    </value-attributes>
+    <on-ambari-upgrade add="true"/>
+  </property>
+  <property>
+    <name>admin.serverPort</name>
+    <value>9393</value>
+    <description>The port the embedded Jetty server listens on. Defaults to 8080.</description>
+    <on-ambari-upgrade add="true"/>
+  </property>
 </configuration>


### PR DESCRIPTION
## What changes were proposed in this pull request?
[AMBARI-25781](https://issues.apache.org/jira/browse/AMBARI-25781)

## How was this patch tested?
We can view the zoo.cfg configuration through ambari ui
![image](https://user-images.githubusercontent.com/76554302/202888373-cab772a6-9930-4610-8a7b-711320054d07.png)
![image](https://user-images.githubusercontent.com/76554302/202888399-52d44ee5-351e-4c81-8929-7d38d32ab503.png)

Test disable Zookeeper AdminServer
![image](https://user-images.githubusercontent.com/76554302/202888532-3f0cd953-5e84-41df-9a5e-3495796ce144.png)
![image](https://user-images.githubusercontent.com/76554302/202888549-fd993e1b-8870-4474-ac2c-6e8afe8cccac.png)




Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.