### PR TITLE
AMBARI-25609: sysUpTime field is populated with invalid value during SNMP trap creation

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/notifications/dispatchers/AmbariSNMPDispatcher.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/notifications/dispatchers/AmbariSNMPDispatcher.java
@@ -119,8 +119,8 @@ public class AmbariSNMPDispatcher extends SNMPDispatcher {
         pdu.setType(snmpVersion.getTrapType());
     
         RuntimeMXBean runtimeMXBean = ManagementFactory.getRuntimeMXBean();
-        long uptimeInMillis = runtimeMXBean.getUptime();
-        pdu.add(new VariableBinding(SnmpConstants.sysUpTime, new TimeTicks(uptimeInMillis)));
+        long uptimeInHundredthsOfSecond = runtimeMXBean.getUptime() / 10;
+        pdu.add(new VariableBinding(SnmpConstants.sysUpTime, new TimeTicks(uptimeInHundredthsOfSecond)));
 
        // Set trap oid for PDU
         pdu.add(new VariableBinding(SnmpConstants.snmpTrapOID, new OID(AMBARI_ALERT_TRAP_OID)));

--- a/ambari-server/src/test/java/org/apache/ambari/server/state/services/AlertNoticeDispatchServiceTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/state/services/AlertNoticeDispatchServiceTest.java
@@ -101,6 +101,10 @@ public class AlertNoticeDispatchServiceTest extends AlertNoticeDispatchService {
   final static String HOSTNAME = "c6401.ambari.apache.org";
   final static Calendar calendar = Calendar.getInstance(TimeZone.getTimeZone("UTC"));
 
+  // the requirement to this test value is to be greater than 2^32-1
+  final static long UPTIME_MILLIS = 8589934592L;
+  final static long UPTIME_HUNDREDTHS_OF_SECOND = UPTIME_MILLIS / 10;
+
   private AmbariMetaInfo m_metaInfo = null;
   private DispatchFactory m_dispatchFactory = null;
   private AlertDispatchDAO m_dao = null;
@@ -170,7 +174,7 @@ public class AlertNoticeDispatchServiceTest extends AlertNoticeDispatchService {
     PowerMock.mockStatic(ManagementFactory.class);
     expect(ManagementFactory.getRuntimeMXBean()).andReturn(m_runtimeMXBean).atLeastOnce();
     PowerMock.replay(ManagementFactory.class);
-    expect(m_runtimeMXBean.getUptime()).andReturn(360000L).atLeastOnce();
+    expect(m_runtimeMXBean.getUptime()).andReturn(UPTIME_MILLIS).atLeastOnce();
 
     replay( m_runtimeMXBean);
     }
@@ -404,7 +408,7 @@ public class AlertNoticeDispatchServiceTest extends AlertNoticeDispatchService {
 
     List<Vector> expectedTrapVectors = new LinkedList<>();
     Vector firstVector = new Vector();
-    firstVector.add(new VariableBinding(SnmpConstants.sysUpTime, new TimeTicks(360000L)));
+    firstVector.add(new VariableBinding(SnmpConstants.sysUpTime, new TimeTicks(UPTIME_HUNDREDTHS_OF_SECOND)));
     firstVector.add(new VariableBinding(SnmpConstants.snmpTrapOID, new OID(AmbariSNMPDispatcher.AMBARI_ALERT_TRAP_OID)));    
     firstVector.add(new VariableBinding(new OID(AmbariSNMPDispatcher.AMBARI_ALERT_DEFINITION_ID_OID), new Integer32(new BigDecimal(1L).intValueExact())));
     firstVector.add(new VariableBinding(new OID(AmbariSNMPDispatcher.AMBARI_ALERT_DEFINITION_NAME_OID), new OctetString("alert-definition-1")));


### PR DESCRIPTION

## What changes were proposed in this pull request?

Forward port commit https://github.com/apache/ambari/pull/3277 on branch-2.7.

(Please fill in changes proposed in this fix)

## How was this patch tested?

(Please explain how this patch was tested. Ex: unit tests, manual tests)
(If this patch involves UI changes, please attach a screen-shot; otherwise, remove this)

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.