### PR TITLE
AMBARI-25610: No warning message at changing repo name to an invalid one

### DIFF
--- a/ambari-admin/src/main/resources/ui/admin-web/app/scripts/services/Stack.js
+++ b/ambari-admin/src/main/resources/ui/admin-web/app/scripts/services/Stack.js
@@ -390,8 +390,8 @@ angular.module('ambariAdminConsole')
                   totalCalls--;
                   if (totalCalls === 0) deferred.resolve(invalidUrls);
                 })
-                .catch(function (response, status, callback, params) {
-                  invalidUrls.push(params.repo);
+                .catch(function (response) {
+                  invalidUrls.push(response.config.repo);
                   totalCalls--;
                   if (totalCalls === 0) deferred.resolve(invalidUrls);
                 });


### PR DESCRIPTION
## What changes were proposed in this pull request?

Forward port commit https://github.com/apache/ambari/pull/3278 on branch-2.7.

(Please fill in changes proposed in this fix)

## How was this patch tested?

(Please explain how this patch was tested. Ex: unit tests, manual tests)
(If this patch involves UI changes, please attach a screen-shot; otherwise, remove this)

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.