### PR TITLE
AMBARI-25411: Cannot use HTTPS repourl and VDF url

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/URLStreamProvider.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/URLStreamProvider.java
@@ -195,7 +195,7 @@ public class URLStreamProvider implements StreamProvider {
 
     URL url = new URL(spec);
     HttpURLConnection connection = (spec.startsWith("https") && setupTruststoreForHttps) ?
-            getSSLConnection(spec) : getConnection(url);
+            getSSLConnection(url) : getConnection(url);
 
     AppCookieManager appCookieManager = getAppCookieManager();
 
@@ -245,7 +245,7 @@ public class URLStreamProvider implements StreamProvider {
       }
       if (wwwAuthHeader != null &&
         wwwAuthHeader.trim().startsWith(NEGOTIATE)) {
-        connection = spec.startsWith("https") ? getSSLConnection(spec) : getConnection(url);
+        connection = spec.startsWith("https") ? getSSLConnection(url) : getConnection(url);
         appCookie = appCookieManager.getAppCookie(spec, true);
         connection.setRequestProperty(COOKIE, appCookie);
         connection.setConnectTimeout(connTimeout);
@@ -344,7 +344,7 @@ public class URLStreamProvider implements StreamProvider {
   }
 
   // Get an ssl connection
-  protected HttpsURLConnection getSSLConnection(String spec) throws IOException, IllegalStateException {
+  protected HttpsURLConnection getSSLConnection(URL url) throws IOException, IllegalStateException {
 
     if (sslSocketFactory == null) {
       synchronized (this) {
@@ -353,7 +353,7 @@ public class URLStreamProvider implements StreamProvider {
           if (trustStorePath == null || trustStorePassword == null) {
             String msg =
                     String.format("Can't get secure connection to %s.  Truststore path or password is not set.",
-                            URLCredentialsHider.hideCredentials(spec));
+                            URLCredentialsHider.hideCredentials(url.toString()));
 
             LOG.error(msg);
             throw new IllegalStateException(msg);
@@ -380,7 +380,7 @@ public class URLStreamProvider implements StreamProvider {
         }
       }
     }
-    HttpsURLConnection connection = (HttpsURLConnection) (new URL(spec)
+    HttpsURLConnection connection = (HttpsURLConnection) (url
         .openConnection());
 
     connection.setSSLSocketFactory(sslSocketFactory);


### PR DESCRIPTION
## What changes were proposed in this pull request?

Forward port commit https://github.com/apache/ambari/pull/3122 on branch-2.7.

(Please fill in changes proposed in this fix)

## How was this patch tested?

(Please explain how this patch was tested. Ex: unit tests, manual tests)
(If this patch involves UI changes, please attach a screen-shot; otherwise, remove this)

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.