### PR TITLE
AMBARI-25363: Daily Namenode Heap Usage alert does not work

### DIFF
--- a/ambari-agent/src/test/python/ambari_agent/dummy_files/stomp/alert_definitions.json
+++ b/ambari-agent/src/test/python/ambari_agent/dummy_files/stomp/alert_definitions.json
@@ -434,7 +434,7 @@
                 "display_name": "AMS application id",
                 "name": "appId",
                 "visibility": "HIDDEN",
-                "value": "NAMENODE",
+                "value": "namenode",
                 "type": "STRING",
                 "description": "The application id used to retrieve the metric."
               },
@@ -601,7 +601,7 @@
                 "display_name": "AMS application id",
                 "name": "appId",
                 "visibility": "HIDDEN",
-                "value": "NAMENODE",
+                "value": "namenode",
                 "type": "STRING",
                 "description": "The application id used to retrieve the metric."
               },
@@ -686,7 +686,7 @@
                 "display_name": "AMS application id",
                 "name": "appId",
                 "visibility": "HIDDEN",
-                "value": "NAMENODE",
+                "value": "namenode",
                 "type": "STRING",
                 "description": "The application id used to retrieve the metric."
               },
@@ -869,7 +869,7 @@
                 "display_name": "AMS application id",
                 "name": "appId",
                 "visibility": "HIDDEN",
-                "value": "NAMENODE",
+                "value": "namenode",
                 "type": "STRING",
                 "description": "The application id used to retrieve the metric."
               },
@@ -1018,7 +1018,7 @@
                 "display_name": "AMS application id",
                 "name": "appId",
                 "visibility": "HIDDEN",
-                "value": "NAMENODE",
+                "value": "namenode",
                 "type": "STRING",
                 "description": "The application id used to retrieve the metric."
               },
@@ -1103,7 +1103,7 @@
                 "display_name": "AMS application id",
                 "name": "appId",
                 "visibility": "HIDDEN",
-                "value": "NAMENODE",
+                "value": "namenode",
                 "type": "STRING",
                 "description": "The application id used to retrieve the metric."
               },
@@ -1220,7 +1220,7 @@
                 "display_name": "AMS application id",
                 "name": "appId",
                 "visibility": "HIDDEN",
-                "value": "NAMENODE",
+                "value": "namenode",
                 "type": "STRING",
                 "description": "The application id used to retrieve the metric."
               },
@@ -1326,7 +1326,7 @@
                 "display_name": "AMS application id",
                 "name": "appId",
                 "visibility": "HIDDEN",
-                "value": "NAMENODE",
+                "value": "namenode",
                 "type": "STRING",
                 "description": "The application id used to retrieve the metric."
               },
@@ -1411,7 +1411,7 @@
                 "display_name": "AMS application id",
                 "name": "appId",
                 "visibility": "HIDDEN",
-                "value": "NAMENODE",
+                "value": "namenode",
                 "type": "STRING",
                 "description": "The application id used to retrieve the metric."
               },
@@ -1619,7 +1619,7 @@
                 "display_name": "AMS application id",
                 "name": "appId",
                 "visibility": "HIDDEN",
-                "value": "NAMENODE",
+                "value": "namenode",
                 "type": "STRING",
                 "description": "The application id used to retrieve the metric."
               },
@@ -1704,7 +1704,7 @@
                 "display_name": "AMS application id",
                 "name": "appId",
                 "visibility": "HIDDEN",
-                "value": "NAMENODE",
+                "value": "namenode",
                 "type": "STRING",
                 "description": "The application id used to retrieve the metric."
               },
@@ -1992,7 +1992,7 @@
                 "display_name": "AMS application id",
                 "name": "appId",
                 "visibility": "HIDDEN",
-                "value": "NAMENODE",
+                "value": "namenode",
                 "type": "STRING",
                 "description": "The application id used to retrieve the metric."
               },

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/alert/ParameterizedSource.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/alert/ParameterizedSource.java
@@ -169,6 +169,10 @@ public abstract class ParameterizedSource extends Source {
       return m_threshold;
     }
 
+    public void setValue(Object value) {
+      this.m_value = value;
+    }
+
     @Override
     public int hashCode() {
       return Objects.hash(m_description, m_displayName, m_name, m_threshold, m_type, m_units, m_value, m_visibility);

--- a/ambari-server/src/main/java/org/apache/ambari/server/upgrade/SchemaUpgradeHelper.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/upgrade/SchemaUpgradeHelper.java
@@ -190,6 +190,7 @@ public class SchemaUpgradeHelper {
       catalogBinder.addBinding().to(UpgradeCatalog270.class);
       catalogBinder.addBinding().to(UpgradeCatalog271.class);
       catalogBinder.addBinding().to(UpgradeCatalog272.class);
+      catalogBinder.addBinding().to(UpgradeCatalog273.class);
       catalogBinder.addBinding().to(UpgradeCatalog274.class);
       catalogBinder.addBinding().to(UpgradeCatalog275.class);
       catalogBinder.addBinding().to(UpgradeCatalog280.class);

--- a/ambari-server/src/main/java/org/apache/ambari/server/upgrade/UpgradeCatalog273.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/upgrade/UpgradeCatalog273.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.ambari.server.upgrade;
+
+import java.sql.SQLException;
+
+import org.apache.ambari.server.AmbariException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.inject.Inject;
+import com.google.inject.Injector;
+
+/**
+ * The {@link UpgradeCatalog273} upgrades Ambari from 2.7.2 to 2.7.3.
+ */
+public class UpgradeCatalog273 extends AbstractUpgradeCatalog {
+
+  private static final Logger LOG = LoggerFactory.getLogger(UpgradeCatalog273.class);
+
+  @Inject
+  public UpgradeCatalog273(Injector injector) {
+    super(injector);
+  }
+
+  @Override
+  public String getSourceVersion() {
+    return "2.7.2";
+  }
+
+  @Override
+  public String getTargetVersion() {
+    return "2.7.3";
+  }
+
+  @Override
+  protected void executeDDLUpdates() throws AmbariException, SQLException {
+    // nothing to do
+  }
+
+  @Override
+  protected void executePreDMLUpdates() throws AmbariException, SQLException {
+    // nothing to do
+  }
+
+  @Override
+  protected void executeDMLUpdates() throws AmbariException, SQLException {
+    addNewConfigurationsFromXml();
+  }
+
+}

--- a/ambari-server/src/main/java/org/apache/ambari/server/upgrade/UpgradeCatalog274.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/upgrade/UpgradeCatalog274.java
@@ -18,12 +18,25 @@
 package org.apache.ambari.server.upgrade;
 
 import java.sql.SQLException;
+import java.util.List;
+import java.util.Map;
 
 import javax.persistence.Table;
 
 import org.apache.ambari.server.AmbariException;
+import org.apache.ambari.server.controller.AmbariManagementController;
 import org.apache.ambari.server.orm.DBAccessor;
+import org.apache.ambari.server.orm.dao.AlertDefinitionDAO;
+import org.apache.ambari.server.orm.entities.AlertDefinitionEntity;
 import org.apache.ambari.server.orm.entities.AmbariConfigurationEntity;
+import org.apache.ambari.server.state.Cluster;
+import org.apache.ambari.server.state.Clusters;
+import org.apache.ambari.server.state.alert.AlertDefinition;
+import org.apache.ambari.server.state.alert.AlertDefinitionFactory;
+import org.apache.ambari.server.state.alert.ParameterizedSource;
+import org.apache.ambari.server.state.alert.ScriptSource;
+import org.apache.ambari.server.state.alert.SourceType;
+import org.apache.commons.collections.MapUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -39,6 +52,11 @@ public class UpgradeCatalog274 extends AbstractUpgradeCatalog {
   static final String AMBARI_CONFIGURATION_TABLE = AmbariConfigurationEntity.class.getAnnotation(Table.class).name();
   static final String AMBARI_CONFIGURATION_PROPERTY_VALUE_COLUMN = UpgradeCatalog270.AMBARI_CONFIGURATION_PROPERTY_VALUE_COLUMN;
   static final Integer AMBARI_CONFIGURATION_PROPERTY_VALUE_COLUMN_LEN = 4000;
+
+  static final String HDFS_SERVICE_NAME = "HDFS";
+  static final String NAMENODE_COMPONENT_NAME = "NAMENODE";
+  static final String APPID_PROPERTY_NAME = "appId";
+  static final String NAMENODE_APP_ID = NAMENODE_COMPONENT_NAME.toLowerCase();
 
 
   @Inject
@@ -87,6 +105,42 @@ public class UpgradeCatalog274 extends AbstractUpgradeCatalog {
   @Override
   protected void executeDMLUpdates() throws AmbariException, SQLException {
     addNewConfigurationsFromXml();
+    updateNameNodeAlertsAppId();
+  }
+
+  protected void updateNameNodeAlertsAppId() {
+    AlertDefinitionDAO alertDefinitionDAO = injector.getInstance(AlertDefinitionDAO.class);
+    AmbariManagementController ambariManagementController = injector.getInstance(AmbariManagementController.class);
+    AlertDefinitionFactory alertDefinitionFactory = injector.getInstance(AlertDefinitionFactory.class);
+
+    Clusters clusters = ambariManagementController.getClusters();
+    if (clusters != null) {
+      Map<String, Cluster> clusterMap = clusters.getClusters();
+      if (MapUtils.isNotEmpty(clusterMap)) {
+        for (final Cluster cluster : clusterMap.values()) {
+          if (cluster.getServices().containsKey(HDFS_SERVICE_NAME)) {
+            List<AlertDefinitionEntity> alertDefinitions =
+                alertDefinitionDAO.findByServiceComponent(cluster.getClusterId(), HDFS_SERVICE_NAME, NAMENODE_COMPONENT_NAME);
+            for (AlertDefinitionEntity alertDefinitionEntity : alertDefinitions) {
+              if (SourceType.SCRIPT.equals(alertDefinitionEntity.getSourceType())) {
+                AlertDefinition databaseDefinition = alertDefinitionFactory.coerce(alertDefinitionEntity);
+                ScriptSource scriptSource = (ScriptSource) databaseDefinition.getSource();
+                for (ParameterizedSource.AlertParameter scriptParameter : scriptSource.getParameters()) {
+                  if (APPID_PROPERTY_NAME.equals(scriptParameter.getName())) {
+                    String value = (String) scriptParameter.getValue();
+                    if (value.equalsIgnoreCase(NAMENODE_APP_ID) && !value.equals(NAMENODE_APP_ID)) {
+                      scriptParameter.setValue(NAMENODE_APP_ID);
+                    }
+                  }
+                }
+                alertDefinitionEntity = alertDefinitionFactory.mergeSource(scriptSource, alertDefinitionEntity);
+                alertDefinitionDAO.merge(alertDefinitionEntity);
+              }
+            }
+          }
+        }
+      }
+    }
   }
 
 

--- a/ambari-server/src/main/java/org/apache/ambari/server/upgrade/UpgradeCatalog274.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/upgrade/UpgradeCatalog274.java
@@ -31,7 +31,7 @@ import com.google.inject.Inject;
 import com.google.inject.Injector;
 
 /**
- * The {@link UpgradeCatalog274} upgrades Ambari from 2.7.2 to 2.7.4.
+ * The {@link UpgradeCatalog274} upgrades Ambari from 2.7.3 to 2.7.4.
  */
 public class UpgradeCatalog274 extends AbstractUpgradeCatalog {
 
@@ -48,7 +48,7 @@ public class UpgradeCatalog274 extends AbstractUpgradeCatalog {
 
   @Override
   public String getSourceVersion() {
-    return "2.7.2";
+    return "2.7.3";
   }
 
   /**
@@ -86,7 +86,7 @@ public class UpgradeCatalog274 extends AbstractUpgradeCatalog {
    */
   @Override
   protected void executeDMLUpdates() throws AmbariException, SQLException {
-    // no actions needed
+    addNewConfigurationsFromXml();
   }
 
 

--- a/ambari-server/src/test/java/org/apache/ambari/server/upgrade/UpgradeCatalog274Test.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/upgrade/UpgradeCatalog274Test.java
@@ -20,14 +20,34 @@ package org.apache.ambari.server.upgrade;
 import static org.apache.ambari.server.upgrade.UpgradeCatalog274.AMBARI_CONFIGURATION_PROPERTY_VALUE_COLUMN;
 import static org.apache.ambari.server.upgrade.UpgradeCatalog274.AMBARI_CONFIGURATION_PROPERTY_VALUE_COLUMN_LEN;
 import static org.apache.ambari.server.upgrade.UpgradeCatalog274.AMBARI_CONFIGURATION_TABLE;
+import static org.apache.ambari.server.upgrade.UpgradeCatalog274.APPID_PROPERTY_NAME;
+import static org.apache.ambari.server.upgrade.UpgradeCatalog274.HDFS_SERVICE_NAME;
+import static org.apache.ambari.server.upgrade.UpgradeCatalog274.NAMENODE_APP_ID;
+import static org.apache.ambari.server.upgrade.UpgradeCatalog274.NAMENODE_COMPONENT_NAME;
 import static org.easymock.EasyMock.capture;
+import static org.easymock.EasyMock.createMock;
 import static org.easymock.EasyMock.eq;
+import static org.easymock.EasyMock.expect;
 import static org.easymock.EasyMock.expectLastCall;
 import static org.easymock.EasyMock.newCapture;
 import static org.easymock.EasyMock.replay;
 import static org.easymock.EasyMock.verify;
 
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+
+import org.apache.ambari.server.controller.AmbariManagementController;
 import org.apache.ambari.server.orm.DBAccessor;
+import org.apache.ambari.server.orm.dao.AlertDefinitionDAO;
+import org.apache.ambari.server.orm.entities.AlertDefinitionEntity;
+import org.apache.ambari.server.state.Cluster;
+import org.apache.ambari.server.state.Clusters;
+import org.apache.ambari.server.state.alert.AlertDefinitionFactory;
+import org.apache.ambari.server.state.alert.ParameterizedSource;
+import org.apache.ambari.server.state.alert.ScriptSource;
+import org.apache.ambari.server.state.alert.Source;
+import org.apache.ambari.server.state.alert.SourceType;
 import org.easymock.Capture;
 import org.easymock.CaptureType;
 import org.easymock.EasyMockSupport;
@@ -73,5 +93,69 @@ public class UpgradeCatalog274Test {
     Assert.assertEquals(AMBARI_CONFIGURATION_PROPERTY_VALUE_COLUMN_LEN, alterPropertyValueColumn.getLength());
 
     verify(dbAccessor);
+  }
+
+  @Test
+  public void testUpdateNameNodeAlertsAppId() {
+    AlertDefinitionDAO alertDefinitionDAO = createMock(AlertDefinitionDAO.class);
+    AmbariManagementController ambariManagementController = createMock(AmbariManagementController.class);
+    AlertDefinitionFactory alertDefinitionFactory = new AlertDefinitionFactory();
+    Clusters clusters = createMock(Clusters.class);
+    Cluster cluster = createMock(Cluster.class);
+
+    expect(injector.getInstance(AlertDefinitionDAO.class)).andReturn(alertDefinitionDAO);
+    expect(injector.getInstance(AmbariManagementController.class)).andReturn(ambariManagementController);
+    expect(injector.getInstance(AlertDefinitionFactory.class)).andReturn(alertDefinitionFactory);
+
+    String sourceJson1 = "{\"path\":\"file.py\",\"parameters\":[{\"name\":\"appId\",\"value\":\"NAMENODE\"},{\"name\":\"metricName\",\"value\":\"jvm.JvmMetrics.MemHeapUsedM\"}],\"type\":\"SCRIPT\"}";
+    String sourceJson2 = "{\"path\":\"file.py\",\"parameters\":[{\"name\":\"appId\",\"value\":\"Namenode\"},{\"name\":\"metricName\",\"value\":\"jvm.JvmMetrics.MemHeapUsedM\"}],\"type\":\"SCRIPT\"}";
+
+    AlertDefinitionEntity alertDefinitionEntity1 = new AlertDefinitionEntity();
+    alertDefinitionEntity1.setSource(sourceJson1);
+    alertDefinitionEntity1.setSourceType(SourceType.SCRIPT);
+    alertDefinitionEntity1.setClusterId(1L);
+    alertDefinitionEntity1.setDefinitionId(1L);
+    alertDefinitionEntity1.setScheduleInterval(1);
+
+    AlertDefinitionEntity alertDefinitionEntity2 = new AlertDefinitionEntity();
+    alertDefinitionEntity2.setSource(sourceJson2);
+    alertDefinitionEntity2.setSourceType(SourceType.SCRIPT);
+    alertDefinitionEntity2.setClusterId(1L);
+    alertDefinitionEntity2.setDefinitionId(1L);
+    alertDefinitionEntity2.setScheduleInterval(1);
+
+    expect(ambariManagementController.getClusters()).andReturn(clusters);
+    expect(clusters.getClusters()).andReturn(new HashMap(){{put("cl1", cluster);}});
+    expect(cluster.getClusterId()).andReturn(1L);
+    expect(cluster.getServices()).andReturn(new HashMap(){{put("HDFS", null);}});
+    expect(alertDefinitionDAO.findByServiceComponent(1L, HDFS_SERVICE_NAME, NAMENODE_COMPONENT_NAME))
+        .andReturn(new ArrayList(){{add(alertDefinitionEntity1); add(alertDefinitionEntity2);}});
+
+    Capture<AlertDefinitionEntity> alertDefinitionEntityCapture = newCapture(CaptureType.ALL);
+    expect(alertDefinitionDAO.merge(capture(alertDefinitionEntityCapture))).andReturn(new AlertDefinitionEntity()).times(2);
+
+    replay(alertDefinitionDAO,ambariManagementController, clusters, cluster, injector);
+    UpgradeCatalog274 upgradeCatalog274 = new UpgradeCatalog274(injector);
+    upgradeCatalog274.updateNameNodeAlertsAppId();
+
+    verify(alertDefinitionDAO,ambariManagementController, clusters, cluster, injector);
+
+    Assert.assertTrue(alertDefinitionEntityCapture.hasCaptured());
+    List<AlertDefinitionEntity> resultAlertDefinitionEntities = alertDefinitionEntityCapture.getValues();
+    Assert.assertEquals(2, resultAlertDefinitionEntities.size());
+    for (AlertDefinitionEntity resultAlertDefinitionEntity : resultAlertDefinitionEntities) {
+      String resultSource = resultAlertDefinitionEntity.getSource();
+      Assert.assertNotNull(resultSource);
+
+      ScriptSource resultScriptSource = (ScriptSource) alertDefinitionFactory.getGson().fromJson(resultSource, Source.class);
+      boolean checked =  false;
+      for (ParameterizedSource.AlertParameter alertParameter : resultScriptSource.getParameters()) {
+        if (APPID_PROPERTY_NAME.equals(alertParameter.getName())) {
+          Assert.assertEquals(NAMENODE_APP_ID, alertParameter.getValue());
+          checked = true;
+        }
+      }
+      Assert.assertTrue("No property with appropriate name (appId) was found", checked);
+    }
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?
Forward port #3071 
Depends on #3485 
(Please fill in changes proposed in this fix)

## How was this patch tested?

(Please explain how this patch was tested. Ex: unit tests, manual tests)
(If this patch involves UI changes, please attach a screen-shot; otherwise, remove this)

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.