### PR TITLE
AMBARI-25788: Ambari server keeps generating keytabs even with KerberosServerAction#OperationType.CREATE_MISSING option.

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/serveraction/kerberos/CreateKeytabFilesServerAction.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/serveraction/kerberos/CreateKeytabFilesServerAction.java
@@ -355,7 +355,7 @@ public class CreateKeytabFilesServerAction extends KerberosServerAction {
             String previousCachedFilePath = principalEntity.getCachedKeytabPath();
             String cachedKeytabFilePath = (cachedKeytabFile.exists()) ? cachedKeytabFile.getAbsolutePath() : null;
 
-            if (previousCachedFilePath != null && !previousCachedFilePath.equals(cachedKeytabFilePath)) {
+            if (previousCachedFilePath == null || !previousCachedFilePath.equals(cachedKeytabFilePath)) {
               principalEntity.setCachedKeytabPath(cachedKeytabFilePath);
               kerberosPrincipalDAO.merge(principalEntity);
             }


### PR DESCRIPTION
## What changes were proposed in this pull request?

It fixes Ambar server's wrong behavior that even if an user select not to generate keytabs which already exists, Ambari server keeps generating new keytabs with new password.
It impacts many kerberized services which uses previously generated keytabs.

Even if a user doesn't regenerate keytabs, this issue can impact the services which shares a common keytab like `/etc/security/keytabs/spnego.service.keytab`. If ambari stack has been changed, new service is added and this service also shares a keytab, services which uses the same keytab could be failed to service like SPNEGO.

## How was this patch tested?

- manually tested with on-premise ambari cluster. After this fix, I found that `cached_keytab_path` column is filled with correct value in `kerberos_principal` table.
