### PR TITLE
AMBARI-25797: Fail to add a component on the same machine with ambari-server of a new service with no kerberos identity when kerberos enabled

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/KerberosHelperImpl.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/KerberosHelperImpl.java
@@ -2320,18 +2320,12 @@ public class KerberosHelperImpl implements KerberosHelper {
     // such as which principals and keytabs files to create as well as what configurations need
     // to be update are stored in data files in this directory. Any keytab files are stored in
     // this directory until they are distributed to their appropriate hosts.
-    File dataDirectory = null;
+    File dataDirectory = createTemporaryDirectory();
 
     // If there are ServiceComponentHosts to process...
     if (!schToProcess.isEmpty()) {
 
       validateKDCCredentials(kerberosDetails, cluster);
-
-      // Create a temporary directory to store metadata needed to complete this task.  Information
-      // such as which principals and keytabs files to create as well as what configurations need
-      // to be update are stored in data files in this directory. Any keytab files are stored in
-      // this directory until they are distributed to their appropriate hosts.
-      dataDirectory = createTemporaryDirectory();
 
       hostsWithValidKerberosClient = getHostsWithValidKerberosClient(cluster);
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

It fixes the problem of failure to add a component on the same machine with ambari server of a new service with no kerberos identity when kerberos enabled.
Details in https://issues.apache.org/jira/browse/AMBARI-25797.

This error is not occurred when adding a component to a machine different from the machine of ambari-server.

## How was this patch tested?

Manually tested.

