### PR TITLE
AMBARI-25706: -DskipPythonTests is not skipping python tests in amabri-agent

### DIFF
--- a/ambari-agent/pom.xml
+++ b/ambari-agent/pom.xml
@@ -254,7 +254,7 @@
               <environmentVariables>
                 <PYTHONPATH>${path.python.1}${pathsep}$PYTHONPATH</PYTHONPATH>
               </environmentVariables>
-              <skip>${skipTests}</skip>
+              <skip>${skipPythonTests}</skip>
             </configuration>
             <id>python-test</id>
             <phase>test</phase>

--- a/ambari-project/pom.xml
+++ b/ambari-project/pom.xml
@@ -48,6 +48,7 @@
     <forkCount>4</forkCount>
     <reuseForks>false</reuseForks>
     <surefire.argLine>-Xmx1024m -Xms512m</surefire.argLine>
+    <skipPythonTests>false</skipPythonTests>
   </properties>
   <profiles>
     <profile>
@@ -85,6 +86,17 @@
           </plugin>
         </plugins>
       </build>
+    </profile>
+    <profile>
+      <id>skipTestRun</id>
+      <activation>
+        <property>
+          <name>skipTests</name>
+        </property>
+      </activation>
+      <properties>
+        <skipPythonTests>true</skipPythonTests>
+      </properties>
     </profile>
   </profiles>
   <dependencyManagement>

--- a/ambari-server/pom.xml
+++ b/ambari-server/pom.xml
@@ -47,7 +47,7 @@
     <stackHooksLocation>src/main/resources/stack-hooks</stackHooksLocation>
     <stacksSrcLocation>src/main/resources/stacks/${stack.distribution}</stacksSrcLocation>
     <tarballResourcesFolder>src/main/resources</tarballResourcesFolder>
-    <skipPythonTests>false</skipPythonTests>
+
     <hadoop.version>2.7.2</hadoop.version>
     <empty.dir>src/main/package</empty.dir> <!-- any directory in project with not very big amount of files (not to waste-load them) -->
     <el.log>ALL</el.log> <!-- log level for EclipseLink eclipselink-staticweave-maven-plugin -->
@@ -878,17 +878,6 @@
           </plugin>
         </plugins>
       </build>
-    </profile>
-    <profile>
-      <id>skipTestRun</id>
-      <activation>
-        <property>
-          <name>skipTests</name>
-        </property>
-      </activation>
-      <properties>
-        <skipPythonTests>true</skipPythonTests>
-      </properties>
     </profile>
     <profile>
       <id>copy-swagger-generated-resources</id>


### PR DESCRIPTION
## What changes were proposed in this pull request?
When -DskipPythonTests passed in mvn command, skipping the python tests. 

## How was this patch tested?
Run below command on ambari-agent before and after change
`mvn test -DskipPythonTests`

**Before the change python test started executing:**
```
[INFO] Running org.apache.ambari.tools.zk.ZkMigratorTest
[INFO] Tests run: 11, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 3.505 s - in org.apache.ambari.tools.zk.ZkMigratorTest
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 11, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] 
[INFO] --- exec-maven-plugin:1.2.1:exec (python-test) @ ambari-agent ---
/ambari/ambari-common/src/main/python/ambari_commons/subprocess32.py:156: RuntimeWarning: The _posixsubprocess module is not being used. Could not import it from ambari_commons.libs.x86_64 Child process reliability may suffer if your program uses threads.
  "program uses threads.", RuntimeWarning)
test_clear_cache (TestHostCleanup.TestHostCleanup) ... ok
```

**After the change, python test is skipped:**

```
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Running org.apache.ambari.tools.zk.ZkMigratorTest
[INFO] Tests run: 11, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 4.748 s - in org.apache.ambari.tools.zk.ZkMigratorTest
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 11, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] 
[INFO] --- exec-maven-plugin:1.2.1:exec (python-test) @ ambari-agent ---
[INFO] skipping execute as per configuraion
[INFO] 
```

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.