### PR TITLE
AMBARI-25818: Set default value for jdk.version in ambari-serviceadvisor

### DIFF
--- a/ambari-serviceadvisor/pom.xml
+++ b/ambari-serviceadvisor/pom.xml
@@ -29,6 +29,9 @@
   <name>Ambari Service Advisor</name>
   <version>1.0.0.0-SNAPSHOT</version>
   <description>Service Advisor</description>
+  <properties>
+    <jdk.version>1.8</jdk.version>
+  </properties>
 
   <dependencies>
     <!-- Log Factory logging


### PR DESCRIPTION
## What changes were proposed in this pull request?
Set default value for jdk.version to 1.8 in ambari-serviceadvisor

## How was this patch tested?

After changes re imported ambari trunk project in intellij and run a test, test run without error mentioned in jira AMBARI-25818

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.