### PR TITLE
AMBARI-25811: Optimize ambari metrics build time

### DIFF
--- a/ambari-metrics/pom.xml
+++ b/ambari-metrics/pom.xml
@@ -200,6 +200,7 @@
         </plugin>
         <plugin>
           <artifactId>maven-assembly-plugin</artifactId>
+          <version>3.4.2</version>
           <configuration>
             <descriptors>
               <descriptor>../ambari-project/src/main/assemblies/empty.xml</descriptor>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Upgrade maven-assembly-plugin from 2.2-beta-5 to 3.4.2(latest version).
This reduces the ambari metrics build time from 10 min to 2 min

## How was this patch tested?

Built before and after the change and observed the build time reduction.
Please refer https://issues.apache.org/jira/browse/AMBARI-25811 for detail

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.
