### PR TITLE
AMBARI-25818: Use java 1.8 in ambari-serviceadvisor module

### DIFF
--- a/ambari-serviceadvisor/pom.xml
+++ b/ambari-serviceadvisor/pom.xml
@@ -29,6 +29,9 @@
   <name>Ambari Service Advisor</name>
   <version>1.0.0.0-SNAPSHOT</version>
   <description>Service Advisor</description>
+  <properties>
+    <jdk.version>1.8</jdk.version>
+  </properties>
 
   <dependencies>
     <!-- Log Factory logging
@@ -104,8 +107,8 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.2</version>
         <configuration>
-          <source>1.7</source>
-          <target>1.7</target>
+          <source>${jdk.version}</source>
+          <target>${jdk.version}</target>
         </configuration>
       </plugin>
       <plugin>


### PR DESCRIPTION
## What changes were proposed in this pull request?

se java 1.8 in ambari-serviceadvisor module, same as the other module

## How was this patch tested?
Build the module after change with mvn clean install -DskipTests command. It built successfully

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.