### PR TITLE
[AMBARI-25823] Fix the widget.json for the Host memory used %

### DIFF
--- a/ambari-server/src/main/resources/widgets.json
+++ b/ambari-server/src/main/resources/widgets.json
@@ -58,7 +58,7 @@
           "values": [
             {
               "name": "Host Memory Used %",
-              "value": "${((mem_total - mem_free - mem_cached)/mem_total)*100}"
+              "value": "${((mem_total - mem_free)/mem_total)*100}"
             }
           ],
           "properties": {


### PR DESCRIPTION
'Free' memory is the memory available after the cached memory getting reduced from total memory but the 'available' memory is the total available memory including the cached memory as that can be reclaimed anytime. So mem_free is nothing but mem_available.

## What changes were proposed in this pull request?
In the host memory used heat map we should just do (mem_total-mem_free)/mem_total to get the used memory fraction.

## How was this patch tested?

(Please explain how this patch was tested. Ex: unit tests, manual tests)
(If this patch involves UI changes, please attach a screen-shot; otherwise, remove this)

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.