### PR TITLE
[AMBARI-25824] Fix the widget.json for the Host CPU Wait IO %

### DIFF
--- a/ambari-server/src/main/resources/widgets.json
+++ b/ambari-server/src/main/resources/widgets.json
@@ -80,8 +80,8 @@
           ],
           "values": [
             {
-              "name": "Host Memory Used %",
-              "value": "${cpu_wio*100}"
+              "name": "Host CPU Wait IO %",
+              "value": "${cpu_wio}"
             }
           ],
           "properties": {


### PR DESCRIPTION
Currently widgets.json shows the Host CPU Wait IO collected by psutil.cpu_times_percent() method in host_info.py. It has been converted to percentage. 

## What changes were proposed in this pull request?
We should use ${cpu_wio} instead of ${cpu_wio*100} as its value in widgets.json.

## How was this patch tested?

(Please explain how this patch was tested. Ex: unit tests, manual tests)
(If this patch involves UI changes, please attach a screen-shot; otherwise, remove this)

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.