### PR TITLE
AMBARI-25839: Reset user after RA HA wizard close

### DIFF
--- a/ambari-web/app/routes/ra_high_availability_routes.js
+++ b/ambari-web/app/routes/ra_high_availability_routes.js
@@ -164,6 +164,7 @@ module.exports = App.WizardRoute.extend({
     },
     next: function (router) {
       router.get('updateController').set('isWorking', true);
+      App.router.get('wizardWatcherController').resetUser();
       var rAHighAvailabilityWizardController = router.get('rAHighAvailabilityWizardController');
       rAHighAvailabilityWizardController.finish();
       App.clusterStatus.setClusterStatus({


### PR DESCRIPTION
## What changes were proposed in this pull request?
Fix to reset wizard user data after Ranger HA wizard completes. Without this fix all other users(except wizard owner) will have readonly screen. 

## How was this patch tested?
Validated manually after deploying the fix in cluster
Inprogress
<img width="1668" alt="inprogress-user1" src="https://user-images.githubusercontent.com/9442345/211782144-9b4d1ba9-d3e5-4714-aee3-e626568c2337.png">

Completed
<img width="1722" alt="completed-user1" src="https://user-images.githubusercontent.com/9442345/211782130-25578960-cf79-4d9c-8f23-762bb6d5ba98.png">


(Please explain how this patch was tested. Ex: unit tests, manual tests)
(If this patch involves UI changes, please attach a screen-shot; otherwise, remove this)

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.