### PR TITLE
AMBARI-25849 : Need to update org.jboss.netty: netty dependency

### DIFF
--- a/ambari-metrics/ambari-metrics-timelineservice/pom.xml
+++ b/ambari-metrics/ambari-metrics-timelineservice/pom.xml
@@ -372,6 +372,10 @@
           <artifactId>javax.ws.rs-api</artifactId>
           <groupId>javax.ws.rs</groupId>
         </exclusion>
+        <exclusion>
+          <groupId>org.jboss.netty</groupId>
+          <artifactId>netty</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
 
@@ -782,6 +786,10 @@
         <exclusion>
           <artifactId>javax.ws.rs-api</artifactId>
           <groupId>javax.ws.rs</groupId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.jboss.netty</groupId>
+          <artifactId>netty</artifactId>
         </exclusion>
         <exclusion>
           <groupId>com.fasterxml.jackson.core</groupId>


### PR DESCRIPTION
## What changes were proposed in this pull request?
Issue:
Need to update org.jboss.netty: netty dependency

Changes:
Excluded org.jboss.netty: netty dependency from unwanted imports.

## How was this patch tested?
Validated ambari-metrics started successfully.