### PR TITLE
AMBARI-25853: 'hbase.zookeeper.quorum' was wrong for Ambari-Metrics in embedded mode

### DIFF
--- a/ambari-server/src/main/resources/common-services/AMBARI_METRICS/2.0.0/package/scripts/params.py
+++ b/ambari-server/src/main/resources/common-services/AMBARI_METRICS/2.0.0/package/scripts/params.py
@@ -283,7 +283,7 @@ else:
   cluster_zookeeper_clientPort = '2181'
 
 if not is_hbase_distributed:
-  zookeeper_quorum_hosts = hostname
+  zookeeper_quorum_hosts = 'localhost'
   zookeeper_clientPort = '61181'
 else:
   zookeeper_quorum_hosts = cluster_zookeeper_quorum_hosts


### PR DESCRIPTION

## What changes were proposed in this pull request?

(Please fill in changes proposed in this fix)

## How was this patch tested?
![604bafdeee01222b1acb110eedb9fa0](https://user-images.githubusercontent.com/16263438/217711777-cc0f04f0-4e84-4ad5-9abe-a6789933809f.png)

(Please explain how this patch was tested. Ex: unit tests, manual tests)
(If this patch involves UI changes, please attach a screen-shot; otherwise, remove this)

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.