### PR TITLE
AMBARI-25857: Ambari-Metrics should in embedded mode when HDFS wasn't installed

### DIFF
--- a/ambari-server/src/main/resources/stacks/BIGTOP/3.2.0/services/stack_advisor.py
+++ b/ambari-server/src/main/resources/stacks/BIGTOP/3.2.0/services/stack_advisor.py
@@ -471,6 +471,11 @@ class BIGTOP320StackAdvisor(DefaultStackAdvisor):
       if "timeline.metrics.service.operation.mode" in services["configurations"]["ams-site"]["properties"]:
         operatingMode = services["configurations"]["ams-site"]["properties"]["timeline.metrics.service.operation.mode"]
 
+    servicesList = [service["StackServices"]["service_name"] for service in services["services"]]
+    if 'HDFS' not in servicesList:
+      operatingMode = "embedded"
+      putAmsSiteProperty("timeline.metrics.service.operation.mode", operatingMode)
+
     if operatingMode == "distributed":
       putAmsSiteProperty("timeline.metrics.service.watcher.disabled", 'true')
       putAmsHbaseSiteProperty("hbase.cluster.distributed", 'true')


### PR DESCRIPTION

## What changes were proposed in this pull request?

(Please fill in changes proposed in this fix)

## How was this patch tested?
When `HDFS` wasn't installed, `timeline.metrics.service.operation.mode` is `embedded`.
![1676614631577](https://user-images.githubusercontent.com/16263438/219564412-87a45176-de2d-44b0-b395-d7f9555dc8b2.png)


(Please explain how this patch was tested. Ex: unit tests, manual tests)
(If this patch involves UI changes, please attach a screen-shot; otherwise, remove this)

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.