### PR TITLE
AMBARI-25863: Fix a problem where the 'supported-refresh-commands' Element in configuration files for service was invalided

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/state/ConfigHelper.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/ConfigHelper.java
@@ -1743,15 +1743,22 @@ public class ConfigHelper {
       String type = changedConfigType.getKey();
       stale |= (serviceInfo.hasConfigDependency(type) || componentInfo.hasConfigType(type));
       if (stale) {
-        changedProperties.addAll(changedConfigType.getValue());
+        for (String propertyName : changedConfigType.getValue()) {
+          changedProperties.add(type + "/" + propertyName);
+        }
       }
     }
 
     String refreshCommand = calculateRefreshCommand(stackInfo.getRefreshCommandConfiguration(), sch, changedProperties);
 
+    Map<String, HostConfig> actual = sch.getActualConfigs();
+
+    Map<String, Map<String, String>> desired = getEffectiveDesiredTags(cluster, sch.getHostName(),cluster.getDesiredConfigs());
+
     if (STALE_CONFIGS_CACHE_ENABLED) {
       if (refreshCommand != null) {
-        int staleHash = Objects.hashCode(cluster.getDesiredConfigs().hashCode(),
+        int staleHash = Objects.hashCode(actual.hashCode(),
+            desired.hashCode(),
             sch.getHostName(),
             sch.getServiceComponentName(),
             sch.getServiceName());

--- a/ambari-server/src/main/resources/stacks/BIGTOP/3.2.0/services/HDFS/configuration/core-site.xml
+++ b/ambari-server/src/main/resources/stacks/BIGTOP/3.2.0/services/HDFS/configuration/core-site.xml
@@ -194,7 +194,7 @@ DEFAULT
     <on-ambari-upgrade add="true"/>
   </property>
   <property>
-    <name>hadoop.proxyuser.*</name>
+    <name>hadoop.proxyuser</name>
     <value/>
     <description>
       This * property is not configured it's used just to define refresh commands for all properties
@@ -203,6 +203,9 @@ DEFAULT
     <supported-refresh-commands>
       <refresh-command componentName="NAMENODE" command="reloadproxyusers" />
     </supported-refresh-commands>
+    <value-attributes>
+      <empty-value-valid>true</empty-value-valid>
+    </value-attributes>
     <on-ambari-upgrade add="false"/>
   </property>
   <property>

--- a/ambari-server/src/main/resources/stacks/BIGTOP/3.2.0/services/HDFS/metainfo.xml
+++ b/ambari-server/src/main/resources/stacks/BIGTOP/3.2.0/services/HDFS/metainfo.xml
@@ -129,6 +129,13 @@
                 <scriptType>PYTHON</scriptType>
               </commandScript>
             </customCommand>
+            <customCommand>
+              <name>RECONFIGURE</name>
+              <commandScript>
+                <script>scripts/namenode.py</script>
+                <scriptType>PYTHON</scriptType>
+              </commandScript>
+            </customCommand>
           </customCommands>
         </component>
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

(Please fill in changes proposed in this fix)

## How was this patch tested?
Modify the properties prefixed with `hadoop.proxyuser` in the `core-site.xml` file and click the button in the red box in the image.
![image](https://user-images.githubusercontent.com/16263438/220930068-68d6b35d-e5c6-43a5-8a11-bc17d37cd386.png)


(Please explain how this patch was tested. Ex: unit tests, manual tests)
(If this patch involves UI changes, please attach a screen-shot; otherwise, remove this)

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.