### PR TITLE
AMBARI-25870: Upgrade Swagger to 1.6.2+ for avoiding NoSuchMethodError

### DIFF
--- a/ambari-project/pom.xml
+++ b/ambari-project/pom.xml
@@ -33,7 +33,7 @@
     <jetty.version>9.4.12.v20180830</jetty.version>
     <ldap-api.version>1.0.0</ldap-api.version>
     <checkstyle.version>8.9</checkstyle.version>
-    <swagger.version>1.5.19</swagger.version>
+    <swagger.version>1.6.9</swagger.version>
     <swagger.maven.plugin.version>3.1.5</swagger.maven.plugin.version>
     <slf4j.version>2.0.0</slf4j.version>
     <reload4j.version>1.2.22</reload4j.version>

--- a/ambari-project/pom.xml
+++ b/ambari-project/pom.xml
@@ -33,7 +33,7 @@
     <jetty.version>9.4.12.v20180830</jetty.version>
     <ldap-api.version>1.0.0</ldap-api.version>
     <checkstyle.version>8.9</checkstyle.version>
-    <swagger.version>1.6.9</swagger.version>
+    <swagger.version>1.6.8</swagger.version>
     <swagger.maven.plugin.version>3.1.5</swagger.maven.plugin.version>
     <slf4j.version>2.0.0</slf4j.version>
     <reload4j.version>1.2.22</reload4j.version>


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR upgrades Swagger to the current latest version 1.6.9 for avoiding NoSuchMethodError in `ambari-utility`'s unit test.

## How was this patch tested?

Ran the following command locally.

```
$ mvn clean test -f ambari-utility/pom.xml

...

[INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.1 s - in org.apache.ambari.swagger.AmbariSwaggerReaderTest
[INFO]
[INFO] Results:
[INFO]
[WARNING] Tests run: 10, Failures: 0, Errors: 0, Skipped: 1

...

[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  6.677 s
[INFO] Finished at: 2023-02-26T09:48:29+09:00
[INFO] ------------------------------------------------------------------------
```