### PR TITLE
AMBARI-25872: make  ambari agent  can communicate with ambari server via http

### DIFF
--- a/ambari-agent/src/main/python/ambari_agent/HeartbeatThread.py
+++ b/ambari-agent/src/main/python/ambari_agent/HeartbeatThread.py
@@ -242,8 +242,13 @@ class HeartbeatThread(threading.Thread):
     """
     Create a stomp connection
     """
-    connection_url = 'wss://{0}:{1}/agent/stomp/v1'.format(self.config.server_hostname, self.config.secured_url_port)
-    connection_helper = security.VerifiedHTTPSConnection(self.config.server_hostname, connection_url, self.config)
+    websocket_protocol = 'wss'
+    server_hostname = self.config.server_hostname
+    if self.config.is_http_connection(server_hostname):
+      websocket_protocol = 'ws'
+    connection_url = '{0}://{1}:{2}/agent/stomp/v1'.format(websocket_protocol, server_hostname, self.config.secured_url_port)
+
+    connection_helper = security.VerifiedStompConnection(server_hostname, connection_url, self.config)
     self.connection = connection_helper.connect()
 
   def add_listeners(self):

--- a/ambari-agent/src/main/python/ambari_agent/NetUtil.py
+++ b/ambari-agent/src/main/python/ambari_agent/NetUtil.py
@@ -66,14 +66,17 @@ class NetUtil:
     try:
       parsedurl = urlparse(url)
 
-      # hasattr being true means that current python version has default cert verification enabled.
-      if hasattr(ssl, '_create_unverified_context') and not ssl_verify_cert:
-          ca_connection = httplib.HTTPSConnection(parsedurl[1], context=ssl._create_unverified_context())
+      if parsedurl.scheme == 'http':
+        connection = httplib.HTTPConnection(parsedurl[1])
       else:
-          ca_connection = httplib.HTTPSConnection(parsedurl[1])
+        # hasattr being true means that current python version has default cert verification enabled.
+        if hasattr(ssl, '_create_unverified_context') and not ssl_verify_cert:
+          connection = httplib.HTTPSConnection(parsedurl[1], context=ssl._create_unverified_context())
+        else:
+          connection = httplib.HTTPSConnection(parsedurl[1])
 
-      ca_connection.request("GET", parsedurl[2])
-      response = ca_connection.getresponse()
+      connection.request("GET", parsedurl[2])
+      response = connection.getresponse()
       status = response.status
 
       if status == 200:

--- a/ambari-agent/src/main/python/ambari_agent/main.py
+++ b/ambari-agent/src/main/python/ambari_agent/main.py
@@ -478,7 +478,7 @@ def main(initializer_module, heartbeat_stop_callback=None):
   # Keep trying to connect to a server or bail out if ambari-agent was stopped
   while not connected and not stopped and not initializer_module.stop_event.is_set():
     for server_hostname in server_hostnames:
-      server_url = config.get_api_url(server_hostname)
+      server_url = config.get_server_api_url(server_hostname)
       try:
         server_ip = socket.gethostbyname(server_hostname)
         logger.info('Connecting to Ambari server at %s (%s)', server_url, server_ip)

--- a/ambari-server/src/main/java/org/apache/ambari/server/configuration/Configuration.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/configuration/Configuration.java
@@ -3943,6 +3943,16 @@ public class Configuration {
   }
 
   /**
+   * Check to see if  SSL auth should be used between server and agents
+   * or not
+   *
+   * @return SSL authentication is enabled
+   */
+  public boolean isSslEnabled() {
+    return Boolean.parseBoolean(getProperty(AGENT_USE_SSL));
+  }
+
+  /**
    * Check to see if the API responses should be compressed via gzip or not
    * @return false if not, true if gzip compression needs to be used.
    */

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/AmbariServer.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/AmbariServer.java
@@ -429,7 +429,7 @@ public class AmbariServer {
 
       // session-per-request strategy for agents
       agentroot.addFilter(new FilterHolder(injector.getInstance(AmbariPersistFilter.class)), "/agent/*", DISPATCHER_TYPES);
-      agentroot.addFilter(SecurityFilter.class, "/*", DISPATCHER_TYPES);
+      agentroot.addFilter(new FilterHolder(injector.getInstance(SecurityFilter.class)), "/*", DISPATCHER_TYPES);
 
       Map<String, String> configsMap = configs.getConfigsMap();
 

--- a/ambari-server/src/main/java/org/apache/ambari/server/security/unsecured/rest/ConnectionInfo.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/security/unsecured/rest/ConnectionInfo.java
@@ -42,6 +42,7 @@ public class ConnectionInfo {
     public static void init(Configuration instance){
         conf = instance;
         response.put(Configuration.SRVR_TWO_WAY_SSL.getKey(),String.valueOf(conf.isTwoWaySsl()));
+        response.put(Configuration.AGENT_USE_SSL.getKey(),String.valueOf(conf.isSslEnabled()));
     }
 
     @GET @ApiIgnore // until documented


### PR DESCRIPTION
## What changes were proposed in this pull request?
ambari server supports closing ssl and communication with agent using http 
However, the function of using http to communicate with ambari server is not implemented in ambari agent.

The PR logic here is
1. The agent detects the communication type, specifically http, ssl oneway, ssl twoway
2. The agent and ambari server establish a corresponding type of websocker persistent connection according to the detection results. Among them, ssl twoway requires ambari agent to provide relevant certificate information, while http and ssl oneway do not need to verify the client, and do not need ssl option
3. The ambari agent will use some http or https short connections to download resources and other operations, so it is necessary to construct a URL with the correct type of protocol.
4. The netutil of ambari agent does not support http, add support
5. In order to cooperate with the detection of whether to enable ssl, the server side needs to add the agent.ssl attribute in the /connecion_info interface.
6. In the security filter, the server needs to determine whether to enable http to determine the filtering rules

## How was this patch tested?
unit tests and manual tests

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.