### PR TITLE
AMBARI-25874: Fix AlertTargetResourceProviderTest to work after merging AMBARI-25300

### DIFF
--- a/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/AlertTargetResourceProviderTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/AlertTargetResourceProviderTest.java
@@ -1073,6 +1073,7 @@ public class AlertTargetResourceProviderTest {
 
   @Test
   public void testEnable() throws Exception {
+    expect(m_dao.findTargetByName(ALERT_TARGET_NAME)).andReturn(null).atLeastOnce();
     Capture<AlertTargetEntity> entityCapture = EasyMock.newCapture();
     m_dao.create(capture(entityCapture));
     expectLastCall().times(1);


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR defines mock's behavior corresponding with `AlertDispatchDAO#findTargetByName` in `AlertTargetResourceProviderTest#testEnable` so that the test in question passes.

## How was this patch tested?

Ran `mvn clean test -Dtest=AlertTargetResourceProviderTest#testEnable -DskipPythonTests=true -f ambari-server/pom.xml` locally and ensured it passed.