### PR TITLE
AMBARI-25878: Fix TopologyManagerTest after merging AMBARI-25186

### DIFF
--- a/ambari-server/src/test/java/org/apache/ambari/server/topology/TopologyManagerTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/topology/TopologyManagerTest.java
@@ -42,6 +42,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.TreeMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
@@ -489,7 +490,11 @@ public class TopologyManagerTest {
     expect(ambariContext.isTopologyResolved(CLUSTER_ID)).andReturn(true).anyTimes();
 
     expect(blueprint.getSecurity()).andReturn(securityConfiguration).anyTimes();
+    expect(securityConfiguration.getDescriptor()).andReturn(Optional.empty());
     expect(request.getCredentialsMap()).andReturn(Collections.singletonMap(TopologyManager.KDC_ADMIN_CREDENTIAL, credential));
+    expect(credential.getAlias()).andReturn("").anyTimes();
+    expect(credential.getKey()).andReturn("").anyTimes();
+    expect(credential.getPrincipal()).andReturn("").anyTimes();
 
     bpConfiguration.setProperty(KerberosHelper.KERBEROS_ENV, KerberosHelper.KDC_TYPE, "none");
 
@@ -515,7 +520,11 @@ public class TopologyManagerTest {
     expect(ambariContext.isTopologyResolved(CLUSTER_ID)).andReturn(true).anyTimes();
 
     expect(blueprint.getSecurity()).andReturn(securityConfiguration).anyTimes();
+    expect(securityConfiguration.getDescriptor()).andReturn(Optional.empty());
     expect(request.getCredentialsMap()).andReturn(Collections.singletonMap(TopologyManager.KDC_ADMIN_CREDENTIAL, credential));
+    expect(credential.getAlias()).andReturn("").anyTimes();
+    expect(credential.getKey()).andReturn("").anyTimes();
+    expect(credential.getPrincipal()).andReturn("").anyTimes();
 
     bpConfiguration.setProperty(KerberosHelper.KERBEROS_ENV, KerberosHelper.MANAGE_IDENTITIES, "false");
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR adds some behaviors to mock objects so that TopologyManagerTest passes.

## How was this patch tested?

Ran the following command locally.

```
$ mvn clean test -Dtest=TopologyManagerTest -DskipPythonTests -f ambari-server/pom.xml

...

[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Running org.apache.ambari.server.topology.TopologyManagerTest
[INFO] Tests run: 13, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 2.296 s - in org.apache.ambari.server.topology.TopologyManagerTest
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 13, Failures: 0, Errors: 0, Skipped: 0
[INFO] 

...

[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  59.262 s
[INFO] Finished at: 2023-02-28T10:55:36+09:00
[INFO] ------------------------------------------------------------------------
```