### PR TITLE
AMBARI-25882 Fix clusterId NPE error on service operation execution

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/actionmanager/Stage.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/actionmanager/Stage.java
@@ -357,6 +357,7 @@ public class Stage {
     ExecutionCommand cmd = new ExecutionCommand();
     ExecutionCommandWrapper wrapper = ecwFactory.createFromCommand(cmd);
     hrc.setExecutionCommandWrapper(wrapper);
+    cmd.setClusterId(Long.toString(clusterId));
     cmd.setHostname(hostName);
     cmd.setClusterName(clusterName);
     cmd.setRequestAndStage(requestId, stageId);


### PR DESCRIPTION
## What changes were proposed in this pull request?

AgentCommandsPublisher can't get clusterId from execution command, cause it's not set in  addGenericExecutionCommand( Stage.java) method.

Why did the action  succeed in the end after throw a NPE error? Because it finally reload it from database if find cluster id is not set properlly.

how to fix:
 all the Stage construction method  include the cluster id ,so just set in the addGenericExecutionCommand

## How was this patch tested?
before fixed,if you try to restart spark or any other components ,NPE error in log
![image](https://user-images.githubusercontent.com/18082602/222371051-295376f5-2c65-4b8d-a1bf-b770fde2aaa0.png)

after fixed, 
![image](https://user-images.githubusercontent.com/18082602/222371343-39dcf3e9-67d1-475c-b2b1-783f46d455a9.png)

(Please explain how this patch was tested. Ex: unit tests, manual tests)
(If this patch involves UI changes, please attach a screen-shot; otherwise, remove this)

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.