### PR TITLE
AMBARI-25884: Set Keytab, Check keytab and Remove Keytab operations f…

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/events/publishers/AgentCommandsPublisher.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/events/publishers/AgentCommandsPublisher.java
@@ -35,6 +35,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
 
 import javax.annotation.Nullable;
@@ -95,8 +96,8 @@ public class AgentCommandsPublisher {
 
   public void sendAgentCommand(Multimap<Long, AgentCommand> agentCommands) throws AmbariRuntimeException {
     if (agentCommands != null && !agentCommands.isEmpty()) {
-      Map<Long, TreeMap<String, ExecutionCommandsCluster>> executionCommandsClusters = new TreeMap<>();
-      Map<Long, Map<String, DesiredConfig>> clusterDesiredConfigs = new HashMap<>();
+      Map<Long, TreeMap<String, ExecutionCommandsCluster>> executionCommandsClusters = new ConcurrentHashMap<>();
+      Map<Long, Map<String, DesiredConfig>> clusterDesiredConfigs = new ConcurrentHashMap<>();
 
       try {
         threadPools.getAgentPublisherCommandsPool().submit(() -> {


### PR DESCRIPTION
…ailing on few clusters

## What changes were proposed in this pull request?

(Please fill in changes proposed in this fix)
Update executionCommandsClusters to threadsafe ConcurrentHashMap

## How was this patch tested?

(Please explain how this patch was tested. Ex: unit tests, manual tests)
Verified the kerberos service check on a large cluster where the service check was getting stuck for 30 minutes, after the fix the service check is getting completed in 20 seconds.

(If this patch involves UI changes, please attach a screen-shot; otherwise, remove this)

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.