### PR TITLE
AMBARI-25891: Enhancements when regenerating keytabs and changing Kerberos configurations

### DIFF
--- a/ambari-web/app/controllers/main/admin/kerberos.js
+++ b/ambari-web/app/controllers/main/admin/kerberos.js
@@ -572,7 +572,7 @@ App.MainAdminKerberosController = App.KerberosWizardStep4Controller.extend({
         self.regenerateKeytabsRequest(false,false);
       });
     } else {
-      this.restartServicesAfterRegenerate(false, callback);
+      this.regenerateKeytabs(callback);
     }
   },
 

--- a/ambari-web/app/utils/ajax/ajax.js
+++ b/ambari-web/app/utils/ajax/ajax.js
@@ -1977,7 +1977,7 @@ var urls = {
   },
 
   'admin.kerberos_security.regenerate_keytabs': {
-    'real': '/clusters/{clusterName}?regenerate_keytabs={type}',
+    'real': '/clusters/{clusterName}?regenerate_keytabs={type}&config_update_policy=none',
     'mock': '',
     'type': 'PUT',
     'format': function (data) {


### PR DESCRIPTION
## What changes were proposed in this pull request?

- Allow administrators to choose whether regenerating all keytabs or only missing keytabs when they are changing configurations in `Kerberos` tab.
- Don't change any configurations related to kerberos.json when regenerating keytabs. It makes administrators confused.

## How was this patch tested?

- manual tests on local env. and internal cluster.