### PR TITLE
AMBARI-25856: Resolve Spring Core dependency [swagger maven plugin]

### DIFF
--- a/ambari-project/pom.xml
+++ b/ambari-project/pom.xml
@@ -748,6 +748,13 @@
           <groupId>com.github.kongchen</groupId>
           <artifactId>swagger-maven-plugin</artifactId>
           <version>${swagger.maven.plugin.version}</version>
+          <dependencies>
+          <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-core</artifactId>
+            <version>${spring.version}</version>
+          </dependency>
+        </dependencies>
         </plugin>
         <plugin>
           <groupId>org.codehaus.mojo</groupId>


### PR DESCRIPTION
## What changes were proposed in this pull request?
spring-core in com.github.kongchen in downloading version which has vulnerabilities. So using spring version for it.

(Please fill in changes proposed in this fix)

## How was this patch tested?
Run on the ambari jenkins pipeline, no error was reported.

(Please explain how this patch was tested. Ex: unit tests, manual tests)
(If this patch involves UI changes, please attach a screen-shot; otherwise, remove this)

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.