### PR TITLE
AMBARI-25912: use LinkedBlockingQueue in AgentsRegistrationQueue for performance improvement

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/agent/stomp/AgentsRegistrationQueue.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/agent/stomp/AgentsRegistrationQueue.java
@@ -19,8 +19,8 @@ package org.apache.ambari.server.agent.stomp;
 
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
-import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 

--- a/ambari-server/src/main/java/org/apache/ambari/server/agent/stomp/AgentsRegistrationQueue.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/agent/stomp/AgentsRegistrationQueue.java
@@ -18,9 +18,9 @@
 package org.apache.ambari.server.agent.stomp;
 
 import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.Executors;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 

--- a/ambari-server/src/main/java/org/apache/ambari/server/agent/stomp/AgentsRegistrationQueue.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/agent/stomp/AgentsRegistrationQueue.java
@@ -17,8 +17,8 @@
  */
 package org.apache.ambari.server.agent.stomp;
 
-import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ThreadFactory;

--- a/ambari-server/src/main/java/org/apache/ambari/server/agent/stomp/AgentsRegistrationQueue.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/agent/stomp/AgentsRegistrationQueue.java
@@ -17,7 +17,7 @@
  */
 package org.apache.ambari.server.agent.stomp;
 
-import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
@@ -46,7 +46,7 @@ public class AgentsRegistrationQueue {
 
   public AgentsRegistrationQueue(Injector injector) {
     Configuration configuration = injector.getInstance(Configuration.class);
-    registrationQueue = new ArrayBlockingQueue<>(configuration.getAgentsRegistrationQueueSize());
+    registrationQueue = new LinkedBlockingQueue<>(configuration.getAgentsRegistrationQueueSize());
   }
 
   public boolean offer(String sessionId) {


### PR DESCRIPTION
## What changes were proposed in this pull request?
#### Background
The AgentRegisteringQueueChecker is an interceptor used during the long connection between the agent and server, mainly for requesting congestion control. It internally uses AgentsRegistrationQueue to store the sessionID of connections.

The sessionID is added to the AgentsRegistrationQueue when the ambari agent registers to the server or sends a heartbeat.

When the long connection between the agent and server is disconnected, or when the server completes the heartbeat request, the sessionID is removed from the AgentsRegistrationQueue.

When the queue is full, the server returns "not allowed" to the agent.

#### Solution
AgentsRegistrationQueue uses ArrayBlockingQueue, which uses the same lock for both writing and consuming, making it easy to negatively impact performance when dealing with large clusters. Therefore, we are switching to using LinkedBlockingQueue in order to improve performance.

## How was this patch tested?
unit tests
