### PR TITLE
AMBARI-25915:The quicklink of Solr is not display

### DIFF
--- a/ambari-server/src/main/resources/stacks/BIGTOP/3.2.0/services/SOLR/quicklinks/quicklinks.json
+++ b/ambari-server/src/main/resources/stacks/BIGTOP/3.2.0/services/SOLR/quicklinks/quicklinks.json
@@ -16,7 +16,7 @@
         {
           "name": "solr_ui",
           "label": "Solr Admin UI",
-          "component_name": "SOLR",
+          "component_name": "SOLR_SERVER",
           "url": "%@://%@:%@",
           "requires_user_name": "false",
           "port": {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Resolve the solr's quicklink non display.

see: [AMBARI-25915](https://issues.apache.org/jira/browse/AMBARI-25915)


## How was this patch tested?

Creating a cluster containing Solr, 
Checking the Solr's quicklink

Please review , thanks