### PR TITLE
AMBARI-25920: fix ambari server build failed due to ambari-serviceadv…

### DIFF
--- a/ambari-server/pom.xml
+++ b/ambari-server/pom.xml
@@ -1790,7 +1790,7 @@
     <dependency>
       <groupId>org.apache.ambari</groupId>
       <artifactId>ambari-serviceadvisor</artifactId>
-      <version>1.0.0.0-SNAPSHOT</version>
+      <version>${revision}</version>
       <exclusions>
         <exclusion>
           <groupId>commons-httpclient</groupId>

--- a/ambari-serviceadvisor/pom.xml
+++ b/ambari-serviceadvisor/pom.xml
@@ -24,10 +24,16 @@
   To test independently without needing the rest of Ambari, simply compile and run as,
   java -jar ambari-serviceadvisor-$VERSION.jar [ACTION] [HOSTS_FILE.json] [SERVICES_FILE.json]
   -->
+  <parent>
+    <groupId>org.apache.ambari</groupId>
+    <artifactId>ambari-project</artifactId>
+    <version>${revision}</version>
+    <relativePath>../ambari-project</relativePath>
+  </parent>
+
   <groupId>org.apache.ambari</groupId>
   <artifactId>ambari-serviceadvisor</artifactId>
   <name>Ambari Service Advisor</name>
-  <version>1.0.0.0-SNAPSHOT</version>
   <description>Service Advisor</description>
   <properties>
     <jdk.version>1.8</jdk.version>
@@ -109,6 +115,14 @@
         <configuration>
           <source>${jdk.version}</source>
           <target>${jdk.version}</target>
+        </configuration>
+      </plugin>
+      <plugin>
+        <artifactId>maven-assembly-plugin</artifactId>
+        <configuration>
+          <descriptors>
+            <descriptor>${project.parent.basedir}/src/main/assemblies/empty.xml</descriptor>
+          </descriptors>
         </configuration>
       </plugin>
       <plugin>


### PR DESCRIPTION
…isor version

## What changes were proposed in this pull request?
ambari build failed due to ambari-serviceadvisor version not correct 

[ERROR] Failed to execute goal on project ambari-server: Could not resolve dependencies for project org.apache.ambari:ambari-server:jar:2.8.0.0.0: Could not find artifact org.apache.ambari:ambari-serviceadvisor:jar:1.0.0.0-SNAPSHOT in Gridsum (http://repository.gridsum.com/repository/maven-public) -> [Help 1]

![image](https://user-images.githubusercontent.com/18082602/230019898-20fb593b-cb4e-4902-b540-8ca1c286ad9d.png)

## How was this patch tested?

manual tests
![image](https://user-images.githubusercontent.com/18082602/230020006-15a279e9-3d16-4076-aa2a-7808c2964917.png)

(Please explain how this patch was tested. Ex: unit tests, manual tests)
(If this patch involves UI changes, please attach a screen-shot; otherwise, remove this)

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.