### PR TITLE
AMBARI-25932: fix wrong config file name in spark service advisor

### DIFF
--- a/ambari-server/src/main/resources/stacks/BIGTOP/3.2.0/services/SPARK/service_advisor.py
+++ b/ambari-server/src/main/resources/stacks/BIGTOP/3.2.0/services/SPARK/service_advisor.py
@@ -42,10 +42,10 @@ except Exception as e:
   traceback.print_exc()
   print "Failed to load parent"
 
-class Spark2ServiceAdvisor(service_advisor.ServiceAdvisor):
+class SparkServiceAdvisor(service_advisor.ServiceAdvisor):
 
   def __init__(self, *args, **kwargs):
-    self.as_super = super(Spark2ServiceAdvisor, self)
+    self.as_super = super(SparkServiceAdvisor, self)
     self.as_super.__init__(*args, **kwargs)
 
     # Always call these methods
@@ -125,8 +125,8 @@ class Spark2ServiceAdvisor(service_advisor.ServiceAdvisor):
     #Logger.info("Class: %s, Method: %s. Recommending Service Configurations." %
     #            (self.__class__.__name__, inspect.stack()[0][3]))
 
-    recommender = Spark2Recommender()
-    recommender.recommendSpark2ConfigurationsFromHDP25(configurations, clusterData, services, hosts)
+    recommender = SparkRecommender()
+    recommender.recommendSparkConfigurationsFromHDP25(configurations, clusterData, services, hosts)
     recommender.recommendSPARK2ConfigurationsFromHDP26(configurations, clusterData, services, hosts)
     recommender.recommendSPARK2ConfigurationsFromHDP30(configurations, clusterData, services, hosts)
 
@@ -141,7 +141,7 @@ class Spark2ServiceAdvisor(service_advisor.ServiceAdvisor):
     #Logger.info("Class: %s, Method: %s. Validating Configurations." %
     #            (self.__class__.__name__, inspect.stack()[0][3]))
 
-    validator = Spark2Validator()
+    validator = SparkValidator()
     # Calls the methods of the validator using arguments,
     # method(siteProperties, siteRecommendations, configurations, services, hosts)
     return validator.validateListOfConfigUsingMethod(configurations, recommendedDefaults, services, hosts, validator.validators)
@@ -173,16 +173,16 @@ class Spark2ServiceAdvisor(service_advisor.ServiceAdvisor):
       return False
 
 
-class Spark2Recommender(service_advisor.ServiceAdvisor):
+class SparkRecommender(service_advisor.ServiceAdvisor):
   """
-  Spark2 Recommender suggests properties when adding the service for the first time or modifying configs via the UI.
+  Spark Recommender suggests properties when adding the service for the first time or modifying configs via the UI.
   """
 
   def __init__(self, *args, **kwargs):
-    self.as_super = super(Spark2Recommender, self)
+    self.as_super = super(SparkRecommender, self)
     self.as_super.__init__(*args, **kwargs)
 
-  def recommendSpark2ConfigurationsFromHDP25(self, configurations, clusterData, services, hosts):
+  def recommendSparkConfigurationsFromHDP25(self, configurations, clusterData, services, hosts):
     """
     :type configurations dict
     :type clusterData dict
@@ -202,16 +202,16 @@ class Spark2Recommender(service_advisor.ServiceAdvisor):
     :type hosts dict
     """
 
-    if Spark2ServiceAdvisor.isKerberosEnabled(services, configurations):
+    if SparkServiceAdvisor.isKerberosEnabled(services, configurations):
 
-      spark2_defaults = self.getServicesSiteProperties(services, "spark-defaults")
+      spark_defaults = self.getServicesSiteProperties(services, "spark-defaults")
 
-      if spark2_defaults:
-        putSpark2DafaultsProperty = self.putProperty(configurations, "spark-defaults", services)
-        putSpark2DafaultsProperty('spark.acls.enable', 'true')
-        putSpark2DafaultsProperty('spark.admin.acls', '')
-        putSpark2DafaultsProperty('spark.history.ui.acls.enable', 'true')
-        putSpark2DafaultsProperty('spark.history.ui.admin.acls', '')
+      if spark_defaults:
+        putSparkDafaultsProperty = self.putProperty(configurations, "spark-defaults", services)
+        putSparkDafaultsProperty('spark.acls.enable', 'true')
+        putSparkDafaultsProperty('spark.admin.acls', '')
+        putSparkDafaultsProperty('spark.history.ui.acls.enable', 'true')
+        putSparkDafaultsProperty('spark.history.ui.admin.acls', '')
 
 
     self.__addZeppelinToLivy2SuperUsers(configurations, services)
@@ -220,45 +220,45 @@ class Spark2Recommender(service_advisor.ServiceAdvisor):
   def recommendSPARK2ConfigurationsFromHDP30(self, configurations, clusterData, services, hosts):
 
     # SAC
-    if "spark2-atlas-application-properties-override" in services["configurations"]:
-      spark2_atlas_application_properties_override = self.getServicesSiteProperties(services, "spark2-atlas-application-properties-override")
-      spark2_defaults_properties = self.getServicesSiteProperties(services, "spark-defaults")
-      putSpark2DefautlsProperty = self.putProperty(configurations, "spark-defaults", services)
-      putSpark2DefaultsPropertyAttribute = self.putPropertyAttribute(configurations,"spark-defaults")
-      putSpark2AtlasHookProperty = self.putProperty(configurations, "spark2-atlas-application-properties-override", services)
-      putSpark2AtlasHookPropertyAttribute = self.putPropertyAttribute(configurations,"spark2-atlas-application-properties-override")
-      spark2_sac_enabled = None
-      if self.checkSiteProperties(spark2_atlas_application_properties_override, "atlas.spark.enabled"):
-        spark2_sac_enabled = spark2_atlas_application_properties_override["atlas.spark.enabled"]
-        spark2_sac_enabled = str(spark2_sac_enabled).upper() == 'TRUE'
+    if "spark-atlas-application-properties-override" in services["configurations"]:
+      spark_atlas_application_properties_override = self.getServicesSiteProperties(services, "spark-atlas-application-properties-override")
+      spark_defaults_properties = self.getServicesSiteProperties(services, "spark-defaults")
+      putSparkDefautlsProperty = self.putProperty(configurations, "spark-defaults", services)
+      putSparkDefaultsPropertyAttribute = self.putPropertyAttribute(configurations,"spark-defaults")
+      putSparkAtlasHookProperty = self.putProperty(configurations, "spark-atlas-application-properties-override", services)
+      putSparkAtlasHookPropertyAttribute = self.putPropertyAttribute(configurations,"spark-atlas-application-properties-override")
+      spark_sac_enabled = None
+      if self.checkSiteProperties(spark_atlas_application_properties_override, "atlas.spark.enabled"):
+        spark_sac_enabled = spark_atlas_application_properties_override["atlas.spark.enabled"]
+        spark_sac_enabled = str(spark_sac_enabled).upper() == 'TRUE'
 
-      if spark2_sac_enabled:
-        self.setOrAddValueToProperty(putSpark2DefautlsProperty, spark2_defaults_properties, "spark.driver.extraClassPath", "/usr/bigtop/current/spark-atlas-connector/*", ":")
-        self.setOrAddValueToProperty(putSpark2DefautlsProperty, spark2_defaults_properties, "spark.yarn.dist.files", "/etc/spark/conf/atlas-application.properties.yarn#atlas-application.properties", ",")
-        self.setOrAddValueToProperty(putSpark2DefautlsProperty, spark2_defaults_properties, "spark.driver.extraClassPath", "/usr/bigtop/current/spark-atlas-connector/*", ":")
-        self.setOrAddValueToProperty(putSpark2DefautlsProperty, spark2_defaults_properties, "spark.extraListeners", "com.hortonworks.spark.atlas.SparkAtlasEventTracker", ",")
-        self.setOrAddValueToProperty(putSpark2DefautlsProperty, spark2_defaults_properties, "spark.sql.queryExecutionListeners", "com.hortonworks.spark.atlas.SparkAtlasEventTracker", ",")
-        self.setOrAddValueToProperty(putSpark2DefautlsProperty, spark2_defaults_properties, "spark.extraListeners", "com.hortonworks.spark.atlas.SparkAtlasEventTracker", ",")
-        self.setOrAddValueToProperty(putSpark2DefautlsProperty, spark2_defaults_properties, "spark.sql.queryExecutionListeners", "com.hortonworks.spark.atlas.SparkAtlasEventTracker", ",")
+      if spark_sac_enabled:
+        self.setOrAddValueToProperty(putSparkDefautlsProperty, spark_defaults_properties, "spark.driver.extraClassPath", "/usr/bigtop/current/spark-atlas-connector/*", ":")
+        self.setOrAddValueToProperty(putSparkDefautlsProperty, spark_defaults_properties, "spark.yarn.dist.files", "/etc/spark/conf/atlas-application.properties.yarn#atlas-application.properties", ",")
+        self.setOrAddValueToProperty(putSparkDefautlsProperty, spark_defaults_properties, "spark.driver.extraClassPath", "/usr/bigtop/current/spark-atlas-connector/*", ":")
+        self.setOrAddValueToProperty(putSparkDefautlsProperty, spark_defaults_properties, "spark.extraListeners", "com.hortonworks.spark.atlas.SparkAtlasEventTracker", ",")
+        self.setOrAddValueToProperty(putSparkDefautlsProperty, spark_defaults_properties, "spark.sql.queryExecutionListeners", "com.hortonworks.spark.atlas.SparkAtlasEventTracker", ",")
+        self.setOrAddValueToProperty(putSparkDefautlsProperty, spark_defaults_properties, "spark.extraListeners", "com.hortonworks.spark.atlas.SparkAtlasEventTracker", ",")
+        self.setOrAddValueToProperty(putSparkDefautlsProperty, spark_defaults_properties, "spark.sql.queryExecutionListeners", "com.hortonworks.spark.atlas.SparkAtlasEventTracker", ",")
 
-        self.setOrAddValueToProperty(putSpark2DefautlsProperty, spark2_defaults_properties, "spark.sql.streaming.streamingQueryListeners", "com.hortonworks.spark.atlas.SparkAtlasStreamingQueryEventTracker", ",")
-        self.setOrAddValueToProperty(putSpark2DefautlsProperty, spark2_defaults_properties, "spark.sql.streaming.streamingQueryListeners", "com.hortonworks.spark.atlas.SparkAtlasStreamingQueryEventTracker", ",")
+        self.setOrAddValueToProperty(putSparkDefautlsProperty, spark_defaults_properties, "spark.sql.streaming.streamingQueryListeners", "com.hortonworks.spark.atlas.SparkAtlasStreamingQueryEventTracker", ",")
+        self.setOrAddValueToProperty(putSparkDefautlsProperty, spark_defaults_properties, "spark.sql.streaming.streamingQueryListeners", "com.hortonworks.spark.atlas.SparkAtlasStreamingQueryEventTracker", ",")
 
-        putSpark2AtlasHookProperty("atlas.client.checkModelInStart", "false")
+        putSparkAtlasHookProperty("atlas.client.checkModelInStart", "false")
 
       else:
-        self.removeValueFromProperty(putSpark2DefautlsProperty, spark2_defaults_properties, "spark.driver.extraClassPath", "/usr/bigtop/current/spark-atlas-connector/*", ":")
-        self.removeValueFromProperty(putSpark2DefautlsProperty, spark2_defaults_properties, "spark.yarn.dist.files", "/etc/spark/conf/atlas-application.properties.yarn#atlas-application.properties", ",")
-        self.removeValueFromProperty(putSpark2DefautlsProperty, spark2_defaults_properties, "spark.driver.extraClassPath", "/usr/bigtop/current/spark-atlas-connector/*", ":")
-        self.removeValueFromProperty(putSpark2DefautlsProperty, spark2_defaults_properties, "spark.extraListeners", "com.hortonworks.spark.atlas.SparkAtlasEventTracker", ",")
-        self.removeValueFromProperty(putSpark2DefautlsProperty, spark2_defaults_properties, "spark.sql.queryExecutionListeners", "com.hortonworks.spark.atlas.SparkAtlasEventTracker", ",")
-        self.removeValueFromProperty(putSpark2DefautlsProperty, spark2_defaults_properties, "spark.extraListeners", "com.hortonworks.spark.atlas.SparkAtlasEventTracker", ",")
-        self.removeValueFromProperty(putSpark2DefautlsProperty, spark2_defaults_properties, "spark.sql.queryExecutionListeners", "com.hortonworks.spark.atlas.SparkAtlasEventTracker", ",")
+        self.removeValueFromProperty(putSparkDefautlsProperty, spark_defaults_properties, "spark.driver.extraClassPath", "/usr/bigtop/current/spark-atlas-connector/*", ":")
+        self.removeValueFromProperty(putSparkDefautlsProperty, spark_defaults_properties, "spark.yarn.dist.files", "/etc/spark/conf/atlas-application.properties.yarn#atlas-application.properties", ",")
+        self.removeValueFromProperty(putSparkDefautlsProperty, spark_defaults_properties, "spark.driver.extraClassPath", "/usr/bigtop/current/spark-atlas-connector/*", ":")
+        self.removeValueFromProperty(putSparkDefautlsProperty, spark_defaults_properties, "spark.extraListeners", "com.hortonworks.spark.atlas.SparkAtlasEventTracker", ",")
+        self.removeValueFromProperty(putSparkDefautlsProperty, spark_defaults_properties, "spark.sql.queryExecutionListeners", "com.hortonworks.spark.atlas.SparkAtlasEventTracker", ",")
+        self.removeValueFromProperty(putSparkDefautlsProperty, spark_defaults_properties, "spark.extraListeners", "com.hortonworks.spark.atlas.SparkAtlasEventTracker", ",")
+        self.removeValueFromProperty(putSparkDefautlsProperty, spark_defaults_properties, "spark.sql.queryExecutionListeners", "com.hortonworks.spark.atlas.SparkAtlasEventTracker", ",")
 
-        self.removeValueFromProperty(putSpark2DefautlsProperty, spark2_defaults_properties, "spark.sql.streaming.streamingQueryListeners", "com.hortonworks.spark.atlas.SparkAtlasStreamingQueryEventTracker", ",")
-        self.removeValueFromProperty(putSpark2DefautlsProperty, spark2_defaults_properties, "spark.sql.streaming.streamingQueryListeners", "com.hortonworks.spark.atlas.SparkAtlasStreamingQueryEventTracker", ",")
+        self.removeValueFromProperty(putSparkDefautlsProperty, spark_defaults_properties, "spark.sql.streaming.streamingQueryListeners", "com.hortonworks.spark.atlas.SparkAtlasStreamingQueryEventTracker", ",")
+        self.removeValueFromProperty(putSparkDefautlsProperty, spark_defaults_properties, "spark.sql.streaming.streamingQueryListeners", "com.hortonworks.spark.atlas.SparkAtlasStreamingQueryEventTracker", ",")
 
-        putSpark2AtlasHookPropertyAttribute("atlas.client.checkModelInStart", "delete", "true")
+        putSparkAtlasHookPropertyAttribute("atlas.client.checkModelInStart", "delete", "true")
 
 
 
@@ -278,14 +278,14 @@ class Spark2Recommender(service_advisor.ServiceAdvisor):
 
   def __addZeppelinToLivy2SuperUsers(self, configurations, services):
     """
-    If Kerberos is enabled AND Zeppelin is installed AND Spark2 Livy Server is installed, then set
+    If Kerberos is enabled AND Zeppelin is installed AND Spark Livy Server is installed, then set
     livy2-conf/livy.superusers to contain the Zeppelin principal name from
     zeppelin-site/zeppelin.server.kerberos.principal
 
     :param configurations:
     :param services:
     """
-    if Spark2ServiceAdvisor.isKerberosEnabled(services, configurations):
+    if SparkServiceAdvisor.isKerberosEnabled(services, configurations):
       zeppelin_site = self.getServicesSiteProperties(services, "zeppelin-site")
 
       if zeppelin_site and 'zeppelin.server.kerberos.principal' in zeppelin_site:
@@ -313,21 +313,21 @@ class Spark2Recommender(service_advisor.ServiceAdvisor):
               putLivy2ConfProperty('livy.superusers', ','.join(_superusers))
 
 
-class Spark2Validator(service_advisor.ServiceAdvisor):
+class SparkValidator(service_advisor.ServiceAdvisor):
   """
-  Spark2 Validator checks the correctness of properties whenever the service is first added or the user attempts to
+  Spark Validator checks the correctness of properties whenever the service is first added or the user attempts to
   change configs via the UI.
   """
 
   def __init__(self, *args, **kwargs):
-    self.as_super = super(Spark2Validator, self)
+    self.as_super = super(SparkValidator, self)
     self.as_super.__init__(*args, **kwargs)
 
-    self.validators = [("spark-defaults", self.validateSpark2DefaultsFromHDP25),
-                       ("spark2-atlas-application-properties-override", self.validateSpark2AtlasApplicationPropertiesFromHDP30)]
+    self.validators = [("spark-defaults", self.validateSparkDefaultsFromHDP25),
+                       ("spark-atlas-application-properties-override", self.validateSparkAtlasApplicationPropertiesFromHDP30)]
 
 
-  def validateSpark2DefaultsFromHDP25(self, properties, recommendedDefaults, configurations, services, hosts):
+  def validateSparkDefaultsFromHDP25(self, properties, recommendedDefaults, configurations, services, hosts):
     validationItems = [
       {
         "config-name": 'spark.yarn.queue',
@@ -336,14 +336,14 @@ class Spark2Validator(service_advisor.ServiceAdvisor):
     ]
     return self.toConfigurationValidationProblems(validationItems, "spark-defaults")
 
-  def validateSpark2AtlasApplicationPropertiesFromHDP30(self, properties, recommendedDefaults, configurations, services, hosts):
+  def validateSparkAtlasApplicationPropertiesFromHDP30(self, properties, recommendedDefaults, configurations, services, hosts):
     validationItems = []
     servicesList = [service["StackServices"]["service_name"] for service in services["services"]]
-    if not "ATLAS" in servicesList and 'atlas.spark.enabled' in services['configurations']['spark2-atlas-application-properties-override']['properties'] and \
-            str(services['configurations']['spark2-atlas-application-properties-override']['properties']['atlas.spark.enabled']).upper() == 'TRUE':
-      validationItems.append({"config-name": "spark2-atlas-application-properties-override",
+    if not "ATLAS" in servicesList and 'atlas.spark.enabled' in services['configurations']['spark-atlas-application-properties-override']['properties'] and \
+            str(services['configurations']['spark-atlas-application-properties-override']['properties']['atlas.spark.enabled']).upper() == 'TRUE':
+      validationItems.append({"config-name": "spark-atlas-application-properties-override",
                                  +                              "item": self.getErrorItem("SAC could be enabled only if ATLAS service is available on cluster!")})
-    return self.toConfigurationValidationProblems(validationItems, "spark2-atlas-application-properties-override")
+    return self.toConfigurationValidationProblems(validationItems, "spark-atlas-application-properties-override")
 
 
 

--- a/ambari-server/src/main/resources/stacks/BIGTOP/3.2.0/services/SPARK/service_advisor.py
+++ b/ambari-server/src/main/resources/stacks/BIGTOP/3.2.0/services/SPARK/service_advisor.py
@@ -79,7 +79,7 @@ class Spark2ServiceAdvisor(service_advisor.ServiceAdvisor):
 
     """
     self.heap_size_properties = {"SPARK2_JOBHISTORYSERVER":
-                                   [{"config-name": "spark2-env",
+                                   [{"config-name": "spark-env",
                                      "property": "spark_daemon_memory",
                                      "default": "2048m"}]}
 
@@ -152,7 +152,7 @@ class Spark2ServiceAdvisor(service_advisor.ServiceAdvisor):
   @staticmethod
   def isKerberosEnabled(services, configurations):
     """
-    Determines if security is enabled by testing the value of spark2-defaults/spark.history.kerberos.enabled enabled.
+    Determines if security is enabled by testing the value of spark-defaults/spark.history.kerberos.enabled enabled.
     If the property exists and is equal to "true", then is it enabled; otherwise is it assumed to be
     disabled.
 
@@ -163,12 +163,12 @@ class Spark2ServiceAdvisor(service_advisor.ServiceAdvisor):
     :rtype: bool
     :return: True or False
     """
-    if configurations and "spark2-defaults" in configurations and \
-            "spark.history.kerberos.enabled" in configurations["spark2-defaults"]["properties"]:
-      return configurations["spark2-defaults"]["properties"]["spark.history.kerberos.enabled"].lower() == "true"
-    elif services and "spark2-defaults" in services["configurations"] and \
-            "spark.history.kerberos.enabled" in services["configurations"]["spark2-defaults"]["properties"]:
-      return services["configurations"]["spark2-defaults"]["properties"]["spark.history.kerberos.enabled"].lower() == "true"
+    if configurations and "spark-defaults" in configurations and \
+            "spark.history.kerberos.enabled" in configurations["spark-defaults"]["properties"]:
+      return configurations["spark-defaults"]["properties"]["spark.history.kerberos.enabled"].lower() == "true"
+    elif services and "spark-defaults" in services["configurations"] and \
+            "spark.history.kerberos.enabled" in services["configurations"]["spark-defaults"]["properties"]:
+      return services["configurations"]["spark-defaults"]["properties"]["spark.history.kerberos.enabled"].lower() == "true"
     else:
       return False
 
@@ -189,17 +189,10 @@ class Spark2Recommender(service_advisor.ServiceAdvisor):
     :type services dict
     :type hosts dict
     """
-    putSparkProperty = self.putProperty(configurations, "spark2-defaults", services)
-    putSparkThriftSparkConf = self.putProperty(configurations, "spark2-thrift-sparkconf", services)
-
-    spark_queue = self.recommendYarnQueue(services, "spark2-defaults", "spark.yarn.queue")
+    putSparkProperty = self.putProperty(configurations, "spark-defaults", services)
+    spark_queue = self.recommendYarnQueue(services, "spark-defaults", "spark.yarn.queue")
     if spark_queue is not None:
       putSparkProperty("spark.yarn.queue", spark_queue)
-
-    spark_thrift_queue = self.recommendYarnQueue(services, "spark2-thrift-sparkconf", "spark.yarn.queue")
-    if spark_thrift_queue is not None:
-      putSparkThriftSparkConf("spark.yarn.queue", spark_thrift_queue)
-
 
   def recommendSPARK2ConfigurationsFromHDP26(self, configurations, clusterData, services, hosts):
     """
@@ -211,10 +204,10 @@ class Spark2Recommender(service_advisor.ServiceAdvisor):
 
     if Spark2ServiceAdvisor.isKerberosEnabled(services, configurations):
 
-      spark2_defaults = self.getServicesSiteProperties(services, "spark2-defaults")
+      spark2_defaults = self.getServicesSiteProperties(services, "spark-defaults")
 
       if spark2_defaults:
-        putSpark2DafaultsProperty = self.putProperty(configurations, "spark2-defaults", services)
+        putSpark2DafaultsProperty = self.putProperty(configurations, "spark-defaults", services)
         putSpark2DafaultsProperty('spark.acls.enable', 'true')
         putSpark2DafaultsProperty('spark.admin.acls', '')
         putSpark2DafaultsProperty('spark.history.ui.acls.enable', 'true')
@@ -229,11 +222,9 @@ class Spark2Recommender(service_advisor.ServiceAdvisor):
     # SAC
     if "spark2-atlas-application-properties-override" in services["configurations"]:
       spark2_atlas_application_properties_override = self.getServicesSiteProperties(services, "spark2-atlas-application-properties-override")
-      spark2_defaults_properties = self.getServicesSiteProperties(services, "spark2-defaults")
-      spark2_thriftspark_conf_properties = self.getServicesSiteProperties(services, "spark2-thrift-sparkconf")
-      putSpark2DefautlsProperty = self.putProperty(configurations, "spark2-defaults", services)
-      putSpark2DefaultsPropertyAttribute = self.putPropertyAttribute(configurations,"spark2-defaults")
-      putSpark2ThriftSparkConfProperty = self.putProperty(configurations, "spark2-thrift-sparkconf", services)
+      spark2_defaults_properties = self.getServicesSiteProperties(services, "spark-defaults")
+      putSpark2DefautlsProperty = self.putProperty(configurations, "spark-defaults", services)
+      putSpark2DefaultsPropertyAttribute = self.putPropertyAttribute(configurations,"spark-defaults")
       putSpark2AtlasHookProperty = self.putProperty(configurations, "spark2-atlas-application-properties-override", services)
       putSpark2AtlasHookPropertyAttribute = self.putPropertyAttribute(configurations,"spark2-atlas-application-properties-override")
       spark2_sac_enabled = None
@@ -242,34 +233,30 @@ class Spark2Recommender(service_advisor.ServiceAdvisor):
         spark2_sac_enabled = str(spark2_sac_enabled).upper() == 'TRUE'
 
       if spark2_sac_enabled:
-
-        self.setOrAddValueToProperty(putSpark2DefautlsProperty, spark2_defaults_properties, "spark.driver.extraClassPath", "/usr/hdp/current/spark-atlas-connector/*", ":")
-        self.setOrAddValueToProperty(putSpark2DefautlsProperty, spark2_defaults_properties, "spark.yarn.dist.files", "/etc/spark2/conf/atlas-application.properties.yarn#atlas-application.properties", ",")
-        self.setOrAddValueToProperty(putSpark2ThriftSparkConfProperty, spark2_thriftspark_conf_properties, "spark.driver.extraClassPath", "/usr/hdp/current/spark-atlas-connector/*", ":")
-
+        self.setOrAddValueToProperty(putSpark2DefautlsProperty, spark2_defaults_properties, "spark.driver.extraClassPath", "/usr/bigtop/current/spark-atlas-connector/*", ":")
+        self.setOrAddValueToProperty(putSpark2DefautlsProperty, spark2_defaults_properties, "spark.yarn.dist.files", "/etc/spark/conf/atlas-application.properties.yarn#atlas-application.properties", ",")
+        self.setOrAddValueToProperty(putSpark2DefautlsProperty, spark2_defaults_properties, "spark.driver.extraClassPath", "/usr/bigtop/current/spark-atlas-connector/*", ":")
         self.setOrAddValueToProperty(putSpark2DefautlsProperty, spark2_defaults_properties, "spark.extraListeners", "com.hortonworks.spark.atlas.SparkAtlasEventTracker", ",")
         self.setOrAddValueToProperty(putSpark2DefautlsProperty, spark2_defaults_properties, "spark.sql.queryExecutionListeners", "com.hortonworks.spark.atlas.SparkAtlasEventTracker", ",")
-        self.setOrAddValueToProperty(putSpark2ThriftSparkConfProperty, spark2_thriftspark_conf_properties, "spark.extraListeners", "com.hortonworks.spark.atlas.SparkAtlasEventTracker", ",")
-        self.setOrAddValueToProperty(putSpark2ThriftSparkConfProperty, spark2_thriftspark_conf_properties, "spark.sql.queryExecutionListeners", "com.hortonworks.spark.atlas.SparkAtlasEventTracker", ",")
+        self.setOrAddValueToProperty(putSpark2DefautlsProperty, spark2_defaults_properties, "spark.extraListeners", "com.hortonworks.spark.atlas.SparkAtlasEventTracker", ",")
+        self.setOrAddValueToProperty(putSpark2DefautlsProperty, spark2_defaults_properties, "spark.sql.queryExecutionListeners", "com.hortonworks.spark.atlas.SparkAtlasEventTracker", ",")
 
         self.setOrAddValueToProperty(putSpark2DefautlsProperty, spark2_defaults_properties, "spark.sql.streaming.streamingQueryListeners", "com.hortonworks.spark.atlas.SparkAtlasStreamingQueryEventTracker", ",")
-        self.setOrAddValueToProperty(putSpark2ThriftSparkConfProperty, spark2_thriftspark_conf_properties, "spark.sql.streaming.streamingQueryListeners", "com.hortonworks.spark.atlas.SparkAtlasStreamingQueryEventTracker", ",")
+        self.setOrAddValueToProperty(putSpark2DefautlsProperty, spark2_defaults_properties, "spark.sql.streaming.streamingQueryListeners", "com.hortonworks.spark.atlas.SparkAtlasStreamingQueryEventTracker", ",")
 
         putSpark2AtlasHookProperty("atlas.client.checkModelInStart", "false")
 
       else:
-
-        self.removeValueFromProperty(putSpark2DefautlsProperty, spark2_defaults_properties, "spark.driver.extraClassPath", "/usr/hdp/current/spark-atlas-connector/*", ":")
-        self.removeValueFromProperty(putSpark2DefautlsProperty, spark2_defaults_properties, "spark.yarn.dist.files", "/etc/spark2/conf/atlas-application.properties.yarn#atlas-application.properties", ",")
-        self.removeValueFromProperty(putSpark2ThriftSparkConfProperty, spark2_thriftspark_conf_properties, "spark.driver.extraClassPath", "/usr/hdp/current/spark-atlas-connector/*", ":")
-
+        self.removeValueFromProperty(putSpark2DefautlsProperty, spark2_defaults_properties, "spark.driver.extraClassPath", "/usr/bigtop/current/spark-atlas-connector/*", ":")
+        self.removeValueFromProperty(putSpark2DefautlsProperty, spark2_defaults_properties, "spark.yarn.dist.files", "/etc/spark/conf/atlas-application.properties.yarn#atlas-application.properties", ",")
+        self.removeValueFromProperty(putSpark2DefautlsProperty, spark2_defaults_properties, "spark.driver.extraClassPath", "/usr/bigtop/current/spark-atlas-connector/*", ":")
         self.removeValueFromProperty(putSpark2DefautlsProperty, spark2_defaults_properties, "spark.extraListeners", "com.hortonworks.spark.atlas.SparkAtlasEventTracker", ",")
         self.removeValueFromProperty(putSpark2DefautlsProperty, spark2_defaults_properties, "spark.sql.queryExecutionListeners", "com.hortonworks.spark.atlas.SparkAtlasEventTracker", ",")
-        self.removeValueFromProperty(putSpark2ThriftSparkConfProperty, spark2_thriftspark_conf_properties, "spark.extraListeners", "com.hortonworks.spark.atlas.SparkAtlasEventTracker", ",")
-        self.removeValueFromProperty(putSpark2ThriftSparkConfProperty, spark2_thriftspark_conf_properties, "spark.sql.queryExecutionListeners", "com.hortonworks.spark.atlas.SparkAtlasEventTracker", ",")
+        self.removeValueFromProperty(putSpark2DefautlsProperty, spark2_defaults_properties, "spark.extraListeners", "com.hortonworks.spark.atlas.SparkAtlasEventTracker", ",")
+        self.removeValueFromProperty(putSpark2DefautlsProperty, spark2_defaults_properties, "spark.sql.queryExecutionListeners", "com.hortonworks.spark.atlas.SparkAtlasEventTracker", ",")
 
         self.removeValueFromProperty(putSpark2DefautlsProperty, spark2_defaults_properties, "spark.sql.streaming.streamingQueryListeners", "com.hortonworks.spark.atlas.SparkAtlasStreamingQueryEventTracker", ",")
-        self.removeValueFromProperty(putSpark2ThriftSparkConfProperty, spark2_thriftspark_conf_properties, "spark.sql.streaming.streamingQueryListeners", "com.hortonworks.spark.atlas.SparkAtlasStreamingQueryEventTracker", ",")
+        self.removeValueFromProperty(putSpark2DefautlsProperty, spark2_defaults_properties, "spark.sql.streaming.streamingQueryListeners", "com.hortonworks.spark.atlas.SparkAtlasStreamingQueryEventTracker", ",")
 
         putSpark2AtlasHookPropertyAttribute("atlas.client.checkModelInStart", "delete", "true")
 
@@ -336,8 +323,7 @@ class Spark2Validator(service_advisor.ServiceAdvisor):
     self.as_super = super(Spark2Validator, self)
     self.as_super.__init__(*args, **kwargs)
 
-    self.validators = [("spark2-defaults", self.validateSpark2DefaultsFromHDP25),
-                       ("spark2-thrift-sparkconf", self.validateSpark2ThriftSparkConfFromHDP25),
+    self.validators = [("spark-defaults", self.validateSpark2DefaultsFromHDP25),
                        ("spark2-atlas-application-properties-override", self.validateSpark2AtlasApplicationPropertiesFromHDP30)]
 
 
@@ -348,17 +334,7 @@ class Spark2Validator(service_advisor.ServiceAdvisor):
         "item": self.validatorYarnQueue(properties, recommendedDefaults, 'spark.yarn.queue', services)
       }
     ]
-    return self.toConfigurationValidationProblems(validationItems, "spark2-defaults")
-
-
-  def validateSpark2ThriftSparkConfFromHDP25(self, properties, recommendedDefaults, configurations, services, hosts):
-    validationItems = [
-      {
-        "config-name": 'spark.yarn.queue',
-        "item": self.validatorYarnQueue(properties, recommendedDefaults, 'spark.yarn.queue', services)
-      }
-    ]
-    return self.toConfigurationValidationProblems(validationItems, "spark2-thrift-sparkconf")
+    return self.toConfigurationValidationProblems(validationItems, "spark-defaults")
 
   def validateSpark2AtlasApplicationPropertiesFromHDP30(self, properties, recommendedDefaults, configurations, services, hosts):
     validationItems = []

--- a/ambari-server/src/main/resources/stacks/BIGTOP/3.2.0/services/SPARK/service_advisor.py
+++ b/ambari-server/src/main/resources/stacks/BIGTOP/3.2.0/services/SPARK/service_advisor.py
@@ -128,9 +128,6 @@ class SparkServiceAdvisor(service_advisor.ServiceAdvisor):
     recommender = SparkRecommender()
     recommender.recommendSparkConfigurationsFromHDP25(configurations, clusterData, services, hosts)
     recommender.recommendSPARKConfigurationsFromHDP26(configurations, clusterData, services, hosts)
-    recommender.recommendSPARKConfigurationsFromHDP30(configurations, clusterData, services, hosts)
-
-
 
   def getServiceConfigurationsValidationItems(self, configurations, recommendedDefaults, services, hosts):
     """
@@ -212,52 +209,6 @@ class SparkRecommender(service_advisor.ServiceAdvisor):
         putSparkDafaultsProperty('spark.admin.acls', '')
         putSparkDafaultsProperty('spark.history.ui.acls.enable', 'true')
         putSparkDafaultsProperty('spark.history.ui.admin.acls', '')
-
-
-
-  def recommendSPARKConfigurationsFromHDP30(self, configurations, clusterData, services, hosts):
-
-    # SAC
-    if "spark-atlas-application-properties-override" in services["configurations"]:
-      spark_atlas_application_properties_override = self.getServicesSiteProperties(services, "spark-atlas-application-properties-override")
-      spark_defaults_properties = self.getServicesSiteProperties(services, "spark-defaults")
-      putSparkDefautlsProperty = self.putProperty(configurations, "spark-defaults", services)
-      putSparkDefaultsPropertyAttribute = self.putPropertyAttribute(configurations,"spark-defaults")
-      putSparkAtlasHookProperty = self.putProperty(configurations, "spark-atlas-application-properties-override", services)
-      putSparkAtlasHookPropertyAttribute = self.putPropertyAttribute(configurations,"spark-atlas-application-properties-override")
-      spark_sac_enabled = None
-      if self.checkSiteProperties(spark_atlas_application_properties_override, "atlas.spark.enabled"):
-        spark_sac_enabled = spark_atlas_application_properties_override["atlas.spark.enabled"]
-        spark_sac_enabled = str(spark_sac_enabled).upper() == 'TRUE'
-
-      if spark_sac_enabled:
-        self.setOrAddValueToProperty(putSparkDefautlsProperty, spark_defaults_properties, "spark.driver.extraClassPath", "/usr/bigtop/current/spark-atlas-connector/*", ":")
-        self.setOrAddValueToProperty(putSparkDefautlsProperty, spark_defaults_properties, "spark.yarn.dist.files", "/etc/spark/conf/atlas-application.properties.yarn#atlas-application.properties", ",")
-        self.setOrAddValueToProperty(putSparkDefautlsProperty, spark_defaults_properties, "spark.driver.extraClassPath", "/usr/bigtop/current/spark-atlas-connector/*", ":")
-        self.setOrAddValueToProperty(putSparkDefautlsProperty, spark_defaults_properties, "spark.extraListeners", "com.hortonworks.spark.atlas.SparkAtlasEventTracker", ",")
-        self.setOrAddValueToProperty(putSparkDefautlsProperty, spark_defaults_properties, "spark.sql.queryExecutionListeners", "com.hortonworks.spark.atlas.SparkAtlasEventTracker", ",")
-        self.setOrAddValueToProperty(putSparkDefautlsProperty, spark_defaults_properties, "spark.extraListeners", "com.hortonworks.spark.atlas.SparkAtlasEventTracker", ",")
-        self.setOrAddValueToProperty(putSparkDefautlsProperty, spark_defaults_properties, "spark.sql.queryExecutionListeners", "com.hortonworks.spark.atlas.SparkAtlasEventTracker", ",")
-
-        self.setOrAddValueToProperty(putSparkDefautlsProperty, spark_defaults_properties, "spark.sql.streaming.streamingQueryListeners", "com.hortonworks.spark.atlas.SparkAtlasStreamingQueryEventTracker", ",")
-        self.setOrAddValueToProperty(putSparkDefautlsProperty, spark_defaults_properties, "spark.sql.streaming.streamingQueryListeners", "com.hortonworks.spark.atlas.SparkAtlasStreamingQueryEventTracker", ",")
-
-        putSparkAtlasHookProperty("atlas.client.checkModelInStart", "false")
-
-      else:
-        self.removeValueFromProperty(putSparkDefautlsProperty, spark_defaults_properties, "spark.driver.extraClassPath", "/usr/bigtop/current/spark-atlas-connector/*", ":")
-        self.removeValueFromProperty(putSparkDefautlsProperty, spark_defaults_properties, "spark.yarn.dist.files", "/etc/spark/conf/atlas-application.properties.yarn#atlas-application.properties", ",")
-        self.removeValueFromProperty(putSparkDefautlsProperty, spark_defaults_properties, "spark.driver.extraClassPath", "/usr/bigtop/current/spark-atlas-connector/*", ":")
-        self.removeValueFromProperty(putSparkDefautlsProperty, spark_defaults_properties, "spark.extraListeners", "com.hortonworks.spark.atlas.SparkAtlasEventTracker", ",")
-        self.removeValueFromProperty(putSparkDefautlsProperty, spark_defaults_properties, "spark.sql.queryExecutionListeners", "com.hortonworks.spark.atlas.SparkAtlasEventTracker", ",")
-        self.removeValueFromProperty(putSparkDefautlsProperty, spark_defaults_properties, "spark.extraListeners", "com.hortonworks.spark.atlas.SparkAtlasEventTracker", ",")
-        self.removeValueFromProperty(putSparkDefautlsProperty, spark_defaults_properties, "spark.sql.queryExecutionListeners", "com.hortonworks.spark.atlas.SparkAtlasEventTracker", ",")
-
-        self.removeValueFromProperty(putSparkDefautlsProperty, spark_defaults_properties, "spark.sql.streaming.streamingQueryListeners", "com.hortonworks.spark.atlas.SparkAtlasStreamingQueryEventTracker", ",")
-        self.removeValueFromProperty(putSparkDefautlsProperty, spark_defaults_properties, "spark.sql.streaming.streamingQueryListeners", "com.hortonworks.spark.atlas.SparkAtlasStreamingQueryEventTracker", ",")
-
-        putSparkAtlasHookPropertyAttribute("atlas.client.checkModelInStart", "delete", "true")
-
 
 
   def setOrAddValueToProperty(self, putConfigProperty, config, propertyName, propertyValue, separator):

--- a/ambari-server/src/main/resources/stacks/BIGTOP/3.2.0/services/SPARK/service_advisor.py
+++ b/ambari-server/src/main/resources/stacks/BIGTOP/3.2.0/services/SPARK/service_advisor.py
@@ -78,7 +78,7 @@ class SparkServiceAdvisor(service_advisor.ServiceAdvisor):
     Must be overriden in child class.
 
     """
-    self.heap_size_properties = {"SPARK2_JOBHISTORYSERVER":
+    self.heap_size_properties = {"SPARK_JOBHISTORYSERVER":
                                    [{"config-name": "spark-env",
                                      "property": "spark_daemon_memory",
                                      "default": "2048m"}]}
@@ -115,7 +115,7 @@ class SparkServiceAdvisor(service_advisor.ServiceAdvisor):
     Must be overriden in child class.
     """
 
-    return self.getServiceComponentCardinalityValidations(services, hosts, "SPARK2")
+    return self.getServiceComponentCardinalityValidations(services, hosts, "SPARK")
 
   def getServiceConfigurationRecommendations(self, configurations, clusterData, services, hosts):
     """
@@ -127,8 +127,8 @@ class SparkServiceAdvisor(service_advisor.ServiceAdvisor):
 
     recommender = SparkRecommender()
     recommender.recommendSparkConfigurationsFromHDP25(configurations, clusterData, services, hosts)
-    recommender.recommendSPARK2ConfigurationsFromHDP26(configurations, clusterData, services, hosts)
-    recommender.recommendSPARK2ConfigurationsFromHDP30(configurations, clusterData, services, hosts)
+    recommender.recommendSPARKConfigurationsFromHDP26(configurations, clusterData, services, hosts)
+    recommender.recommendSPARKConfigurationsFromHDP30(configurations, clusterData, services, hosts)
 
 
 
@@ -147,7 +147,7 @@ class SparkServiceAdvisor(service_advisor.ServiceAdvisor):
     return validator.validateListOfConfigUsingMethod(configurations, recommendedDefaults, services, hosts, validator.validators)
 
   def isComponentUsingCardinalityForLayout(self, componentName):
-    return componentName in ('SPARK2_THRIFTSERVER', 'LIVY2_SERVER')
+    return componentName in ('SPARK_THRIFTSERVER', 'LIVY2_SERVER')
 
   @staticmethod
   def isKerberosEnabled(services, configurations):
@@ -194,7 +194,7 @@ class SparkRecommender(service_advisor.ServiceAdvisor):
     if spark_queue is not None:
       putSparkProperty("spark.yarn.queue", spark_queue)
 
-  def recommendSPARK2ConfigurationsFromHDP26(self, configurations, clusterData, services, hosts):
+  def recommendSPARKConfigurationsFromHDP26(self, configurations, clusterData, services, hosts):
     """
     :type configurations dict
     :type clusterData dict
@@ -217,7 +217,7 @@ class SparkRecommender(service_advisor.ServiceAdvisor):
     self.__addZeppelinToLivy2SuperUsers(configurations, services)
 
 
-  def recommendSPARK2ConfigurationsFromHDP30(self, configurations, clusterData, services, hosts):
+  def recommendSPARKConfigurationsFromHDP30(self, configurations, clusterData, services, hosts):
 
     # SAC
     if "spark-atlas-application-properties-override" in services["configurations"]:


### PR DESCRIPTION
## What changes were proposed in this pull request?
fix wrong config file name in spark service advisor
and remove livy2 related code from spark service advisor, cause it not supported in bigtop3.2 stacks

for more details see https://issues.apache.org/jira/browse/AMBARI-25932

## How was this patch tested?

manual test 

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.