### PR TITLE
AMBARI-25950: Exclude hosts getting erased when RM, NN are restarted

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/AmbariCustomCommandExecutionHelper.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/AmbariCustomCommandExecutionHelper.java
@@ -1040,7 +1040,7 @@ public class AmbariCustomCommandExecutionHelper {
     }
   }
 
-  private Set<String> calculateDecommissionedNodes(Service service, String slaveCompType) throws AmbariException {
+  Set<String> calculateDecommissionedNodes(Service service, String slaveCompType) throws AmbariException {
     Set<String> decommissionedHostsSet = new HashSet<>();
     ServiceComponent serviceComponent = service.getServiceComponent(slaveCompType);
     for (ServiceComponentHost serviceComponentHost : serviceComponent.getServiceComponentHosts().values()) {
@@ -1151,6 +1151,15 @@ public class AmbariCustomCommandExecutionHelper {
           extraParams.put(componentName, requestParams.get(componentName));
         }
 
+        if (resourceFilter.getComponentName().equals(Role.RESOURCEMANAGER.name())){
+          extraParams.putIfAbsent(ALL_DECOMMISSIONED_HOSTS, StringUtils.join(calculateDecommissionedNodes(
+            clusters.getCluster(actionExecutionContext.getClusterName()).getService(Service.Type.YARN.name()),
+              Role.NODEMANAGER.name()), ','));
+        } else if (resourceFilter.getComponentName().equals(Role.NAMENODE.name())){
+          extraParams.putIfAbsent(ALL_DECOMMISSIONED_HOSTS, StringUtils.join(calculateDecommissionedNodes(
+            clusters.getCluster(actionExecutionContext.getClusterName()).getService(Service.Type.HDFS.name()),
+              Role.DATANODE.name()), ','));
+        }
         // If command should be retried upon failure then add the option and also the default duration for retry
         if (requestParams.containsKey(KeyNames.COMMAND_RETRY_ENABLED)) {
           extraParams.put(KeyNames.COMMAND_RETRY_ENABLED, requestParams.get(KeyNames.COMMAND_RETRY_ENABLED));

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/AmbariManagementControllerImpl.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/AmbariManagementControllerImpl.java
@@ -2615,6 +2615,17 @@ public class AmbariManagementControllerImpl implements AmbariManagementControlle
     execCmd.setRoleParams(roleParams);
     execCmd.setCommandParams(commandParams);
 
+    String role = execCmd.getRole();
+    if (role.equals(Role.RESOURCEMANAGER.name())) {
+      commandParams.putIfAbsent(AmbariCustomCommandExecutionHelper.ALL_DECOMMISSIONED_HOSTS,
+        StringUtils.join(customCommandExecutionHelper.calculateDecommissionedNodes(
+          clusterService, Role.NODEMANAGER.name()), ','));
+    } else if (role.equals(Role.NAMENODE.name())) {
+      commandParams.putIfAbsent(AmbariCustomCommandExecutionHelper.ALL_DECOMMISSIONED_HOSTS,
+        StringUtils.join(customCommandExecutionHelper.calculateDecommissionedNodes(
+          clusterService, Role.DATANODE.name()), ','));
+    }
+
     CommandRepository commandRepository;
     try {
       commandRepository = repoVersionHelper.getCommandRepository(cluster, component, host);

--- a/ambari-server/src/test/java/org/apache/ambari/server/controller/BackgroundCustomCommandExecutionTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/controller/BackgroundCustomCommandExecutionTest.java
@@ -196,8 +196,10 @@ public class BackgroundCustomCommandExecutionTest {
     createService("c1", "HDFS", null);
     createService("c1", "HBASE", null);
     createServiceComponent("c1", "HDFS", "NAMENODE", State.INIT);
+    createServiceComponent("c1", "HDFS", "DATANODE", State.INIT);
     createServiceComponent("c1", "HBASE", "HBASE_MASTER", State.INIT);
     createServiceComponentHost("c1", "HDFS", "NAMENODE", "c6401", null);
+    createServiceComponentHost("c1", "HDFS", "DATANODE", "c6401", null);
     createServiceComponentHost("c1", "HBASE", "HBASE_MASTER", "c7007", null);
   }
   private void addHost(String hostname, String clusterName) throws AmbariException {


### PR DESCRIPTION
## What changes were proposed in this pull request?
Handle exclude hosts during RM,NN restart flow

(Please fill in changes proposed in this fix)

## How was this patch tested?
Updated ambari-server jar on the existing cluster, decommissioned a DataNode, Nodemanager. Verified the exlude hosts files on performing 
1. Component Level Stop, Start, Restart(HDFS, YARN)  
2. NN, RM Start, Stop, Restart  
3. Restart all required services on config changes

(Please explain how this patch was tested. Ex: unit tests, manual tests)
(If this patch involves UI changes, please attach a screen-shot; otherwise, remove this)

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.