### PR TITLE
[AMBARI-25964] action schema version toFixed(1) added

### DIFF
--- a/contrib/views/wfmanager/src/main/resources/ui/app/domain/schema-versions.js
+++ b/contrib/views/wfmanager/src/main/resources/ui/app/domain/schema-versions.js
@@ -79,7 +79,7 @@ export default Ember.Object.extend({
 
   initializeDefaultVersions(){
     this.supportedVersions.forEach((value, key) =>{
-      var max = Math.max.apply(null,value);
+      var max = Math.max.apply(null,value).toFixed(1);
       if(isNaN(max)){
         max = value.reduce((a, b) => a > b?a:b);
       }


### PR DESCRIPTION
## What changes were proposed in this pull request?
Added toFixed(1) function to Math.max.apply(null, value) function to fix precision of action schema version. 
variable max stores max value of available action schema versions. 

## How was this patch tested?
#### manual tests
* Build the wfmanager jar file and distribute it to ambari server host.
* Generate oozie workflow xml file.
* Check action schema version is '1.0' not '1'.

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.