### PR TITLE
AMBARI-25963: Metrics metadata sync problem, accessing metrics which got created though other collector throws NPE

### DIFF
--- a/ambari-metrics/ambari-metrics-timelineservice/src/main/java/org/apache/ambari/metrics/core/timeline/discovery/TimelineMetricMetadataManager.java
+++ b/ambari-metrics/ambari-metrics-timelineservice/src/main/java/org/apache/ambari/metrics/core/timeline/discovery/TimelineMetricMetadataManager.java
@@ -423,6 +423,16 @@ public class TimelineMetricMetadataManager {
   }
 
   /**
+   * Add uuid to metrics metadata mapping.
+   *
+   * @param uuid        metrics uuid
+   * @param metadataKey metrics metadata key
+   */
+  public void addMetricsInUuidMap(byte[] uuid, TimelineMetricMetadataKey metadataKey) {
+    uuidKeyMap.put(new TimelineMetricUuid(uuid), metadataKey);
+  }
+
+  /**
    * Returns the UUID gen strategy.
    * @param configuration the config
    * @return the UUID generator of type org.apache.ambari.metrics.core.timeline.uuid.MetricUuidGenStrategy

--- a/ambari-metrics/ambari-metrics-timelineservice/src/main/java/org/apache/ambari/metrics/core/timeline/discovery/TimelineMetricMetadataSync.java
+++ b/ambari-metrics/ambari-metrics-timelineservice/src/main/java/org/apache/ambari/metrics/core/timeline/discovery/TimelineMetricMetadataSync.java
@@ -110,6 +110,7 @@ public class TimelineMetricMetadataSync implements Runnable {
       for (Map.Entry<TimelineMetricMetadataKey, TimelineMetricMetadata> metadataEntry : metadataFromStore.entrySet()) {
         if (!cachedMetadata.containsKey(metadataEntry.getKey())) {
           cachedMetadata.put(metadataEntry.getKey(), metadataEntry.getValue());
+          cacheManager.addMetricsInUuidMap(metadataEntry.getValue().getUuid(), metadataEntry.getKey());
         }
       }
     }


### PR DESCRIPTION
## What changes were proposed in this pull request?

(Please fill in changes proposed in this fix)

## How was this patch tested?

(Please explain how this patch was tested. Ex: unit tests, manual tests)
(If this patch involves UI changes, please attach a screen-shot; otherwise, remove this)

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.