### PR TITLE
AMBARI-25968: Fails to compile ambari-admin

### DIFF
--- a/ambari-admin/src/main/resources/ui/admin-web/.bowerrc
+++ b/ambari-admin/src/main/resources/ui/admin-web/.bowerrc
@@ -1,4 +1,5 @@
 {
     "directory": "app/bower_components",
-    "registry": "https://bower.herokuapp.com"
+    "registry": "https://registry.bower.io",
+    "strict-ssl": false
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?
Fails to compile ambari-admin, the reason is that https://bower.herokuapp.com/ is deprecated, new registry address is https://registry.bower.io/. errors are as follows

[root@bigtop1 ambari-admin]# mvn package -DskipTests
[INFO] Scanning for projects...
[INFO]
[INFO] -------------------< org.apache.ambari:ambari-admin >-------------------
[INFO] Building Ambari Admin View 3.0.0.0-SNAPSHOT
[INFO]   from pom.xml
[INFO] --------------------------------[ jar ]---------------------------------
[INFO]
[INFO] --- build-helper:1.8:regex-property (parse-package-version) @ ambari-admin ---
[INFO]
[INFO] --- build-helper:1.8:regex-property (parse-package-release) @ ambari-admin ---
[INFO]
[INFO] --- build-helper:1.8:parse-version (parse-version) @ ambari-admin ---
[INFO]
[INFO] --- build-helper:1.8:regex-property (regex-property) @ ambari-admin ---
[INFO]
[INFO] --- enforcer:3.0.0-M2:enforce (enforce-maven-version) @ ambari-admin ---
[INFO]
[INFO] --- enforcer:3.0.0-M2:enforce (enforce-versions) @ ambari-admin ---
[INFO]
[INFO] --- frontend:1.3:install-node-and-npm (install node and npm) @ ambari-admin ---
[INFO] Node v4.5.0 is already installed.
[INFO] NPM 2.15.0 is already installed.
[INFO]
[INFO] --- frontend:1.3:npm (npm install) @ ambari-admin ---
[INFO] npm not inheriting proxy config from Maven
[INFO] Running 'npm install --unsafe-perm' in /root/ambari/ambari/ambari-admin/src/main/resources/ui/admin-web
[WARNING] npm WARN package.json adminconsole@0.0.0 No description
[WARNING] npm WARN package.json adminconsole@0.0.0 No repository field.
[WARNING] npm WARN package.json adminconsole@0.0.0 No README data
[WARNING] npm WARN package.json adminconsole@0.0.0 No license field.
[INFO]
[INFO] --- exec:1.2.1:exec (Bower install) @ ambari-admin ---
bower bootstrap#3.3.7     ECONNREFUSED Request to https://bower.herokuapp.com/packages/bootstrap failed: connect ECONNREFUSED 66.220.146.94:443
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  15.407 s
[INFO] Finished at: 2023-07-19T14:51:14+08:00
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal org.codehaus.mojo:exec-maven-plugin:1.2.1:exec (Bower install) on project ambari-admin: Command execution failed.: Process exited with an error: 1 (Exit value: 1) -> [Help 1]
[ERROR]
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR]
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoExecutionException


## How was this patch tested?
Run "mvn package -DskipTests"


Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.