### PR TITLE
AMBARI-25970: Fix incorrect ambari infra-solr service config

### DIFF
--- a/ambari-server/src/main/resources/common-services/AMBARI_INFRA_SOLR/3.0.0/properties/solr.xml.j2
+++ b/ambari-server/src/main/resources/common-services/AMBARI_INFRA_SOLR/3.0.0/properties/solr.xml.j2
@@ -63,8 +63,6 @@ limitations under the License.
       <str name="filter">os.systemCpuLoad</str>
       <str name="filter">os.openFileDescriptorCount</str>
     </reporter>
-  </metrics>
-  <metrics>
     <reporter name="ambariInfraCore" group="core" class="org.apache.ambari.infra.solr.metrics.reporters.SimpleAMSReporter">
       <int name="period">60</int>
       <str name="amsCollectorHosts">{{ams_collector_hosts}}</str>
@@ -89,8 +87,6 @@ limitations under the License.
       <str name="filter">QUERY./query.requestTimes</str>
       <str name="filter">INDEX.sizeInBytes</str>
     </reporter>
-  </metrics>
-  <metrics>
     <reporter name="ambariInfraCache" group="core" class="org.apache.ambari.infra.solr.metrics.reporters.AMSCacheReporter">
       <int name="period">60</int>
       <str name="amsCollectorHosts">{{ams_collector_hosts}}</str>
@@ -104,8 +100,6 @@ limitations under the License.
       <str name="filter">CACHE.searcher.documentCache</str>
       <str name="fields">hitratio, size, warmupTime</str>
     </reporter>
-  </metrics>
-  <metrics>
     <reporter name="ambariInfraFieldCache" group="core" class="org.apache.ambari.infra.solr.metrics.reporters.AMSCacheReporter">
       <int name="period">60</int>
       <str name="amsCollectorHosts">{{ams_collector_hosts}}</str>


### PR DESCRIPTION
## What changes were proposed in this pull request?

ambari infra-solr raised an error after started like this:
```
12:29:22,119 [main] ERROR [   ] org.apache.solr.servlet.SolrDispatchFilter (SolrDispatchFilter.java:193) - Could not start Solr. Check solr/home property and the logs
12:29:22,154 [main] ERROR [   ] org.apache.solr.common.SolrException (SolrException.java:182) - null
org.apache.solr.common.SolrException: null contains more than one value for config path: solr/metrics
at org.apache.solr.core.XmlConfigFile.getNode(XmlConfigFile.java:251) ~[solr-core-8.11.2.jar:8.11.2 17dee71932c683e345508113523e764c3e4c80fa - mdrob - 2022-06-13 11:27:54]
at org.apache.solr.core.XmlConfigFile.getNode(XmlConfigFile.java:232) ~[solr-core-8.11.2.jar:8.11.2 17dee71932c683e345508113523e764c3e4c80fa - mdrob - 2022-06-13 11:27:54]
at org.apache.solr.core.SolrXmlConfig.getMetricsConfig(SolrXmlConfig.java:540) ~[solr-core-8.11.2.jar:8.11.2 17dee71932c683e345508113523e764c3e4c80fa - mdrob - 2022-06-13 11:27:54]
at org.apache.solr.core.SolrXmlConfig.fromConfig(SolrXmlConfig.java:149) ~[solr-core-8.11.2.jar:8.11.2 17dee71932c683e345508113523e764c3e4c80fa - mdrob - 2022-06-13 11:27:54]
at org.apache.solr.core.SolrXmlConfig.fromInputStream(SolrXmlConfig.java:190) ~[solr-core-8.11.2.jar:8.11.2 17dee71932c683e345508113523e764c3e4c80fa - mdrob - 2022-06-13 11:27:54]
at org.apache.solr.core.SolrXmlConfig.fromFile(SolrXmlConfig.java:164) ~[solr-core-8.11.2.jar:8.11.2 17dee71932c683e345508113523e764c3e4c80fa - mdrob - 2022-06-13 11:27:54]
at org.apache.solr.core.SolrXmlConfig.fromSolrHome(SolrXmlConfig.java:200) ~[solr-core-8.11.2.jar:8.11.2 17dee71932c683e345508113523e764c3e4c80fa - mdrob - 2022-06-13 11:27:54]
at org.apache.solr.servlet.SolrDispatchFilter.loadNodeConfig(SolrDispatchFilter.java:317) ~[solr-core-8.11.2.jar:8.11.2 17dee71932c683e345508113523e764c3e4c80fa - mdrob - 2022-06-13 11:27:54]
at org.apache.solr.servlet.SolrDispatchFilter.createCoreContainer(SolrDispatchFilter.java:285) ~[solr-core-8.11.2.jar:8.11.2 17dee71932c683e345508113523e764c3e4c80fa - mdrob - 2022-06-13 11:27:54]
at org.apache.solr.servlet.SolrDispatchFilter.init(SolrDispatchFilter.java:184) ~[solr-core-8.11.2.jar:8.11.2 17dee71932c683e345508113523e764c3e4c80fa - mdrob - 2022-06-13 11:27:54]
at org.eclipse.jetty.servlet.FilterHolder.initialize(FilterHolder.java:140) ~[jetty-servlet-9.4.44.v20210927.jar:9.4.44.v20210927]
at org.eclipse.jetty.servlet.ServletHandler.lambda$initialize$0(ServletHandler.java:731) ~[jetty-servlet-9.4.44.v20210927.jar:9.4.44.v20210927]
at java.util.Spliterators$ArraySpliterator.forEachRemaining(Spliterators.java:948) ~[?:1.8.0_161]
at java.util.stream.Streams$ConcatSpliterator.forEachRemaining(Streams.java:742) ~[?:1.8.0_161]
at java.util.stream.ReferencePipeline$Head.forEach(ReferencePipeline.java:580) ~[?:1.8.0_161]
at org.eclipse.jetty.servlet.ServletHandler.initialize(ServletHandler.java:755) ~[jetty-servlet-9.4.44.v20210927.jar:9.4.44.v20210927]
at org.eclipse.jetty.servlet.ServletContextHandler.startContext(ServletContextHandler.java:379) ~[jetty-servlet-9.4.44.v20210927.jar:9.4.44.v20210927]
at org.eclipse.jetty.webapp.WebAppContext.startWebapp(WebAppContext.java:1449) ~[jetty-webapp-9.4.44.v20210927.jar:9.4.44.v20210927]
at org.eclipse.jetty.webapp.WebAppContext.startContext(WebAppContext.java:1414) ~[jetty-webapp-9.4.44.v20210927.jar:9.4.44.v20210927]
at org.eclipse.jetty.server.handler.ContextHandler.doStart(ContextHandler.java:910) ~[jetty-server-9.4.44.v20210927.jar:9.4.44.v20210927]
at org.eclipse.jetty.servlet.ServletContextHandler.doStart(ServletContextHandler.java:288) ~[jetty-servlet-9.4.44.v20210927.jar:9.4.44.v20210927]
at org.eclipse.jetty.webapp.WebAppContext.doStart(WebAppContext.java:524) ~[jetty-webapp-9.4.44.v20210927.jar:9.4.44.v20210927]
at org.eclipse.jetty.util.component.AbstractLifeCycle.start(AbstractLifeCycle.java:73) ~[jetty-util-9.4.44.v20210927.jar:9.4.44.v20210927]
at org.eclipse.jetty.util.component.ContainerLifeCycle.start(ContainerLifeCycle.java:169) ~[jetty-util-9.4.44.v20210927.jar:9.4.44.v20210927]
at org.eclipse.jetty.util.component.ContainerLifeCycle.doStart(ContainerLifeCycle.java:117) ~[jetty-util-9.4.44.v20210927.jar:9.4.44.v20210927]
at org.eclipse.jetty.server.handler.AbstractHandler.doStart(AbstractHandler.java:97) ~[jetty-server-9.4.44.v20210927.jar:9.4.44.v20210927]
at org.eclipse.jetty.util.component.AbstractLifeCycle.start(AbstractLifeCycle.java:73) ~[jetty-util-9.4.44.v20210927.jar:9.4.44.v20210927]
at org.eclipse.jetty.util.component.ContainerLifeCycle.start(ContainerLifeCycle.java:169) ~[jetty-util-9.4.44.v20210927.jar:9.4.44.v20210927]
at org.eclipse.jetty.util.component.ContainerLifeCycle.doStart(ContainerLifeCycle.java:110) ~[jetty-util-9.4.44.v20210927.jar:9.4.44.v20210927]
at org.eclipse.jetty.server.handler.AbstractHandler.doStart(AbstractHandler.java:97) ~[jetty-server-9.4.44.v20210927.jar:9.4.44.v20210927]
at org.eclipse.jetty.util.component.AbstractLifeCycle.start(AbstractLifeCycle.java:73) ~[jetty-util-9.4.44.v20210927.jar:9.4.44.v20210927]
at org.eclipse.jetty.util.component.ContainerLifeCycle.start(ContainerLifeCycle.java:169) ~[jetty-util-9.4.44.v20210927.jar:9.4.44.v20210927]
at org.eclipse.jetty.util.component.ContainerLifeCycle.doStart(ContainerLifeCycle.java:117) ~[jetty-util-9.4.44.v20210927.jar:9.4.44.v20210927]
at org.eclipse.jetty.server.handler.AbstractHandler.doStart(AbstractHandler.java:97) ~[jetty-server-9.4.44.v20210927.jar:9.4.44.v20210927]
at org.eclipse.jetty.util.component.AbstractLifeCycle.start(AbstractLifeCycle.java:73) ~[jetty-util-9.4.44.v20210927.jar:9.4.44.v20210927]
at org.eclipse.jetty.util.component.ContainerLifeCycle.start(ContainerLifeCycle.java:169) ~[jetty-util-9.4.44.v20210927.jar:9.4.44.v20210927]
at org.eclipse.jetty.util.component.ContainerLifeCycle.doStart(ContainerLifeCycle.java:110) ~[jetty-util-9.4.44.v20210927.jar:9.4.44.v20210927]
at org.eclipse.jetty.server.handler.AbstractHandler.doStart(AbstractHandler.java:97) ~[jetty-server-9.4.44.v20210927.jar:9.4.44.v20210927]
at org.eclipse.jetty.util.component.AbstractLifeCycle.start(AbstractLifeCycle.java:73) ~[jetty-util-9.4.44.v20210927.jar:9.4.44.v20210927]
at org.eclipse.jetty.util.component.ContainerLifeCycle.start(ContainerLifeCycle.java:169) ~[jetty-util-9.4.44.v20210927.jar:9.4.44.v20210927]
at org.eclipse.jetty.util.component.ContainerLifeCycle.doStart(ContainerLifeCycle.java:110) ~[jetty-util-9.4.44.v20210927.jar:9.4.44.v20210927]
at org.eclipse.jetty.server.handler.AbstractHandler.doStart(AbstractHandler.java:97) ~[jetty-server-9.4.44.v20210927.jar:9.4.44.v20210927]
at org.eclipse.jetty.server.handler.gzip.GzipHandler.doStart(GzipHandler.java:426) ~[jetty-server-9.4.44.v20210927.jar:9.4.44.v20210927]
at org.eclipse.jetty.util.component.AbstractLifeCycle.start(AbstractLifeCycle.java:73) ~[jetty-util-9.4.44.v20210927.jar:9.4.44.v20210927]
at org.eclipse.jetty.util.component.ContainerLifeCycle.start(ContainerLifeCycle.java:169) ~[jetty-util-9.4.44.v20210927.jar:9.4.44.v20210927]
at org.eclipse.jetty.server.Server.start(Server.java:423) ~[jetty-server-9.4.44.v20210927.jar:9.4.44.v20210927]
at org.eclipse.jetty.util.component.ContainerLifeCycle.doStart(ContainerLifeCycle.java:110) ~[jetty-util-9.4.44.v20210927.jar:9.4.44.v20210927]
at org.eclipse.jetty.server.handler.AbstractHandler.doStart(AbstractHandler.java:97) ~[jetty-server-9.4.44.v20210927.jar:9.4.44.v20210927]
at org.eclipse.jetty.server.Server.doStart(Server.java:387) ~[jetty-server-9.4.44.v20210927.jar:9.4.44.v20210927]
at org.eclipse.jetty.util.component.AbstractLifeCycle.start(AbstractLifeCycle.java:73) ~[jetty-util-9.4.44.v20210927.jar:9.4.44.v20210927]
at org.eclipse.jetty.xml.XmlConfiguration.lambda$main$3(XmlConfiguration.java:1907) ~[jetty-xml-9.4.44.v20210927.jar:9.4.44.v20210927]
at java.security.AccessController.doPrivileged(Native Method) ~[?:1.8.0_161]
at org.eclipse.jetty.xml.XmlConfiguration.main(XmlConfiguration.java:1857) [jetty-xml-9.4.44.v20210927.jar:9.4.44.v20210927]
at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[?:1.8.0_161]
at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62) ~[?:1.8.0_161]
at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[?:1.8.0_161]
at java.lang.reflect.Method.invoke(Method.java:498) ~[?:1.8.0_161]
at org.eclipse.jetty.start.Main.invokeMain(Main.java:218) [start.jar:9.4.44.v20210927]
at org.eclipse.jetty.start.Main.start(Main.java:491) [start.jar:9.4.44.v20210927]
at org.eclipse.jetty.start.Main.main(Main.java:77) [start.jar:9.4.44.v20210927]
```

solrconfig.xml contains more than one value for config path: XXXXX

root cause is ：
XML configuration parsing is now more strict about situations where a single setting is allowed but multiple values are found. In the past, one value would be chosen arbitrarily and silently. Starting with 4.5, configuration parsing will fail with an error

## How was this patch tested?

manual tests
after apply this patch infra-solr start smoonthly, and no more error logs  in infra-sorl logs.
![image](https://github.com/apache/ambari/assets/18082602/223a0f06-c7fa-48fb-b9ae-0ea89045ea91)

![image](https://github.com/apache/ambari/assets/18082602/66c723ca-cbde-448c-856a-d089d3f4ba4b)


Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.