### PR TITLE
AMBARI-25977: Increase default value of phoenix.mutate.maxSizeBytes from 100 MB to 255 MB

### DIFF
--- a/ambari-server/src/main/resources/common-services/AMBARI_METRICS/3.0.0/configuration/ams-hbase-site.xml
+++ b/ambari-server/src/main/resources/common-services/AMBARI_METRICS/3.0.0/configuration/ams-hbase-site.xml
@@ -642,4 +642,16 @@
     </value-attributes>
     <on-ambari-upgrade add="true"/>
   </property>
+  <property>
+    <name>phoenix.mutate.maxSizeBytes</name>
+    <value>267386880</value>
+    <description>
+      Maximum amount of batch data size in bytes beyond which client requests are not accepted.
+    </description>
+    <value-attributes>
+      <type>int</type>
+      <unit>Bytes</unit>
+    </value-attributes>
+    <on-ambari-upgrade add="true"/>
+  </property>
 </configuration>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Change phoenix.mutate.maxSizeBytes value from 100 MB to 255 MB

## How was this patch tested?

Applied the fix in existing cluster, deleted and readded ambari metrics and verified the fix, attached snapshot in this PR jira.

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.