### PR TITLE
AMBARI-25981: zeppelin cannot download interpreter dependencies

### DIFF
--- a/ambari-server/src/main/resources/stacks/BIGTOP/3.2.0/services/ZEPPELIN/package/scripts/zeppelin_server.py
+++ b/ambari-server/src/main/resources/stacks/BIGTOP/3.2.0/services/ZEPPELIN/package/scripts/zeppelin_server.py
@@ -122,6 +122,7 @@ class ZeppelinServer(Script):
               group=params.zeppelin_group,
               cd_access="a",
               create_parents=True,
+              recursive_ownership=True,
               mode=0755
     )
     self.chown_zeppelin_pid_dir(env)


### PR DESCRIPTION
## What changes were proposed in this pull request?

fix zeppelin cannot download interpreter dependencies issue.
After zeppelin started, while configure zeppelin to access hive using jdbc interpreter, it report "Error setting properties for interpreter 'jdbc.jdbc': Cannot fetch dependencies for org.apache.hive:hive-jdbc:3.1.3".

Checkout the ownership of directory and found:
1. /usr/bigtop/3.2.0/usr/lib/zeppelin, this dir's owner is zeppelin:zeppelin
2. /usr/bigtop/3.2.0/usr/lib/zeppelin, the owner of subdirectories and files  is root:root
3. While the owner of zeppelin process is zeppelin.
4. Normally, zeppelin need to download interpreter dependencies to local-repo, and it's default location is /usr/bigtop/3.2.0/usr/lib/zeppelin/local-repo.
5. Due to the ownership, zeppelin cannot save these dependency files.

## How was this patch tested?

(Please explain how this patch was tested. Ex: unit tests, manual tests)
local manual test

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.