### PR TITLE
AMBARI-25977: Increase default value of phoenix.mutate.maxSizeBytes from 100 MB to 255 MB

### DIFF
--- a/ambari-server/src/main/resources/common-services/AMBARI_METRICS/0.1.0/configuration/ams-hbase-site.xml
+++ b/ambari-server/src/main/resources/common-services/AMBARI_METRICS/0.1.0/configuration/ams-hbase-site.xml
@@ -630,4 +630,28 @@
     </depends-on>
     <on-ambari-upgrade add="true"/>
   </property>
+  <property>
+    <name>hbase.rpc.rows.warning.threshold</name>
+    <value>10000</value>
+    <description>
+      Number of rows in a batch operation above which a warning will be logged in hbase.
+    </description>
+    <value-attributes>
+      <type>int</type>
+      <unit>rows</unit>
+    </value-attributes>
+    <on-ambari-upgrade add="true"/>
+  </property>
+  <property>
+    <name>phoenix.mutate.maxSizeBytes</name>
+    <value>267386880</value>
+    <description>
+      Maximum amount of batch data size in bytes beyond which client requests are not accepted.
+    </description>
+    <value-attributes>
+      <type>int</type>
+      <unit>Bytes</unit>
+    </value-attributes>
+    <on-ambari-upgrade add="true"/>
+  </property>
 </configuration>


### PR DESCRIPTION
## What changes were proposed in this pull request?

(Please fill in changes proposed in this fix)

## How was this patch tested?

(Please explain how this patch was tested. Ex: unit tests, manual tests)
(If this patch involves UI changes, please attach a screen-shot; otherwise, remove this)

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.