### PR TITLE
AMBARI-25980 Hbase Summary Page make links inactive for inactive servers

### DIFF
--- a/ambari-web/app/templates/main/service/info/summary.hbs
+++ b/ambari-web/app/templates/main/service/info/summary.hbs
@@ -96,9 +96,9 @@
                       </h5>
                     {{/if}}
                     {{#each quickLinks in group.links}}
-                      <h6>{{quickLinks.publicHostNameLabel}}</h6>
+                      <h6 {{bindAttr class="quickLinks.activeClass"}}>{{quickLinks.publicHostNameLabel}}</h6>
                       {{#each quickLinks}}
-                        <a {{bindAttr href="url"}} target="_blank" rel="noopener noreferrer">{{label}}</a>
+                        <a {{bindAttr href="url" disabled="quickLinks.serverComponentStopped"}} target="_blank" rel="noopener noreferrer">{{label}}</a>
                       {{/each}}
                     {{/each}}
                   </div>


### PR DESCRIPTION
## What changes were proposed in this pull request?

In Hbase Summary Page, for inactive servers quick links are now disabled.

## How was this patch tested?
Tried starting and stopping the servers, corresponding links behaved as expected

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.