### PR TITLE
AMBARI-25986: Upgrade Ambari hadoop dependency version

### DIFF
--- a/ambari-server/pom.xml
+++ b/ambari-server/pom.xml
@@ -48,7 +48,7 @@
     <stackHooksLocation>src/main/resources/stack-hooks</stackHooksLocation>
     <stacksSrcLocation>src/main/resources/stacks/${stack.distribution}</stacksSrcLocation>
     <tarballResourcesFolder>src/main/resources</tarballResourcesFolder>
-    <hadoop.version>2.7.2</hadoop.version>
+    <hadoop.version>3.3.4</hadoop.version>
     <ambari.metrics.version>2.7.0.0.0</ambari.metrics.version>
     <empty.dir>src/main/package</empty.dir> <!-- any directory in project with not very big amount of files (not to waste-load them) -->
     <el.log>ALL</el.log> <!-- log level for EclipseLink eclipselink-staticweave-maven-plugin -->

--- a/contrib/management-packs/pom.xml
+++ b/contrib/management-packs/pom.xml
@@ -30,7 +30,7 @@
   <properties>
     <ambari.version>${revision}</ambari.version>
     <ambari.dir>${project.parent.parent.basedir}</ambari.dir>
-    <hadoop.version>2.7.1</hadoop.version>
+    <hadoop.version>3.3.4</hadoop.version>
   </properties>
   <modules>
     <module>microsoft-r_mpack</module>

--- a/contrib/views/pom.xml
+++ b/contrib/views/pom.xml
@@ -30,7 +30,7 @@
   <properties>
     <ambari.version>${revision}</ambari.version>
     <ambari.dir>${project.parent.parent.basedir}</ambari.dir>
-    <hadoop.version>3.1.0</hadoop.version>
+    <hadoop.version>3.3.4</hadoop.version>
     <views.jars.dir>views-jars</views.jars.dir>
     <views.jars.dir.rel>../target/${views.jars.dir}</views.jars.dir.rel>
   </properties>

--- a/contrib/views/utils/pom.xml
+++ b/contrib/views/utils/pom.xml
@@ -176,6 +176,11 @@
       <version>2.4</version>
     </dependency>
     <dependency>
+      <groupId>commons-lang</groupId>
+      <artifactId>commons-lang</artifactId>
+      <version>2.6</version>
+    </dependency>
+    <dependency>
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-azure</artifactId>
       <version>${hadoop.version}</version>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Due to Ambari 2.8's Bigtop stack, the default version of Hadoop is 3.3.4. Starting from Hadoop 3.3, Jetty was upgraded to version 9.4.
https://issues.apache.org/jira/browse/HADOOP-16152
However, certain parts of Ambari still retain Hadoop versions lower than 3.3, which use Jetty versions below 9.4. This leads to an API incompatibility issue, causing failures in Ambari's contributed tests that utilize the HDFS MiniCluster due to conflicting Jetty versions.

Furthermore, the version of Hadoop should also align with the current default stack's Hadoop version to ensure consistency.
and the files View within the ambari/contrib/views/ relies on the version of Hadoop to communicate with HDFS. Using version 2 of Hadoop could lead to compatibility issues.

The reason for adding the dependency on 'common-lang2' is that after upgrading the Hadoop version to 3, the code no longer has the dependency on 'org.apache.commons.lang.StringUtils' present in Hadoop 2. This is because Hadoop 3 uses Commons Lang 3.x. Without this dependency, the code compilation will fail. Therefore, adding this dependency resolves the issue.

![image](https://github.com/apache/ambari/assets/18082602/c6e1dbb3-06be-46e0-8c86-90956f4f3962)

## How was this patch tested?
manual test
![image](https://github.com/apache/ambari/assets/18082602/8ca139c7-7b16-48e4-a0fe-dac50c5b8cf7)

(Please explain how this patch was tested. Ex: unit tests, manual tests)
(If this patch involves UI changes, please attach a screen-shot; otherwise, remove this)

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.