### PR TITLE
AMBARI-25987: Add hadoop native libraries support for better performance (spark)

### DIFF
--- a/ambari-server/src/main/resources/stacks/BIGTOP/3.2.0/services/SPARK/configuration/spark-env.xml
+++ b/ambari-server/src/main/resources/stacks/BIGTOP/3.2.0/services/SPARK/configuration/spark-env.xml
@@ -148,6 +148,9 @@ export SPARK_DIST_CLASSPATH=$(${HADOOP_HOME}/bin/hadoop classpath)
 # The java implementation to use.
 export JAVA_HOME={{java_home}}
 
+# Add hadoop native libraries support for better performance
+export LD_LIBRARY_PATH=$HADOOP_HOME/lib/native/:$LD_LIBRARY_PATH
+
 </value>
     <value-attributes>
       <type>content</type>


### PR DESCRIPTION
## What changes were proposed in this pull request?

(Please fill in changes proposed in this fix)
Jira: AMBARI-25987
Currently, when run spark tasks, spark will report cannot load hadoop native libraries.

Also, the hadoop short-circuit read feature cannot be applied. For better performance, add hadoop native libraries support.

## How was this patch tested?

After this fix, re-run the same spark-example, no WARN report any more.

(Please explain how this patch was tested. Ex: unit tests, manual tests)
(If this patch involves UI changes, please attach a screen-shot; otherwise, remove this)

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.