### PR TITLE
AMBARI-25988: Fix outdated ember-collection dependency

### DIFF
--- a/contrib/views/files/src/main/resources/ui/package.json
+++ b/contrib/views/files/src/main/resources/ui/package.json
@@ -40,7 +40,7 @@
     "ember-cli-sri": "^2.0.0",
     "ember-cli-uglify": "^1.2.0",
     "ember-cli-clipboard": "^0.3.1",
-    "ember-collection": "git://github.com/emberjs/ember-collection.git#bf752508a501161791e3f3b9a546c9b97d5c387a",
+    "ember-collection": "git+https://github.com/adopted-ember-addons/ember-collection.git#bf752508a501161791e3f3b9a546c9b97d5c387a",
     "ember-data": "2.3.0",
     "ember-disable-proxy-controllers": "^1.0.1",
     "ember-export-application-global": "^1.0.4",


### PR DESCRIPTION
## What changes were proposed in this pull request?

In the contrib/views module, specifically within the views subdirectory, there is a dependency on the outdated ember-collection in the frontend code. This is causing the files view to fail during compilation.
![image](https://github.com/apache/ambari/assets/18082602/e7ee75b3-98f5-40f2-821e-ac51b21b9599)

This issue is occurring because the repository git://github.com/emberjs/ember-collection.git has been moved or relocated.

The problem can be resolved by updating the following file: contrib/views/files/src/main/resources/ui/package.json

## How was this patch tested?
manual test
Once this fix is applied, successful compilation should be achieved.
![image](https://github.com/apache/ambari/assets/18082602/c26c47f1-ffab-4b14-88dd-a7f305139d40)


(Please explain how this patch was tested. Ex: unit tests, manual tests)
(If this patch involves UI changes, please attach a screen-shot; otherwise, remove this)

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.