### PR TITLE
AMBARI-25989: Remove not supported modules from views

### DIFF
--- a/contrib/views/pom.xml
+++ b/contrib/views/pom.xml
@@ -38,9 +38,9 @@
     <module>utils</module>
     <module>commons</module>
     <module>files</module>
-    <module>pig</module>
+<!--    <module>pig</module>-->
     <module>capacity-scheduler</module>
-    <module>wfmanager</module>
+<!--    <module>wfmanager</module>-->
     <!--ambari-views-package should be last in the module list for it to function properly-->
     <module>ambari-views-package</module>
   </modules>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Comment out the deprecated pig and wfmanager modules, as these two modules are not supported by stacks after Ambari 2.8. Additionally, this also impacts the compilation of Ambari views.

Other than this PR, there are two more PRs.

1. AMBARI-25988: Correcting outdated ember-collection dependency
   Link: [https://github.com/apache/ambari/pull/3741](https://github.com/apache/ambari/pull/3741)

2. AMBARI-25986: Updating Ambari's Hadoop dependency version #3739
   Link: [https://github.com/apache/ambari/pull/3739](https://github.com/apache/ambari/pull/3739)

These two PRs are interrelated. Once all three PRs are merged, the Ambari view will be functional.
## How was this patch tested?
manual test
![image](https://github.com/apache/ambari/assets/18082602/e3f4a517-4540-43f2-9670-3ef2fa764beb)

ambari Files View for HDFS
![image](https://github.com/apache/ambari/assets/18082602/91a6e1dc-9d4b-4404-8a10-79f43a4801cf)


ambari capacityScheduler View
![image](https://github.com/apache/ambari/assets/18082602/e8c3d04c-26b8-469a-8758-83f32c875a05)

(Please explain how this patch was tested. Ex: unit tests, manual tests)
(If this patch involves UI changes, please attach a screen-shot; otherwise, remove this)

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.