### PR TITLE
AMBARI-25997: Improvement and Bug Fix in ambari_server.properties.py

### DIFF
--- a/ambari-server/src/main/python/ambari_server/properties.py
+++ b/ambari-server/src/main/python/ambari_server/properties.py
@@ -171,6 +171,11 @@ class Properties(object):
     except KeyError:
       if hasattr(self._props, name):
         return getattr(self._props, name)
+      else:
+        raise NotImplementedError("The method '{}' is not implemented.".format(name))
+
+  def __contains__(self, key):
+    return  key in self._props
 
   def sort_props(self):
     tmp_props = {}

--- a/ambari-server/src/main/python/ambari_server/serverSetup.py
+++ b/ambari-server/src/main/python/ambari_server/serverSetup.py
@@ -411,8 +411,6 @@ class JDKSetup(object):
   # Downloads and installs the JDK and the JCE policy archive
   #
   def download_and_install_jdk(self, args, properties, ambariOnly = False):
-    conf_file = properties.fileName
-
     jcePolicyWarn = "JCE Policy files are required for configuring Kerberos security. If you plan to use Kerberos," \
                     "please make sure JCE Unlimited Strength Jurisdiction Policy Files are valid on all hosts."
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

File Location: ambari-server/src/main/python/ambari_server/properties.py

Problem Description:
1. The `_getattr_` method is used for dynamic proxying of methods. In the case where `hasattr(self._props, name)` is false indicating the corresponding method or attribute cannot be found, an exception needs to be thrown. If not, it may confuse the user and obstruct code debugging.

2. The class `Properties` proxies the `has_key` method to the `dict` object through `_getattr`, which is acceptable: `Properties().has_key("x")`. However, for the operation `"x" in Properties()`, it ends up in an infinite hang, never returning. Therefore, a `contains_` method needs to be implemented to keep consistency with the logic of `has_key`, i.e., to determine whether the object is in `_props`:

```python
def _contains_(self, key):
   return key in self._props
```
This modification prevents the infinite hang problem from occurring. 

To reproduce the hang issue, we can make a simplified version of the `Properties` class for testing, as follows:

```python
#!/usr/bin/env python

import os
import re
import time

class Properties(object):
   def _init_(self, props=None):
       self._props = {}
       self._origprops = {}
       self._keymap = {}

   def get_property(self, key):
       return self._props.get(key, '')

   def propertyNames(self):
       return self._props.keys()

   def getPropertyDict(self):
       return self._props

   def _getitem_(self, name):
       return self.get_property(name)

   def _getattr_(self, name):
       try:
           return self._dict_[name]
       except KeyError:
           if hasattr(self._props, name):
               return getattr(self._props, name)
           else:
               raise NotImplementedError("The method '{}' is not implemented.".format(name))

   def _contains_(self, key):
       return  key in self._props

if _name_ == "_main_":
   p = Properties()
   "a" in p
```
Upon running this program with either Python 3 or Python 2 python, it will indefinitely hang, never returning.  

## How was this patch tested?
manual test
unit test
(Please explain how this patch was tested. Ex: unit tests, manual tests)
(If this patch involves UI changes, please attach a screen-shot; otherwise, remove this)

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.