### PR TITLE
AMBARI-25998: Host uuid is not getting synced to other collectors, causing NPE while accessing metric

### DIFF
--- a/ambari-metrics/ambari-metrics-timelineservice/src/main/java/org/apache/ambari/metrics/core/timeline/discovery/TimelineMetricMetadataManager.java
+++ b/ambari-metrics/ambari-metrics-timelineservice/src/main/java/org/apache/ambari/metrics/core/timeline/discovery/TimelineMetricMetadataManager.java
@@ -433,6 +433,17 @@ public class TimelineMetricMetadataManager {
   }
 
   /**
+   * Add host with uuid into uuidHostMap
+   *
+   * @param hostName       host name
+   * @param tmHostMetadata TimelineMetricHostMetadata
+   */
+  public void addHostInUuidHostMap(String hostName, TimelineMetricHostMetadata tmHostMetadata) {
+    TimelineMetricUuid timelineMetricUuid = new TimelineMetricUuid(tmHostMetadata.getUuid());
+    uuidHostMap.put(timelineMetricUuid, hostName);
+  }
+
+  /**
    * Returns the UUID gen strategy.
    * @param configuration the config
    * @return the UUID generator of type org.apache.ambari.metrics.core.timeline.uuid.MetricUuidGenStrategy

--- a/ambari-metrics/ambari-metrics-timelineservice/src/main/java/org/apache/ambari/metrics/core/timeline/discovery/TimelineMetricMetadataSync.java
+++ b/ambari-metrics/ambari-metrics-timelineservice/src/main/java/org/apache/ambari/metrics/core/timeline/discovery/TimelineMetricMetadataSync.java
@@ -201,8 +201,12 @@ public class TimelineMetricMetadataSync implements Runnable {
       Map<String, TimelineMetricHostMetadata> cachedData = cacheManager.getHostedAppsCache();
 
       for (Map.Entry<String, TimelineMetricHostMetadata> storeEntry : hostedAppsDataFromStore.entrySet()) {
-        if (!cachedData.containsKey(storeEntry.getKey()) ||
-                !cachedData.get(storeEntry.getKey()).getHostedApps().keySet().containsAll(storeEntry.getValue().getHostedApps().keySet())) {
+        if (!cachedData.containsKey(storeEntry.getKey())) {
+          // New host is being synced
+          cacheManager.addHostInUuidHostMap(storeEntry.getKey(), storeEntry.getValue());
+          cachedData.put(storeEntry.getKey(), storeEntry.getValue());
+        } else if (!cachedData.get(storeEntry.getKey()).getHostedApps().keySet().containsAll(storeEntry.getValue().getHostedApps().keySet())) {
+          // host apps are being synced
           cachedData.put(storeEntry.getKey(), storeEntry.getValue());
         }
       }


### PR DESCRIPTION
## What changes were proposed in this pull request?

When new host is synced from other collector, cache host uuid also

## How was this patch tested?

Written UT to test this functionality. Before change UT is failing, after fix UT is passing.

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.