### PR TITLE
AMBARI-26030: Implement Handling for DB Records Purge with Cluster ID -1

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/cleanup/TimeBasedCleanupPolicy.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/cleanup/TimeBasedCleanupPolicy.java
@@ -23,6 +23,7 @@ package org.apache.ambari.server.cleanup;
 public class TimeBasedCleanupPolicy {
 
   private String clusterName;
+  private boolean cleanCommonInfo;
   private Long toDateInMillis;
 
   /**
@@ -31,9 +32,14 @@ public class TimeBasedCleanupPolicy {
    * @param clusterName      the cluster name
    * @param toDateInMillis timestamp before that entities are purged.
    */
-  public TimeBasedCleanupPolicy(String clusterName, Long toDateInMillis) {
+  public TimeBasedCleanupPolicy(String clusterName, Long toDateInMillis, boolean cleanCommonInfo) {
     this.clusterName = clusterName;
+    this.cleanCommonInfo = cleanCommonInfo;
     this.toDateInMillis = toDateInMillis;
+  }
+
+  public TimeBasedCleanupPolicy(String clusterName, Long toDateInMillis) {
+    this(clusterName, toDateInMillis, false); // Set a default value for cleanCommonInfo
   }
 
   /**
@@ -41,6 +47,10 @@ public class TimeBasedCleanupPolicy {
    */
   public String getClusterName() {
     return clusterName;
+  }
+
+  public boolean getcleanCommonInfo() {
+    return cleanCommonInfo;
   }
 
   /**

--- a/ambari-server/src/main/python/ambari-server.py
+++ b/ambari-server/src/main/python/ambari-server.py
@@ -674,6 +674,7 @@ def init_enable_stack_parser_options(parser):
 @OsFamilyFuncImpl(OsFamilyImpl.DEFAULT)
 def init_db_purge_parser_options(parser):
   parser.add_option('--cluster-name', default=None, help="Cluster name", dest="cluster_name")
+  parser.add_option('--purge-common-info', default="false", type="string", help="Want to purge records for cluster_id = -1",dest="clean_common_info")
   parser.add_option("-d", "--from-date", dest="purge_from_date", default=None, type="string", help="Specify date for the database purge process in 'yyyy-MM-dd' format")
 
 @OsFamilyFuncImpl(OsFamilyImpl.DEFAULT)

--- a/ambari-server/src/main/python/ambari_server/dbCleanup.py
+++ b/ambari-server/src/main/python/ambari_server/dbCleanup.py
@@ -40,12 +40,14 @@ DEBUG_SUSPEND_AT_START = "n"
 DB_CLEANUP_CMD = "{0} " \
                  "-cp {1} org.apache.ambari.server.cleanup.CleanupDriver " \
                  "--cluster-name {2} " \
-                 "--from-date {3}> " + configDefaults.SERVER_OUT_FILE + " 2>&1"
+                 "--purge-common-info {3} " \
+                 "--from-date {4}> " + configDefaults.SERVER_OUT_FILE + " 2>&1"
 
-DB_DEBUG_CLEANUP_CMD = "{0} -agentlib:jdwp=transport=dt_socket,server=y,suspend={4},address={5} " \
+DB_DEBUG_CLEANUP_CMD = "{0} -agentlib:jdwp=transport=dt_socket,server=y,suspend={5},address={6} " \
                        "-cp {1} org.apache.ambari.server.cleanup.CleanupDriver " \
                        "--cluster-name {2} " \
-                       "--from-date {3}> " + configDefaults.SERVER_OUT_FILE + " 2>&1"
+                       "--purge-common-info {3} " \
+                       "--from-date {4}> " + configDefaults.SERVER_OUT_FILE + " 2>&1"
 
 
 def run_db_purge(options):
@@ -98,6 +100,7 @@ def run_db_purge(options):
       jdk_path,
       class_path,
       options.cluster_name,
+      options.clean_common_info,
       options.purge_from_date,
       DEBUG_SUSPEND_AT_START,
       DEBUG_PORT
@@ -107,6 +110,7 @@ def run_db_purge(options):
       jdk_path,
       class_path,
       options.cluster_name,
+      options.clean_common_info,
       options.purge_from_date
     )
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Adding a New feature extending the ambari db purge command to purge the DB records with cluster id -1

## How was this patch tested?
### Tested by removing the DB records having cluster id -1 below are the result for same

Modified command to run DB purge

<img width="1416" alt="command_png" src="https://github.com/apache/ambari/assets/138098620/a469df81-a711-4df7-b1a5-37c29d33fe35">



Verifying on DB shell

<img width="1381" alt="terminal_png" src="https://github.com/apache/ambari/assets/138098620/35a115cb-8bb4-4833-9039-8c66262b705f">



