### PR TITLE
AMBARI-26103: Remove google analytics, as per ASF Privacy Policy.

### DIFF
--- a/docs/src/site/site.xml
+++ b/docs/src/site/site.xml
@@ -44,23 +44,6 @@
 
   <body>
     <head>
-       <!-- Start of Google analytics -->
-       <script type="text/javascript">
-         var _gaq = _gaq || [];
-         _gaq.push(['_setAccount', 'UA-27188762-1']);
-         _gaq.push(['_trackPageview']);
-
-         (function() {
-            var ga = document.createElement('script'); 
-            ga.type = 'text/javascript'; ga.async = true;
-            ga.src = ('https:' == document.location.protocol ? 
-                      'https://ssl' : 'http://www') + 
-                     '.google-analytics.com/ga.js';
-            var s = document.getElementsByTagName('script')[0]; 
-            s.parentNode.insertBefore(ga, s);
-          })();
-       </script>
-       <!-- End of Google analytics -->
        <style>
            .well.sidebar-nav {
              background-color: #fff;


### PR DESCRIPTION
This PR removes Google Analytics from the docs site template. This is in order to bring the site into compliance with ASF privacy policy - https://privacy.apache.org/policies/website-policy.html

Note that if you still want/need analytics, you can use Matamo - details at https://privacy.apache.org/matomo/