### PR TITLE
AMBARI-26049: Fix type error in ambari port alert

### DIFF
--- a/ambari-agent/src/main/python/ambari_agent/alerts/port_alert.py
+++ b/ambari-agent/src/main/python/ambari_agent/alerts/port_alert.py
@@ -154,8 +154,8 @@ class PortAlert(BaseAlert):
         start_time = time.time()
         s.connect((host, port))
         if self.socket_command is not None:
-          s.sendall(self.socket_command)
-          data = s.recv(1024)
+          s.sendall(self.socket_command.encode())
+          data = s.recv(1024).decode()
           if self.socket_command_response is not None and data != self.socket_command_response:
             raise Exception("Expected response {0}, Actual response {1}".format(
               self.socket_command_response, data))


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR addresses a bug that was introduced after upgrading from Python 2 to Python 3. The original code was using byte strings for socket communication, which is the default string type in Python 2. However, in Python 3, strings are Unicode by default and need to be explicitly encoded to byte strings before being sent over a socket. Similarly, received data must be decoded back into a Unicode string. The changes in this PR ensure that the socket_command is properly encoded before sending and the received data is decoded back into a string for further processing. This fix restores proper socket communication functionality under Python 3.


(Please fill in changes proposed in this fix)

## How was this patch tested?
unit test
manual test

(Please explain how this patch was tested. Ex: unit tests, manual tests)
(If this patch involves UI changes, please attach a screen-shot; otherwise, remove this)

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.