### PR TITLE
AMBARI-26061 : Add password validation criteria for ambari local users

### DIFF
--- a/ambari-server/docs/configuration/index.md
+++ b/ambari-server/docs/configuration/index.md
@@ -168,7 +168,7 @@ The following are the properties which can be used to configure Ambari.
 | security.master.keystore.location | The location on the Ambari Server of the master keystore file. | | 
 | security.passwords.encryption.enabled | Whether security password encryption is enabled or not. In case it is we store passwords in their own file(s); otherwise we store passwords in the Ambari credential store. |`false` | 
 | security.server.cert_chain_name | The name of the file located in the `security.server.keys_dir` directory containing the CA certificate chain used to verify certificates during 2-way SSL communications. |`ca_chain.pem` | 
-| security.password.policy.history.count | Password policy to mandate that new password should be different from previous passwords, this would be based on the history count configured by the user. | `1` |
+| security.password.policy.history.count | Password policy to mandate that new password should be different from previous passwords, this would be based on the history count configured by the user. Valid values are 1 to 10. | `1` |
 | security.server.cert_name | The name of the file located in the `security.server.keys_dir` directory where certificates will be generated when Ambari uses the `openssl ca` command. |`ca.crt` | 
 | security.server.crt_pass | The password for the keystores, truststores, and certificates. If not specified, then `security.server.crt_pass_file` should be used | | 
 | security.server.crt_pass.len | The length of the randomly generated password for keystores and truststores.  |`50` | 

--- a/ambari-server/docs/configuration/index.md
+++ b/ambari-server/docs/configuration/index.md
@@ -168,6 +168,7 @@ The following are the properties which can be used to configure Ambari.
 | security.master.keystore.location | The location on the Ambari Server of the master keystore file. | | 
 | security.passwords.encryption.enabled | Whether security password encryption is enabled or not. In case it is we store passwords in their own file(s); otherwise we store passwords in the Ambari credential store. |`false` | 
 | security.server.cert_chain_name | The name of the file located in the `security.server.keys_dir` directory containing the CA certificate chain used to verify certificates during 2-way SSL communications. |`ca_chain.pem` | 
+| security.password.policy.history.count | Password policy to mandate that new password should be different from previous passwords, this would be based on the history count configured by the user. | `1` |
 | security.server.cert_name | The name of the file located in the `security.server.keys_dir` directory where certificates will be generated when Ambari uses the `openssl ca` command. |`ca.crt` | 
 | security.server.crt_pass | The password for the keystores, truststores, and certificates. If not specified, then `security.server.crt_pass_file` should be used | | 
 | security.server.crt_pass.len | The length of the randomly generated password for keystores and truststores.  |`50` | 

--- a/ambari-server/src/main/java/org/apache/ambari/server/configuration/Configuration.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/configuration/Configuration.java
@@ -325,6 +325,16 @@ public class Configuration {
   // Ambari server log4j file name
   public static final String AMBARI_LOG_FILE = "log4j.properties";
 
+  /**
+   * The maximum value of password history count which can be configured by the user.
+   */
+  public static final int MAXIMUM_PASSWORD_HISTORY_LIMIT = 10;
+
+  /**
+   * The default and minimum value of password history count which can be configured by the user.
+   */
+  public static final int MINIMUM_PASSWORD_HISTORY_LIMIT = 1;
+
   @Markdown(
           description = "Interval for heartbeat presence checks.",
           examples = {"60000","600000"} )
@@ -534,7 +544,7 @@ public class Configuration {
    * Password history count to validate how many previous passwords should be checked before updating user password.
    */
   @Markdown(
-          description = "Password policy to mandate that new password should be different from previous passwords, this would be based on the history count configured by the user.")
+          description = "Password policy to mandate that new password should be different from previous passwords, this would be based on the history count configured by the user. Valid values are 1 to 10.")
   public static final ConfigurationProperty<String> PASSWORD_POLICY_HISTORY_COUNT = new ConfigurationProperty<>(
           "security.password.policy.history.count", "1");
 
@@ -4150,7 +4160,16 @@ public class Configuration {
    * @return Password policy history count
    */
   public int getPasswordPolicyHistoryCount() {
-    return Integer.parseInt(getProperty(PASSWORD_POLICY_HISTORY_COUNT));
+    int historyCount = Integer.parseInt(getProperty(PASSWORD_POLICY_HISTORY_COUNT));
+    if(historyCount < MINIMUM_PASSWORD_HISTORY_LIMIT){
+      historyCount = MINIMUM_PASSWORD_HISTORY_LIMIT;
+      LOG.debug("Invalid password history count detected. The count has been automatically set to the minimum permissible value of {}.",MINIMUM_PASSWORD_HISTORY_LIMIT);
+    }
+    if(historyCount > MAXIMUM_PASSWORD_HISTORY_LIMIT){
+      historyCount = MAXIMUM_PASSWORD_HISTORY_LIMIT;
+      LOG.debug("Invalid password history count detected. The count has been automatically set to the maximum permissible value of {}.",MAXIMUM_PASSWORD_HISTORY_LIMIT);
+    }
+    return historyCount;
   }
 
   public JPATableGenerationStrategy getJPATableGenerationStrategy() {

--- a/ambari-server/src/main/java/org/apache/ambari/server/configuration/Configuration.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/configuration/Configuration.java
@@ -531,6 +531,14 @@ public class Configuration {
       "security.password.policy.description", "");
 
   /**
+   * Password history count to validate how many previous passwords should be checked before updating user password.
+   */
+  @Markdown(
+          description = "Password policy to mandate that new password should be different from previous passwords, this would be based on the history count configured by the user.")
+  public static final ConfigurationProperty<String> PASSWORD_POLICY_HISTORY_COUNT = new ConfigurationProperty<>(
+          "security.password.policy.history.count", "1");
+
+  /**
    * Determines whether the Ambari Agent host names should be validated against
    * a regular expression to ensure that they are well-formed.
    */
@@ -4136,6 +4144,13 @@ public class Configuration {
    */
   public String getPasswordPolicyDescription() {
     return getProperty(PASSWORD_POLICY_DESCRIPTION);
+  }
+
+  /**
+   * @return Password policy history count
+   */
+  public int getPasswordPolicyHistoryCount() {
+    return Integer.parseInt(getProperty(PASSWORD_POLICY_HISTORY_COUNT));
   }
 
   public JPATableGenerationStrategy getJPATableGenerationStrategy() {

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/UserResourceProvider.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/UserResourceProvider.java
@@ -384,7 +384,7 @@ public class UserResourceProvider extends AbstractControllerResourceProvider imp
       // Setting a user's the password here is to allow for backward compatibility with pre-Ambari-3.0
       // versions so that the contract for REST API V1 is maintained.
       if (!StringUtils.isEmpty(password)) {
-        users.validatePassword(password);
+        users.validatePassword(password, username);
       }
 
       UserEntity userEntity = users.createUser(username, localUserName, displayName, request.isActive());

--- a/ambari-server/src/main/java/org/apache/ambari/server/orm/entities/UserAuthenticationEntity.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/orm/entities/UserAuthenticationEntity.java
@@ -17,6 +17,10 @@
  */
 package org.apache.ambari.server.orm.entities;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
 import javax.persistence.Basic;
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -117,18 +121,18 @@ public class UserAuthenticationEntity {
   }
 
   public void updateAuthenticationKey(String newAuthenticationKey, int historyCount) {
-    int currentCount = this.authenticationKey.split(",").length;
-    while(currentCount >= historyCount){
-      int lastCommaIndex = this.authenticationKey.lastIndexOf(",");
-      if(lastCommaIndex == -1){
-        this.authenticationKey = "";
-      } else {
-        this.authenticationKey = this.authenticationKey.substring(0, lastCommaIndex);
-      }
-      currentCount--;
+    if (this.authenticationKey == null || this.authenticationKey.isEmpty()) {
+        this.authenticationKey = newAuthenticationKey;
+    } else {
+        String[] keys = this.authenticationKey.split(",");
+        List<String> keyList = new ArrayList<>(Arrays.asList(keys));
+        if (keyList.size() >= historyCount) {
+            keyList = keyList.subList(0, historyCount - 1);
+        }
+        keyList.add(0, newAuthenticationKey);
+        this.authenticationKey = String.join(",", keyList);
     }
-    this.authenticationKey = newAuthenticationKey + "," + this.authenticationKey;
-  }
+}
 
   public long getCreateTime() {
     return createTime;

--- a/ambari-server/src/main/java/org/apache/ambari/server/orm/entities/UserAuthenticationEntity.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/orm/entities/UserAuthenticationEntity.java
@@ -101,11 +101,33 @@ public class UserAuthenticationEntity {
   }
 
   public String getAuthenticationKey() {
+    int firstCommaIndex = authenticationKey.indexOf(",");
+    if (firstCommaIndex != -1) {
+      return authenticationKey.substring(0, firstCommaIndex);
+    }
+    return authenticationKey;
+  }
+
+  public String getFullAuthenticationKey() {
     return authenticationKey;
   }
 
   public void setAuthenticationKey(String authenticationKey) {
     this.authenticationKey = authenticationKey;
+  }
+
+  public void updateAuthenticationKey(String newAuthenticationKey, int historyCount) {
+    int currentCount = this.authenticationKey.split(",").length;
+    while(currentCount >= historyCount){
+      int lastCommaIndex = this.authenticationKey.lastIndexOf(",");
+      if(lastCommaIndex == -1){
+        this.authenticationKey = "";
+      } else {
+        this.authenticationKey = this.authenticationKey.substring(0, lastCommaIndex);
+      }
+      currentCount--;
+    }
+    this.authenticationKey = newAuthenticationKey + "," + this.authenticationKey;
   }
 
   public long getCreateTime() {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add password validation criteria for ambari local users

1. Password should not contain the user name
2. Password should not be same as previous n passwords

## How was this patch tested?

1. Installed Ambari
2. Validated the password updation for admin user (covered both the password with the username and password matching previous passwords)
3. Created another local user and similarly validated for that user
4. Added the UTs also

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.