### PR TITLE
AMBARI-26068: Fix python3 type error on trunk reader and  collections…

### DIFF
--- a/ambari-agent/src/main/python/ambari_agent/Utils.py
+++ b/ambari-agent/src/main/python/ambari_agent/Utils.py
@@ -111,8 +111,8 @@ class Utils(object):
     Update the dictionary 'd' and its sub-dictionaries with values of dictionary 'u' and its sub-dictionaries.
     """
     for k, v in u.items():
-      if isinstance(d, collections.Mapping):
-        if isinstance(v, collections.Mapping):
+      if isinstance(d, collections.abc.Mapping):
+        if isinstance(v, collections.abc.Mapping):
           r = Utils.update_nested(d.get(k, {}), v)
           d[k] = r
         else:

--- a/ambari-common/src/main/python/ambari_commons/shell.py
+++ b/ambari-common/src/main/python/ambari_commons/shell.py
@@ -325,7 +325,7 @@ def chunks_reader(cmd, kill_timer):
 
     if not data_chunk:
       break
-    str_buffer += data_chunk
+    str_buffer += data_chunk.decode()
 
     if os.linesep in str_buffer:
       copy_offset = str_buffer.rindex(os.linesep)


### PR DESCRIPTION
….Mapping

## What changes were proposed in this pull request?
During the adaptation process of Ambari for Ubuntu 22, encountered a type error with Ambari trunk reader while installing deb pkg and  collections.Mapping error


1.in Python 3, collections.Mapping has been moved. The correct import path is now collections.abc.Mapping. 
2.Because all subprocess child processes have universal_newlines=True, all outputs are strings. However, os.read returns bytes, so str_buffer += data_chunk will result in an error.

## How was this patch tested?

(Please explain how this patch was tested. Ex: unit tests, manual tests)
(If this patch involves UI changes, please attach a screen-shot; otherwise, remove this)

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.