### PR TITLE
AMBARI-26070: Ambari throws SyntaxWarnings after moving to Python3

### DIFF
--- a/ambari-agent/src/main/python/ambari_agent/HostCleanup.py
+++ b/ambari-agent/src/main/python/ambari_agent/HostCleanup.py
@@ -617,7 +617,7 @@ def get_choice_string_input(prompt, default, firstChoice, secondChoice):
     return True
   elif choice in secondChoice:
     return False
-  elif choice is "": # Just enter pressed
+  elif choice == "": # Just enter pressed
     return default
   else:
     print("input not recognized, please try again: ")

--- a/ambari-common/src/main/python/resource_management/libraries/functions/component_version.py
+++ b/ambari-common/src/main/python/resource_management/libraries/functions/component_version.py
@@ -64,7 +64,7 @@ def _get_component_repositories(config):
   :config:  the configuration dictionary
   :return:
   """
-  if "componentVersionMap" not in config or config["componentVersionMap"] is "":
+  if "componentVersionMap" not in config or config["componentVersionMap"] == "":
     return None
 
   return config["componentVersionMap"]

--- a/ambari-server/src/main/python/ambari-server.py
+++ b/ambari-server/src/main/python/ambari-server.py
@@ -731,13 +731,13 @@ def are_db_auth_options_ok(db_windows_auth, db_username, db_password):
   if db_windows_auth is True:
     return True
   else:
-    if db_username is not None and db_username is not "" and db_password is not None and db_password is not "":
+    if db_username is not None and db_username != "" and db_password is not None and db_password != "":
       return True
   return False
 
 @OsFamilyFuncImpl(OSConst.WINSRV_FAMILY)
 def are_cmd_line_db_args_valid(options):
-  if (options.database_host is not None and options.database_host is not "" \
+  if (options.database_host is not None and options.database_host != "" \
       #and options.database_name is not None \         # ambari by default is ok
       and are_db_auth_options_ok(options.database_windows_auth,
                                  options.database_username,

--- a/ambari-server/src/main/python/ambari_server/dbConfiguration.py
+++ b/ambari-server/src/main/python/ambari_server/dbConfiguration.py
@@ -239,20 +239,20 @@ class DBMSConfig(object):
   @staticmethod
   def _init_member_with_default(options, attr_name, default_val):
     options_val = getattr(options, attr_name, None)
-    val = options_val if options_val is not None and options_val is not "" else default_val
+    val = options_val if options_val is not None and options_val != "" else default_val
     return val
 
   @staticmethod
   def _init_member_with_properties(options, attr_name, properties, property_key):
     options_val = getattr(options, attr_name, None)
-    if options_val is None or options_val is "":
+    if options_val is None or options_val == "":
       options_val = get_value_from_properties(properties, property_key, None)
     return options_val
 
   @staticmethod
   def _init_member_with_prop_default(options, attr_name, properties, property_key, default_val):
     val = DBMSConfig._init_member_with_properties(options, attr_name, properties, property_key)
-    if val is None or val is "":
+    if val is None or val == "":
       val = default_val
     return val
 

--- a/ambari-server/src/main/python/ambari_server/dbConfiguration_windows.py
+++ b/ambari-server/src/main/python/ambari_server/dbConfiguration_windows.py
@@ -198,7 +198,7 @@ class MSSQLConfig(DBMSConfig):
 
     try:
       driver_path = properties[JDBC_DRIVER_PATH_PROPERTY]
-      if driver_path is None or driver_path is "":
+      if driver_path is None or driver_path == "":
         return 0
     except Exception:
       # No such attribute set
@@ -324,7 +324,7 @@ class MSSQLAmbariDBConfig(MSSQLConfig):
 
     super(MSSQLAmbariDBConfig, self).__init__(options, properties, storage_type)
 
-    if self.database_name is None or self.database_name is "":
+    if self.database_name is None or self.database_name == "":
       self.database_name = AMBARI_DATABASE_NAME
 
     self.persistence_property = PERSISTENCE_TYPE_PROPERTY

--- a/ambari-server/src/main/python/ambari_server/serverConfiguration.py
+++ b/ambari-server/src/main/python/ambari_server/serverConfiguration.py
@@ -1041,7 +1041,7 @@ def get_original_master_key(properties, options = None):
 
     # Decrypt alias with master to validate it, if no master return
     password = None
-    if alias and env_master_key and env_master_key is not "" and env_master_key != "None":
+    if alias and env_master_key and env_master_key != "" and env_master_key != "None":
       password = read_passwd_for_alias(alias, env_master_key, options)
     if not password:
       try:
@@ -1356,31 +1356,31 @@ class JDKRelease:
   inst_dir = ""
 
   def __init__(self, i_name, i_desc, i_url, i_dest_file, i_jcpol_url, i_dest_jcpol_file, i_inst_dir, i_reg_exp):
-    if i_name is None or i_name is "":
+    if i_name is None or i_name == "":
       raise FatalException(-1, "Invalid JDK name: " + (i_desc or ""))
     self.name = i_name
-    if i_desc is None or i_desc is "":
+    if i_desc is None or i_desc == "":
       self.desc = self.name
     else:
       self.desc = i_desc
-    if i_url is None or i_url is "":
+    if i_url is None or i_url == "":
       raise FatalException(-1, "Invalid URL for JDK " + i_name)
     self.url = i_url
-    if i_dest_file is None or i_dest_file is "":
+    if i_dest_file is None or i_dest_file == "":
       self.dest_file = i_name + ".exe"
     else:
       self.dest_file = i_dest_file
-    if not (i_jcpol_url is None or i_jcpol_url is ""):
+    if not (i_jcpol_url is None or i_jcpol_url == ""):
       self.jcpol_url = i_jcpol_url
-    if i_dest_jcpol_file is None or i_dest_jcpol_file is "":
+    if i_dest_jcpol_file is None or i_dest_jcpol_file == "":
       self.dest_jcpol_file = "jcpol-" + i_name + ".zip"
     else:
       self.dest_jcpol_file = i_dest_jcpol_file
-    if i_inst_dir is None or i_inst_dir is "":
+    if i_inst_dir is None or i_inst_dir == "":
       self.inst_dir = os.path.join(configDefaults.JDK_INSTALL_DIR, i_desc)
     else:
       self.inst_dir = i_inst_dir
-    if i_reg_exp is None or i_reg_exp is "":
+    if i_reg_exp is None or i_reg_exp == "":
       raise FatalException(-1, "Invalid output parsing regular expression for JDK " + i_name)
     self.reg_exp = i_reg_exp
 
@@ -1392,7 +1392,7 @@ class JDKRelease:
 
   @staticmethod
   def __load_properties(properties, section_name):
-    if section_name is None or section_name is "":
+    if section_name is None or section_name == "":
       raise FatalException(-1, "Invalid properties section: " + ("(empty)" if section_name is None else ""))
     if(properties.__contains__(section_name + ".desc")):   #Not critical
       desc = properties[section_name + ".desc"]

--- a/ambari-server/src/main/python/ambari_server/userInput.py
+++ b/ambari-server/src/main/python/ambari_server/userInput.py
@@ -58,7 +58,7 @@ def get_choice_string_input(prompt, default, firstChoice, secondChoice, answer =
     elif choice in secondChoice:
       result = False
       inputBool = False
-    elif choice is "":  # Just enter pressed
+    elif choice == "":  # Just enter pressed
       result = default
       inputBool = False
     else:

--- a/ambari-server/src/main/resources/scripts/check_ambari_permissions.py
+++ b/ambari-server/src/main/resources/scripts/check_ambari_permissions.py
@@ -79,7 +79,7 @@ def get_choice_string_input(prompt, default, firstChoice, secondChoice):
     return True
   elif choice in secondChoice:
     return False
-  elif choice is "":  # Just enter pressed
+  elif choice == "":  # Just enter pressed
     return default
   else:
     print("input not recognized, please try again: ")


### PR DESCRIPTION
## What changes were proposed in this pull request?

Resolves "is" and "is not" compiler warnings introduced in python 3.8 when comparing literals.
See https://discuss.python.org/t/demoting-the-is-operator-to-avoid-an-identity-crisis/86 for more details.

Before:
![before](https://github.com/apache/ambari/assets/1467830/061938c2-f903-49e7-a2ef-40200e06c278)

After:
![after](https://github.com/apache/ambari/assets/1467830/e53c6b45-1865-4f8e-ac19-8c82a216f756)

## How was this patch tested?

Manual test / validation in custom Rocky Linux 9 docker environment (planning on contributing support for Redhat 9 in the near future)

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.