### PR TITLE
AMBARI-26065: Add Hadoop Federation Router Service support

### DIFF
--- a/ambari-server/src/main/resources/stacks/BIGTOP/3.2.0/services/HADOOP_ROUTER/configuration/hdfs-rbf-site.xml
+++ b/ambari-server/src/main/resources/stacks/BIGTOP/3.2.0/services/HADOOP_ROUTER/configuration/hdfs-rbf-site.xml
@@ -69,13 +69,13 @@
     </property>
 
     <!-- If you want to enable the mount function of multiple clusters -->
-    <proterty>
+    <property>
         <name>dfs.federation.router.file.resolver.client.class</name>
         <value>org.apache.hadoop.hdfs.server.federation.resolver.MultipleDestinationMountTableResolver</value>
-    </proterty>
+    </property>
 
-    <proterty>
+    <property>
         <name>dfs.federation.router.http-address</name>
         <value>0.0.0.0:50071</value>
-    </proterty>
+    </property>
 </configuration>

--- a/ambari-server/src/main/resources/stacks/BIGTOP/3.2.0/services/HADOOP_ROUTER/configuration/hdfs-rbf-site.xml
+++ b/ambari-server/src/main/resources/stacks/BIGTOP/3.2.0/services/HADOOP_ROUTER/configuration/hdfs-rbf-site.xml
@@ -1,0 +1,81 @@
+<?xml version="1.0"?>
+<?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+ -->
+<!-- Put site-specific property overrides in this file. -->
+<configuration xmlns:xi="http://www.w3.org/2001/XInclude" supports_final="true">
+    <property>
+        <name>dfs.federation.router.default.nameserviceId</name>
+        <value>hdpOne</value>
+    </property>
+    <property>
+        <name>dfs.federation.router.default.nameservice.enable</name>
+        <value>true</value>
+    </property>
+
+    <property>
+        <name>dfs.federation.router.store.driver.class</name>
+        <value>org.apache.hadoop.hdfs.server.federation.store.driver.impl.StateStoreZooKeeperImpl</value>
+    </property>
+
+    <property>
+        <name>hadoop.zk.address</name>
+        <value>sjsysc-hh202-zbhx482w:2181,sjsysc-hh202-zbhx483w:2181,sjsysc-hh202-zbhx484w:2181</value>
+    </property>
+
+    <property>
+        <name>dfs.federation.router.store.driver.zk.parent-path</name>
+        <value>/hdfs-federation</value>
+    </property>
+
+    <property>
+        <name>dfs.client.failover.random.order</name>
+        <value>true</value>
+    </property>
+
+    <!-- If Router and NameNode the same host True -->
+    <property>
+        <name>dfs.federation.router.monitor.localnamenode.enable</name>
+        <value>false</value>
+    </property>
+
+    <!-- Specifies the routing destination of the NameNode -->
+    <property>
+        <name>dfs.federation.router.monitor.namenode</name>
+        <value>hdpOne.nn1,hdpOne.nn2,hdpTwo.nn1,hdpTwo.nn2</value>
+    </property>
+
+    <property>
+        <name>dfs.federation.router.quota.enable</name>
+        <value>true</value>
+    </property>
+    <property>
+        <name>dfs.federation.router.cache.ttl</name>
+        <value>10s</value>
+    </property>
+
+    <!-- If you want to enable the mount function of multiple clusters -->
+    <proterty>
+        <name>dfs.federation.router.file.resolver.client.class</name>
+        <value>org.apache.hadoop.hdfs.server.federation.resolver.MultipleDestinationMountTableResolver</value>
+    </proterty>
+
+    <proterty>
+        <name>dfs.federation.router.http-address</name>
+        <value>0.0.0.0:50071</value>
+    </proterty>
+</configuration>

--- a/ambari-server/src/main/resources/stacks/BIGTOP/3.2.0/services/HADOOP_ROUTER/metainfo.xml
+++ b/ambari-server/src/main/resources/stacks/BIGTOP/3.2.0/services/HADOOP_ROUTER/metainfo.xml
@@ -1,0 +1,103 @@
+<?xml version="1.0"?>
+<!--
+   Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+<metainfo>
+  <schemaVersion>2.0</schemaVersion>
+  <services>
+    <service>
+      <name>HADOOP_ROUTER</name>
+      <displayName>HADOOP ROUTER</displayName>
+      <comment>This component acts as a gateway, offering a unified access point for authentication and interaction with multiple Apache Hadoop services across a federated cluster environment. It simplifies client interactions by providing a central, transparent routing mechanism to various services, thereby enhancing the scalability and manageability of large Hadoop ecosystems.</comment>
+      <version>2.0.0</version>
+      <components>
+        <component>
+          <name>ROUTER</name>
+          <displayName>Hadoop Router</displayName>
+          <category>MASTER</category>
+          <cardinality>1+</cardinality>
+          <versionAdvertised>true</versionAdvertised>
+          <reassignAllowed>true</reassignAllowed>
+          <dependencies>
+            <dependency>
+              <name>HDFS/HDFS_CLIENT</name>
+              <scope>host</scope>
+              <auto-deploy>
+                <enabled>true</enabled>
+              </auto-deploy>
+            </dependency>
+            <dependency>
+              <name>ZOOKEEPER/ZOOKEEPER_SERVER</name>
+              <scope>cluster</scope>
+              <auto-deploy>
+                <enabled>true</enabled>
+              </auto-deploy>
+            </dependency>
+          </dependencies>
+          <commandScript>
+            <script>scripts/dfsrouter.py</script>
+            <scriptType>PYTHON</scriptType>
+            <timeout>1200</timeout>
+          </commandScript>
+          <logs>
+            <log>
+              <logId>router</logId>
+              <primary>true</primary>
+            </log>
+          </logs>
+        </component>
+      </components>
+
+      <quickLinksConfigurations>
+        <quickLinksConfiguration>
+          <fileName>quicklinks.json</fileName>
+          <default>true</default>
+        </quickLinksConfiguration>
+      </quickLinksConfigurations>
+
+      <osSpecifics>
+        <osSpecific>
+          <osFamily>redhat9,redhat8,redhat7,amazonlinux2,redhat6,suse11,suse12</osFamily>
+          <packages>
+            <package>
+              <name>hadoop_${stack_version}-hdfs-dfsrouter</name>
+            </package>
+          </packages>
+        </osSpecific>
+        <osSpecific>
+          <osFamily>ubuntu22</osFamily>
+          <packages>
+            <package>
+              <name>hadoop-${stack_version}-hdfs-dfsrouter</name>
+            </package>
+          </packages>
+        </osSpecific>
+      </osSpecifics>
+
+      <commandScript>
+        <script>scripts/service_check.py</script>
+        <scriptType>PYTHON</scriptType>
+        <timeout>300</timeout>
+      </commandScript>
+
+      <configuration-dependencies>
+        <config-type>hdfs-rbf-site</config-type>
+      </configuration-dependencies>
+
+
+    </service>
+  </services>
+</metainfo>

--- a/ambari-server/src/main/resources/stacks/BIGTOP/3.2.0/services/HADOOP_ROUTER/package/files/checkWebUI.py
+++ b/ambari-server/src/main/resources/stacks/BIGTOP/3.2.0/services/HADOOP_ROUTER/package/files/checkWebUI.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+
+'''
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+'''
+
+import optparse
+import http.client
+import socket
+import ssl
+
+class ForcedProtocolHTTPSConnection(http.client.HTTPSConnection):
+  """
+  Some of python implementations does not work correctly with sslv3 but trying to use it, we need to change protocol to
+  tls1.
+  """
+  def __init__(self, host, port, force_protocol, **kwargs):
+    http.client.HTTPSConnection.__init__(self, host, port, **kwargs)
+    self.force_protocol = force_protocol
+
+  def connect(self):
+    sock = socket.create_connection((self.host, self.port), self.timeout)
+    if getattr(self, '_tunnel_host', None):
+      self.sock = sock
+      self._tunnel()
+    self.sock = ssl.wrap_socket(sock, self.key_file, self.cert_file, ssl_version=getattr(ssl, self.force_protocol))
+
+def make_connection(host, port, https, force_protocol=None):
+  try:
+    conn = http.client.HTTPConnection(host, port) if not https else http.client.HTTPSConnection(host, port)
+    conn.request("GET", "/")
+    return conn.getresponse().status
+  except ssl.SSLError:
+    # got ssl error, lets try to use TLS1 protocol, maybe it will work
+    try:
+      tls1_conn = ForcedProtocolHTTPSConnection(host, port, force_protocol)
+      tls1_conn.request("GET", "/")
+      return tls1_conn.getresponse().status
+    except Exception as e:
+      print(e)
+    finally:
+      tls1_conn.close()
+  except Exception as e:
+    print(e)
+  finally:
+    conn.close()
+#
+# Main.
+#
+def main():
+  parser = optparse.OptionParser(usage="usage: %prog [options] component ")
+  parser.add_option("-m", "--hosts", dest="hosts", help="Comma separated hosts list for WEB UI to check it availability")
+  parser.add_option("-p", "--port", dest="port", help="Port of WEB UI to check it availability")
+  parser.add_option("-s", "--https", dest="https", help="\"True\" if value of dfs.http.policy is \"HTTPS_ONLY\"")
+  parser.add_option("-o", "--protocol", dest="protocol", help="Protocol to use when executing https request")
+
+  (options, args) = parser.parse_args()
+  
+  hosts = options.hosts.split(',')
+  port = options.port
+  https = options.https
+  protocol = options.protocol
+
+  for host in hosts:
+    httpCode = make_connection(host, port, https.lower() == "true", protocol)
+
+    if httpCode != 200:
+      print("Cannot access WEB UI on: http://" + host + ":" + port if not https.lower() == "true" else "Cannot access WEB UI on: https://" + host + ":" + port)
+      exit(1)
+
+if __name__ == "__main__":
+  main()

--- a/ambari-server/src/main/resources/stacks/BIGTOP/3.2.0/services/HADOOP_ROUTER/package/scripts/dfsrouter.py
+++ b/ambari-server/src/main/resources/stacks/BIGTOP/3.2.0/services/HADOOP_ROUTER/package/scripts/dfsrouter.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 """
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file

--- a/ambari-server/src/main/resources/stacks/BIGTOP/3.2.0/services/HADOOP_ROUTER/package/scripts/dfsrouter.py
+++ b/ambari-server/src/main/resources/stacks/BIGTOP/3.2.0/services/HADOOP_ROUTER/package/scripts/dfsrouter.py
@@ -1,0 +1,72 @@
+"""
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+"""
+
+import os
+
+from resource_management.libraries.script.script import Script
+from resource_management.libraries.functions.check_process_status import check_process_status
+from resource_management.libraries.functions.format import format
+from resource_management.libraries.functions import stack_select
+from resource_management.libraries.functions.constants import Direction
+from resource_management.libraries.functions.security_commons import build_expectations
+from resource_management.libraries.functions.security_commons import cached_kinit_executor
+from resource_management.libraries.functions.security_commons import validate_security_config_properties
+from resource_management.libraries.functions.security_commons import get_params_from_filesystem
+from resource_management.libraries.functions.security_commons import FILE_TYPE_XML
+from resource_management.libraries.functions.show_logs import show_logs
+from resource_management.core.resources.system import File, Execute, Link
+from resource_management.core.resources.service import Service
+from resource_management.core.logger import Logger
+
+
+from ambari_commons import OSConst, OSCheck
+from ambari_commons.os_family_impl import OsFamilyImpl
+from hdfs_dfsrouter import *
+
+
+class DfsRouter(Script):
+    def configure(self, env):
+        import params
+        env.set_params(params)
+        dfsrouter(action="configure")
+
+    def install(self, env):
+        import params
+        env.set_params(params)
+        self.install_packages(env)
+
+    def start(self, env, upgrade_type=None):
+        import params
+        env.set_params(params)
+        self.configure(env)
+        dfsrouter(action="start")
+
+    def stop(self, env, upgrade_type=None):
+        import params
+        env.set_params(params)
+        dfsrouter(action="stop")
+
+    def status(self, env):
+        import status_params
+        env.set_params(status_params)
+        dfsrouter(action="status")
+
+
+if __name__ == '__main__':
+    DfsRouter().execute()

--- a/ambari-server/src/main/resources/stacks/BIGTOP/3.2.0/services/HADOOP_ROUTER/package/scripts/hdfs_dfsrouter.py
+++ b/ambari-server/src/main/resources/stacks/BIGTOP/3.2.0/services/HADOOP_ROUTER/package/scripts/hdfs_dfsrouter.py
@@ -1,0 +1,131 @@
+from resource_management import check_process_status
+from resource_management.core.resources.system import Directory, Execute, File
+from ambari_commons.os_family_impl import OsFamilyImpl, OsFamilyFuncImpl
+from resource_management.libraries import XmlConfig
+from resource_management.core.shell import as_sudo
+from resource_management.libraries.functions import format
+from resource_management.core.shell import as_user
+from resource_management.libraries.functions.show_logs import show_logs
+from resource_management.core import shell
+import subprocess
+
+@OsFamilyFuncImpl(os_family=OsFamilyImpl.DEFAULT)
+def dfsrouter(action=None):
+    if action == "configure":
+        import params
+        XmlConfig("hdfs-rbf-site.xml",
+                  conf_dir = params.hadoop_conf_dir,
+                  configurations=params.config['configurations']['hdfs-rbf-site'],
+                  configuration_attributes = params.config['configurationAttributes']['hdfs-rbf-site'],
+                  owner = params.hdfs_user,
+                  group = params.user_group,
+                  mode = 0o644)
+
+        if params.mount_table_content:
+            File(params.mount_table_xml_inclusion_file_full_path,
+                 owner=params.hdfs_user,
+                 group=params.user_group,
+                 content=params.mount_table_content,
+                 mode=0o644
+                 )
+    elif action == "start" or action == "stop":
+        import params
+        service(
+            action=action, name="dfsrouter",
+            user=params.hdfs_user,
+            create_pid_dir=True,
+            create_log_dir=True
+        )
+    elif action == "status":
+        import status_params
+        check_process_status(status_params.dfsrouter_pid_file)
+
+
+
+def service(action=None, name=None, user=None, options="", create_pid_dir=False,
+            create_log_dir=False):
+    """
+    :param action: Either "start" or "stop"
+    :param name: Component name, e.g., "namenode", "datanode", "secondarynamenode", "zkfc"
+    :param user: User to run the command as
+    :param options: Additional options to pass to command as a string
+    :param create_pid_dir: Create PID directory
+    :param create_log_dir: Crate log file directory
+    """
+    import params
+    import status_params
+    ulimit_cmd = "ulimit -c unlimited ; "
+    options = options if options else ""
+    pid_dir = status_params.hadoop_pid_dir
+    pid_file = status_params.dfsrouter_pid_file
+    hadoop_env_exports = {
+        'HADOOP_LIBEXEC_DIR': params.hadoop_libexec_dir
+    }
+    log_dir = f"{params.hdfs_log_dir_prefix}/{user}"
+    process_id_exists_command = as_sudo(["test", "-f", pid_file]) + " && " + as_sudo(["pgrep", "-F", pid_file])
+
+    # on STOP directories shouldn't be created
+    # since during stop still old dirs are used (which were created during previous start)
+    if action != "stop":
+        Directory(params.hadoop_pid_dir_prefix,
+                  mode=0o755,
+                  owner=params.hdfs_user,
+                  group=params.user_group
+                  )
+        if create_pid_dir:
+            Directory(pid_dir,
+                      owner=user,
+                      group=params.user_group,
+                      create_parents = True)
+        if create_log_dir:
+            Directory(log_dir,
+                      owner=user,
+                      group=params.user_group,
+                      create_parents = True)
+
+
+    hadoop_daemon = f"{params.hadoop_bin}/hadoop-daemon.sh"
+
+    if user == "root":
+        cmd = [hadoop_daemon, "--config", params.hadoop_conf_dir, action, name]
+        if options:
+            cmd += [options, ]
+        daemon_cmd = as_sudo(cmd)
+    else:
+        cmd = f"{ulimit_cmd} {hadoop_daemon} --config {params.hadoop_conf_dir} {action} {name}"
+        if options:
+            cmd += " " + options
+        daemon_cmd = as_user(cmd, user)
+
+    if action == "start":
+
+        # remove pid file from dead process
+        File(pid_file, action="delete", not_if=process_id_exists_command)
+
+        try:
+            Execute(daemon_cmd, not_if=process_id_exists_command, environment=hadoop_env_exports)
+        except:
+            show_logs(log_dir, user)
+            raise
+    elif action == "stop":
+        try:
+            Execute(daemon_cmd, only_if=process_id_exists_command, environment=hadoop_env_exports)
+        except:
+            show_logs(log_dir, user)
+            raise
+
+        # Wait until stop actually happens
+        process_id_does_not_exist_command = format("! ( {process_id_exists_command} )")
+        code, out = shell.call(process_id_does_not_exist_command,
+                               env=hadoop_env_exports,
+                               tries = 6,
+                               try_sleep = 10,
+                               )
+
+        # If stop didn't happen, kill it forcefully
+        if code != 0:
+            code, out, err = shell.checked_call(("cat", pid_file), sudo=True, env=hadoop_env_exports, stderr=subprocess.PIPE)
+            pid = out
+            Execute(("kill", "-9", pid), sudo=True)
+
+        File(pid_file, action="delete")

--- a/ambari-server/src/main/resources/stacks/BIGTOP/3.2.0/services/HADOOP_ROUTER/package/scripts/hdfs_dfsrouter.py
+++ b/ambari-server/src/main/resources/stacks/BIGTOP/3.2.0/services/HADOOP_ROUTER/package/scripts/hdfs_dfsrouter.py
@@ -1,3 +1,22 @@
+#!/usr/bin/env python3
+"""
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+"""
 from resource_management import check_process_status
 from resource_management.core.resources.system import Directory, Execute, File
 from ambari_commons.os_family_impl import OsFamilyImpl, OsFamilyFuncImpl

--- a/ambari-server/src/main/resources/stacks/BIGTOP/3.2.0/services/HADOOP_ROUTER/package/scripts/params.py
+++ b/ambari-server/src/main/resources/stacks/BIGTOP/3.2.0/services/HADOOP_ROUTER/package/scripts/params.py
@@ -1,0 +1,65 @@
+"""
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Ambari Agent
+
+"""
+from ambari_commons import OSCheck
+from resource_management.libraries.functions.default import default
+from resource_management.libraries.functions import conf_select
+from resource_management.libraries.functions import format
+from resource_management.libraries.script.script import Script
+from resource_management.libraries.functions.version import format_stack_version
+import status_params
+from resource_management.libraries.functions import stack_select, conf_select
+import os
+
+config = Script.get_config()
+
+
+stack_root = Script.get_stack_root()
+stack_version_unformatted = config['clusterLevelParams']['stack_version']
+stack_version_formatted = format_stack_version(stack_version_unformatted)
+
+hadoop_pid_dir_prefix = "/var/run/hadoop"
+root_user="root"
+
+hadoop_router_hosts = default("/clusterHostInfo/router_hosts", [])
+router_addr = config['configurations']['hdfs-rbf-site']['dfs.federation.router.http-address']
+hdfs_user = config['configurations']['hadoop-env']['hdfs_user']
+hadoop_conf_dir = conf_select.get_hadoop_conf_dir()
+hadoop_pid_dir = format("{hadoop_pid_dir_prefix}/{hdfs_user}")
+hadoop_bin = stack_select.get_hadoop_dir("sbin")
+hadoop_bin_dir = stack_select.get_hadoop_dir("bin")
+
+dfsrouter_pid_file = format("{hadoop_pid_dir}/hadoop-{hdfs_user}-{root_user}-dfsrouter.pid")
+user_group = config['configurations']['cluster-env']['user_group']
+hadoop_libexec_dir = stack_select.get_hadoop_dir("libexec")
+mount_table_xml_inclusion_file_full_path = None
+mount_table_content = None
+hdfs_log_dir_prefix = "/var/log/hadoop"
+
+if 'viewfs-mount-table' in config['configurations']:
+  xml_inclusion_file_name = 'viewfs-mount-table.xml'
+  mount_table = config['configurations']['viewfs-mount-table']
+
+  if 'content' in mount_table and mount_table['content'].strip():
+    mount_table_xml_inclusion_file_full_path = os.path.join(hadoop_conf_dir, xml_inclusion_file_name)
+    mount_table_content = mount_table['content']
+
+smoke_user = config['configurations']['cluster-env']['smokeuser']
+tmp_dir = Script.get_tmp_dir()

--- a/ambari-server/src/main/resources/stacks/BIGTOP/3.2.0/services/HADOOP_ROUTER/package/scripts/params.py
+++ b/ambari-server/src/main/resources/stacks/BIGTOP/3.2.0/services/HADOOP_ROUTER/package/scripts/params.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 """
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
@@ -14,8 +15,6 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
-
-Ambari Agent
 
 """
 from ambari_commons import OSCheck

--- a/ambari-server/src/main/resources/stacks/BIGTOP/3.2.0/services/HADOOP_ROUTER/package/scripts/service_check.py
+++ b/ambari-server/src/main/resources/stacks/BIGTOP/3.2.0/services/HADOOP_ROUTER/package/scripts/service_check.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 """
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file

--- a/ambari-server/src/main/resources/stacks/BIGTOP/3.2.0/services/HADOOP_ROUTER/package/scripts/service_check.py
+++ b/ambari-server/src/main/resources/stacks/BIGTOP/3.2.0/services/HADOOP_ROUTER/package/scripts/service_check.py
@@ -1,0 +1,62 @@
+"""
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+"""
+
+from resource_management.libraries.script.script import Script
+from resource_management.core.shell import as_user
+from ambari_commons.os_family_impl import OsFamilyImpl
+from ambari_commons import OSConst
+from resource_management.libraries.functions.curl_krb_request import curl_krb_request
+from resource_management.libraries import functions
+from resource_management.libraries.functions.format import format
+from resource_management.libraries.resources.execute_hadoop import ExecuteHadoop
+from resource_management.core.logger import Logger
+from resource_management.core.source import StaticFile
+from resource_management.core.resources.system import Execute, File
+
+
+class HadoopRouterServiceCheck(Script):
+    pass
+
+@OsFamilyImpl(os_family=OsFamilyImpl.DEFAULT)
+class HadoopRouterServiceCheckDefault(HadoopRouterServiceCheck):
+    def service_check(self, env):
+        import params
+
+        env.set_params(params)
+
+        checkWebUIFileName = "checkWebUI.py"
+        checkWebUIFilePath = format("{params.tmp_dir}/{checkWebUIFileName}")
+        router_port = params.router_addr.split(":")[1]
+        https_only= False
+        comma_sep_router_hosts = ",".join(params.hadoop_router_hosts)
+
+        checkWebUICmd = f"ambari-python-wrap {checkWebUIFilePath} -m {comma_sep_router_hosts} -p {router_port} -s {https_only}"
+        File(checkWebUIFilePath,
+             content=StaticFile(checkWebUIFileName),
+             mode=0o775)
+
+        Execute(checkWebUICmd,
+                logoutput=True,
+                try_sleep=3,
+                tries=5,
+                user=params.smoke_user
+                )
+
+if __name__ == "__main__":
+    HadoopRouterServiceCheck().execute()

--- a/ambari-server/src/main/resources/stacks/BIGTOP/3.2.0/services/HADOOP_ROUTER/package/scripts/status_params.py
+++ b/ambari-server/src/main/resources/stacks/BIGTOP/3.2.0/services/HADOOP_ROUTER/package/scripts/status_params.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file

--- a/ambari-server/src/main/resources/stacks/BIGTOP/3.2.0/services/HADOOP_ROUTER/package/scripts/status_params.py
+++ b/ambari-server/src/main/resources/stacks/BIGTOP/3.2.0/services/HADOOP_ROUTER/package/scripts/status_params.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python
+"""
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+"""
+from resource_management.libraries.functions import format
+from resource_management.libraries.functions.default import default
+from resource_management.libraries.functions import get_kinit_path
+from resource_management.libraries.script.script import Script
+from ambari_commons import OSCheck
+from resource_management.libraries.functions.version import format_stack_version
+from resource_management.libraries.functions.stack_features import check_stack_feature
+from resource_management.libraries.functions import StackFeature
+
+
+config = Script.get_config()
+stack_root = Script.get_stack_root()
+stack_version_unformatted = config['clusterLevelParams']['stack_version']
+hdfs_user = config['configurations']['hadoop-env']['hdfs_user']
+stack_version_formatted = format_stack_version(stack_version_unformatted)
+
+hadoop_pid_dir_prefix = "/var/run/hadoop"
+hadoop_pid_dir = format("{hadoop_pid_dir_prefix}/{hdfs_user}")
+dfsrouter_pid_file = format("{hadoop_pid_dir}/hadoop-{hdfs_user}-dfsrouter.pid")

--- a/ambari-server/src/main/resources/stacks/BIGTOP/3.2.0/services/HADOOP_ROUTER/quicklinks/quicklinks.json
+++ b/ambari-server/src/main/resources/stacks/BIGTOP/3.2.0/services/HADOOP_ROUTER/quicklinks/quicklinks.json
@@ -1,0 +1,21 @@
+{
+  "name": "default",
+  "description": "default quick links configuration",
+  "configuration": {
+    "links": [
+      {
+        "name": "Router_WEB_UI",
+        "label": "Router Web UI",
+        "requires_user_name": "false",
+        "component_name": "ROUTER",
+        "url":"%@://%@:%@",
+        "port":{
+          "http_property": "dfs.federation.router.http-address",
+          "http_default_port": "50071",
+          "regex" : "\\w*:(\\d+)",
+          "site": "hdfs-rbf-site"
+        }
+      }
+    ]
+  }
+}

--- a/ambari-server/src/main/resources/stacks/BIGTOP/3.2.0/services/HADOOP_ROUTER/role_command_order.json
+++ b/ambari-server/src/main/resources/stacks/BIGTOP/3.2.0/services/HADOOP_ROUTER/role_command_order.json
@@ -1,0 +1,5 @@
+{
+  "general_deps" : {
+    "ROUTER-START" : ["NAMENODE-START"]
+  }
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add management for Hadoop RBF (Router-Based Federation) router service, facilitating the setup and management of multiple Hadoop federation clusters.

## How was this patch tested?
manual test 
router service check
![image](https://github.com/apache/ambari/assets/18082602/ba056bb5-a854-40a5-a71c-2dde4e3e71a6)

router web ui
![image](https://github.com/apache/ambari/assets/18082602/c487b7cb-2293-4362-b923-fbe1d34639e2)

router web service
![image](https://github.com/apache/ambari/assets/18082602/215eaad8-be86-40e4-9ac4-b79323cc2ab4)


tested with  multiple routers
route web ui
![image](https://github.com/apache/ambari/assets/18082602/1545141d-8565-4897-8a9f-c8f10de03588)

two routers monitor one hadoop
![image](https://github.com/apache/ambari/assets/18082602/f4c851db-583d-4a2e-a817-a5d355de9187)


all subclusters
![image](https://github.com/apache/ambari/assets/18082602/6707c78d-89dd-4a1d-9ecf-642dc4135b73)

(Please explain how this patch was tested. Ex: unit tests, manual tests)
(If this patch involves UI changes, please attach a screen-shot; otherwise, remove this)

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.