### PR TITLE
AMBARI-25928: Continuous increase of websocket connections in Ambari web UI

### DIFF
--- a/ambari-web/app/utils/stomp_client.js
+++ b/ambari-web/app/utils/stomp_client.js
@@ -182,7 +182,10 @@ module.exports = Em.Object.extend({
   },
 
   disconnect: function () {
-    this.get('client').disconnect();
+    var client = this.get('client');
+    if (client.ws.readyState === client.ws.OPEN) {
+      client.disconnect();
+    }
   },
 
   /**

--- a/ambari-web/app/utils/stomp_client.js
+++ b/ambari-web/app/utils/stomp_client.js
@@ -59,6 +59,11 @@ module.exports = Em.Object.extend({
   isConnected: false,
 
   /**
+   * @type {number | null}
+   */
+  timerId: null,
+
+  /**
    * @type {boolean}
    */
   isWebSocketSupported: true,
@@ -157,9 +162,13 @@ module.exports = Em.Object.extend({
   },
 
   reconnect: function(useSockJS) {
+    if (this.timerId !== null) {
+      clearTimeout(this.timerId);
+    }
     const subscriptions = Object.assign({}, this.get('subscriptions'));
-    setTimeout(() => {
+    this.timerId = setTimeout(() => {
       console.debug('Reconnecting to WebSocket...');
+      this.disconnect();
       this.connect(useSockJS).done(() => {
         this.set('subscriptions', {});
         for (let i in subscriptions) {


### PR DESCRIPTION
## What changes were proposed in this pull request?
Added debounce to `reconnect` and invoked `disconnect` to disconnect the previous connection instance when websocket performs reconnection.
## How was this patch tested?
Tested manually by comparison.

Before applying this fix, websocket reconnection would create multiple active connections (Time pending):

![SCR-20240424-ofbx](https://github.com/apache/ambari/assets/16508606/6a0d86b9-9d3d-40e1-b263-37b3f6737221)

After a while (approximately 5 minutes), more connections would be created, causing page blockage or even crashes:

![SCR-20240424-ogva](https://github.com/apache/ambari/assets/16508606/62e4b665-453d-4aab-8014-661ce8471f6b)

The fix will maintain one active websocket connection:
![SCR-20240424-odwp](https://github.com/apache/ambari/assets/16508606/142eaa71-a823-4865-82a9-d134cd5c7276)

## Applying this change to the current cluster:
Simply make partial modifications to the packaged files `/usr/lib/ambari-server/web/javascripts/app.js`
```diff
...

/**
* @type {boolean}
*/
isConnected: false,

+ timerId: null,

...

 reconnect: function(useSockJS) {
    var _this2 = this;
+   if (_this2.timerId !== null) {
+     clearTimeout(_this2.timerId);
+    }
    ...
-   setTimeout(() => {
+   _this2.timerId = setTimeout(() => {
      console.debug('Reconnecting to WebSocket...');
+     _this2.disconnect();

...

    }, _this2.RECONNECT_TIMEOUT);
  },

  disconnect: function () {
-   this.get('client').disconnect();
+   var client = this.get('client');
+   if (client.ws.readyState === client.ws.OPEN) {
+   client.disconnect();
    }
  },

...
```