### PR TITLE
AMBARI-26088: Upgrading Ambari Bigtop Stack ZK to Zookeeper 3.7.2, Enhancing Servic…

### DIFF
--- a/ambari-server/src/main/resources/stacks/BIGTOP/3.3.0/services/ZOOKEEPER/configuration/zoo.cfg.xml
+++ b/ambari-server/src/main/resources/stacks/BIGTOP/3.3.0/services/ZOOKEEPER/configuration/zoo.cfg.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0"?>
+<?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
+<!--
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+-->
+<configuration>
+   <property>
+    <name>admin.serverPort</name>
+    <value>8180</value>
+    <description>admin.serverPort</description>
+    <on-ambari-upgrade add="true"/>
+  </property>
+  <property>
+    <name>admin.enableServer</name>
+    <value>true</value>
+    <display-name>Enable Admin Server </display-name>
+    <description>Enable Admin Server.</description>
+    <value-attributes>
+      <type>boolean</type>
+    </value-attributes>
+    <on-ambari-upgrade add="true"/>
+  </property>
+  <property>
+    <name>4lw.commands.whitelist</name>
+    <value>ruok</value>
+    <description>resolve "conf is not executed because it is not in the whitelist" problem. </description>
+    <on-ambari-upgrade add="true"/>
+  </property>
+</configuration>

--- a/ambari-server/src/main/resources/stacks/BIGTOP/3.3.0/services/ZOOKEEPER/configuration/zoo.cfg.xml
+++ b/ambari-server/src/main/resources/stacks/BIGTOP/3.3.0/services/ZOOKEEPER/configuration/zoo.cfg.xml
@@ -36,10 +36,4 @@
     </value-attributes>
     <on-ambari-upgrade add="true"/>
   </property>
-  <property>
-    <name>4lw.commands.whitelist</name>
-    <value>ruok</value>
-    <description>resolve "conf is not executed because it is not in the whitelist" problem. </description>
-    <on-ambari-upgrade add="true"/>
-  </property>
 </configuration>

--- a/ambari-server/src/main/resources/stacks/BIGTOP/3.3.0/services/ZOOKEEPER/metainfo.xml
+++ b/ambari-server/src/main/resources/stacks/BIGTOP/3.3.0/services/ZOOKEEPER/metainfo.xml
@@ -20,7 +20,16 @@
   <services>
     <service>
       <name>ZOOKEEPER</name>
-      <version>3.8.1-1</version>
+      <version>3.7.2-1</version>
+
+      <quickLinksConfigurations-dir>quicklinks</quickLinksConfigurations-dir>
+        <quickLinksConfigurations>
+          <quickLinksConfiguration>
+          <fileName>quicklinks.json</fileName>
+          <default>true</default>
+        </quickLinksConfiguration>
+      </quickLinksConfigurations>
+      
     </service>
   </services>
 </metainfo>

--- a/ambari-server/src/main/resources/stacks/BIGTOP/3.3.0/services/ZOOKEEPER/quicklinks/quicklinks.json
+++ b/ambari-server/src/main/resources/stacks/BIGTOP/3.3.0/services/ZOOKEEPER/quicklinks/quicklinks.json
@@ -1,0 +1,26 @@
+{
+  "name": "default",
+  "description": "default quick links configuration",
+  "configuration": {
+    "protocol":
+    {
+      "type":"http"
+    },
+
+    "links": [
+      {
+        "name": "zookeeper-adminserver",
+        "label": "Zookeeper AdminServer",
+        "requires_user_name": "false",
+        "component_name": "ZOOKEEPER_SERVER",
+        "url": "%@://%@:%@/commands/",
+        "port":{
+          "http_property": "admin.serverPort",
+          "http_default_port": "8180",
+          "regex": "^(\\d+)$",
+          "site": "zoo.cfg"
+        }
+      }
+    ]
+  }
+}


### PR DESCRIPTION
…e Functionality

## What changes were proposed in this pull request?
The version of Zookeeper in Bigtop Stack 3.3.0 is 3.7.2. Added configurations for Zookeeper admin and a quick access link.
(Please fill in changes proposed in this fix)

## How was this patch tested?
manual test
![image](https://github.com/apache/ambari/assets/18082602/38cc3b23-9289-465f-a941-f1f13235f4a5)
![image](https://github.com/apache/ambari/assets/18082602/1f7bda7d-bac0-4717-b095-594566d647cf)

(Please explain how this patch was tested. Ex: unit tests, manual tests)
(If this patch involves UI changes, please attach a screen-shot; otherwise, remove this)

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.