### PR TITLE
AMBARI-26091: Fix remote cluster cannot be deregistered

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/view/RemoteAmbariClusterRegistry.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/view/RemoteAmbariClusterRegistry.java
@@ -100,6 +100,9 @@ public class RemoteAmbariClusterRegistry {
    * @throws AmbariHttpException
    */
   public void saveOrUpdate(RemoteAmbariClusterEntity entity, boolean update) throws IOException, AmbariHttpException {
+    if (update) {
+      delete(entity);
+    }
 
     RemoteAmbariCluster cluster = new RemoteAmbariCluster(entity, configuration);
     Set<String> services = cluster.getServices();


### PR DESCRIPTION
## What changes were proposed in this pull request?

![微信图片_20240703154812](https://github.com/apache/ambari/assets/2969606/ed613094-836b-475b-a75d-c7ace0fec420)

Here is how I reproduce the problem:
1. Click Remote Cluster, Then click Add button to create a new cluster in Ambari.
2. Modify the remote cluster name from MyRemoteCluster to NewRemoteCluster. 
3. After I updated the cluster name, I clicked the deregister remote cluster button and found no response on the page. 
4. When I refreshed the page, the cluster I added was still there. So I conclude that this is a bug for remote clusters.

Here is my ideas for solving the problem:
When I updated the name of the remote cluster, the database was updated. For some reason, the JPA cache was not updated, but the query interface directly looked up the database, so there was no problem. 
When I delete the data in the cache and delete it in the database, I find that the data in the cache is inconsistent with the database, so the deletion fails.
In the end, I achieved consistency between the cached data and the database after the update by deleting the cache before the update. The natural problem has also been solved.

## How was this patch tested?

(Please explain how this patch was tested. Ex: unit tests, manual tests)
(If this patch involves UI changes, please attach a screen-shot; otherwise, remove this)

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.