### PR TITLE
AMBARI-26096: Fix Ranger script file to python3

### DIFF
--- a/ambari-server/src/main/resources/stacks/BIGTOP/3.2.0/services/KAFKA/package/scripts/setup_ranger_kafka.py
+++ b/ambari-server/src/main/resources/stacks/BIGTOP/3.2.0/services/KAFKA/package/scripts/setup_ranger_kafka.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file

--- a/ambari-server/src/main/resources/stacks/BIGTOP/3.3.0/services/RANGER/package/alerts/alert_ranger_admin_passwd_check.py
+++ b/ambari-server/src/main/resources/stacks/BIGTOP/3.3.0/services/RANGER/package/alerts/alert_ranger_admin_passwd_check.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """
 Licensed to the Apache Software Foundation (ASF) under one

--- a/ambari-server/src/main/resources/stacks/BIGTOP/3.3.0/services/RANGER/package/scripts/params.py
+++ b/ambari-server/src/main/resources/stacks/BIGTOP/3.3.0/services/RANGER/package/scripts/params.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file

--- a/ambari-server/src/main/resources/stacks/BIGTOP/3.3.0/services/RANGER/package/scripts/ranger_admin.py
+++ b/ambari-server/src/main/resources/stacks/BIGTOP/3.3.0/services/RANGER/package/scripts/ranger_admin.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file

--- a/ambari-server/src/main/resources/stacks/BIGTOP/3.3.0/services/RANGER/package/scripts/ranger_service.py
+++ b/ambari-server/src/main/resources/stacks/BIGTOP/3.3.0/services/RANGER/package/scripts/ranger_service.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file

--- a/ambari-server/src/main/resources/stacks/BIGTOP/3.3.0/services/RANGER/package/scripts/ranger_tagsync.py
+++ b/ambari-server/src/main/resources/stacks/BIGTOP/3.3.0/services/RANGER/package/scripts/ranger_tagsync.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file

--- a/ambari-server/src/main/resources/stacks/BIGTOP/3.3.0/services/RANGER/package/scripts/ranger_usersync.py
+++ b/ambari-server/src/main/resources/stacks/BIGTOP/3.3.0/services/RANGER/package/scripts/ranger_usersync.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file

--- a/ambari-server/src/main/resources/stacks/BIGTOP/3.3.0/services/RANGER/package/scripts/service_check.py
+++ b/ambari-server/src/main/resources/stacks/BIGTOP/3.3.0/services/RANGER/package/scripts/service_check.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 """
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file

--- a/ambari-server/src/main/resources/stacks/BIGTOP/3.3.0/services/RANGER/package/scripts/setup_ranger_xml.py
+++ b/ambari-server/src/main/resources/stacks/BIGTOP/3.3.0/services/RANGER/package/scripts/setup_ranger_xml.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file

--- a/ambari-server/src/main/resources/stacks/BIGTOP/3.3.0/services/RANGER/package/scripts/status_params.py
+++ b/ambari-server/src/main/resources/stacks/BIGTOP/3.3.0/services/RANGER/package/scripts/status_params.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file

--- a/ambari-server/src/main/resources/stacks/BIGTOP/3.3.0/services/RANGER/package/scripts/upgrade.py
+++ b/ambari-server/src/main/resources/stacks/BIGTOP/3.3.0/services/RANGER/package/scripts/upgrade.py
@@ -1,5 +1,4 @@
-
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file

--- a/ambari-server/src/main/resources/stacks/BIGTOP/3.3.0/services/RANGER_KMS/package/scripts/kms.py
+++ b/ambari-server/src/main/resources/stacks/BIGTOP/3.3.0/services/RANGER_KMS/package/scripts/kms.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file

--- a/ambari-server/src/main/resources/stacks/BIGTOP/3.3.0/services/RANGER_KMS/package/scripts/kms_server.py
+++ b/ambari-server/src/main/resources/stacks/BIGTOP/3.3.0/services/RANGER_KMS/package/scripts/kms_server.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file

--- a/ambari-server/src/main/resources/stacks/BIGTOP/3.3.0/services/RANGER_KMS/package/scripts/kms_service.py
+++ b/ambari-server/src/main/resources/stacks/BIGTOP/3.3.0/services/RANGER_KMS/package/scripts/kms_service.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file

--- a/ambari-server/src/main/resources/stacks/BIGTOP/3.3.0/services/RANGER_KMS/package/scripts/params.py
+++ b/ambari-server/src/main/resources/stacks/BIGTOP/3.3.0/services/RANGER_KMS/package/scripts/params.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file

--- a/ambari-server/src/main/resources/stacks/BIGTOP/3.3.0/services/RANGER_KMS/package/scripts/service_check.py
+++ b/ambari-server/src/main/resources/stacks/BIGTOP/3.3.0/services/RANGER_KMS/package/scripts/service_check.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file

--- a/ambari-server/src/main/resources/stacks/BIGTOP/3.3.0/services/RANGER_KMS/package/scripts/status_params.py
+++ b/ambari-server/src/main/resources/stacks/BIGTOP/3.3.0/services/RANGER_KMS/package/scripts/status_params.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file

--- a/ambari-server/src/main/resources/stacks/BIGTOP/3.3.0/services/RANGER_KMS/package/scripts/upgrade.py
+++ b/ambari-server/src/main/resources/stacks/BIGTOP/3.3.0/services/RANGER_KMS/package/scripts/upgrade.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file


### PR DESCRIPTION
## What changes were proposed in this pull request?
The script file header of  the Ranger is not use python3, I changed it to python3. So, we can unified python3 env for all components.

cmd  >>>  grep "/usr/bin/env python" ambari-server/src/* -rn

src/main/resources/stacks/BIGTOP/3.2.0/services/KAFKA/package/scripts/setup_ranger_kafka.py:1:#!/usr/bin/env python
.......
src/main/resources/stacks/BIGTOP/3.3.0/services/RANGER/package/alerts/alert_ranger_admin_passwd_check.py:1:#!/usr/bin/env python
src/main/resources/stacks/BIGTOP/3.3.0/services/RANGER/package/scripts/params.py:1:#!/usr/bin/env python
src/main/resources/stacks/BIGTOP/3.3.0/services/RANGER/package/scripts/ranger_admin.py:1:#!/usr/bin/env python
src/main/resources/stacks/BIGTOP/3.3.0/services/RANGER/package/scripts/ranger_service.py:1:#!/usr/bin/env python
src/main/resources/stacks/BIGTOP/3.3.0/services/RANGER/package/scripts/ranger_tagsync.py:1:#!/usr/bin/env python
src/main/resources/stacks/BIGTOP/3.3.0/services/RANGER/package/scripts/ranger_usersync.py:1:#!/usr/bin/env python
src/main/resources/stacks/BIGTOP/3.3.0/services/RANGER/package/scripts/setup_ranger_xml.py:1:#!/usr/bin/env python
src/main/resources/stacks/BIGTOP/3.3.0/services/RANGER/package/scripts/status_params.py:1:#!/usr/bin/env python
src/main/resources/stacks/BIGTOP/3.3.0/services/RANGER/package/scripts/upgrade.py:2:#!/usr/bin/env python
src/main/resources/stacks/BIGTOP/3.3.0/services/RANGER_KMS/package/scripts/kms.py:1:#!/usr/bin/env python
src/main/resources/stacks/BIGTOP/3.3.0/services/RANGER_KMS/package/scripts/kms_server.py:1:#!/usr/bin/env python
src/main/resources/stacks/BIGTOP/3.3.0/services/RANGER_KMS/package/scripts/kms_service.py:1:#!/usr/bin/env python
src/main/resources/stacks/BIGTOP/3.3.0/services/RANGER_KMS/package/scripts/params.py:1:#!/usr/bin/env python
src/main/resources/stacks/BIGTOP/3.3.0/services/RANGER_KMS/package/scripts/service_check.py:1:#!/usr/bin/env python
src/main/resources/stacks/BIGTOP/3.3.0/services/RANGER_KMS/package/scripts/status_params.py:1:#!/usr/bin/env python
src/main/resources/stacks/BIGTOP/3.3.0/services/RANGER_KMS/package/scripts/upgrade.py:1:#!/usr/bin/env python
......

## How was this patch tested?
I build on RockyLinux8.10
1.  jdk1.8.0_202   apache-maven-3.9.8
2. yum install git python3 python3-devel fontconfig-devel nodejs rpm-build gcc gcc-c++ curl-devel expat-devel openssl-devel zlib-devel libffi-devel asciidoc
3. download and install phantomjs-2.1.1

Execute command when the env is ready：
mvn clean install package rpm:rpm -Dbuild-rpm -Drat.skip=true -DskipTests -Dmaven.test.skip=true

......
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary for Ambari Main 3.0.0.0-SNAPSHOT:
[INFO] 
[INFO] Ambari Main ........................................ SUCCESS [ 10.475 s]
[INFO] Apache Ambari Project POM .......................... SUCCESS [  0.371 s]
[INFO] Ambari Web ......................................... SUCCESS [04:38 min]
[INFO] Ambari Views ....................................... SUCCESS [  3.162 s]
[INFO] Ambari Admin View .................................. SUCCESS [01:10 min]
[INFO] ambari-utility ..................................... SUCCESS [  5.036 s]
[INFO] Ambari Server SPI .................................. SUCCESS [  2.448 s]
[INFO] Ambari Service Advisor ............................. SUCCESS [  0.522 s]
[INFO] Ambari Server ...................................... SUCCESS [17:37 min]
[INFO] Ambari Functional Tests ............................ SUCCESS [  6.273 s]
[INFO] Ambari Agent ....................................... SUCCESS [03:00 min]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  26:56 min
[INFO] Finished at: 2024-07-24T21:49:04-04:00
[INFO] ------------------------------------------------------------------------

