### PR TITLE
AMBARI-26105: Fix TestPortAlert.py unit test failures in Ambari agent…

### DIFF
--- a/ambari-agent/src/test/python/ambari_agent/TestPortAlert.py
+++ b/ambari-agent/src/test/python/ambari_agent/TestPortAlert.py
@@ -393,7 +393,7 @@ class TestPortAlert(TestCase):
     alert.set_cluster(cluster, cluster_id, host)
     alert.configuration_builder = MagicMock()
     s = socket()
-    s.recv.return_value = "imok"
+    s.recv.return_value = "imok".encode()
 
     def collector_side_effect(clus, data):
       self.assertEqual(data['name'], alert_meta['name'])
@@ -451,7 +451,7 @@ class TestPortAlert(TestCase):
     alert.set_cluster(cluster, cluster_id, host)
     alert.configuration_builder = MagicMock()
     s = socket()
-    s.recv.return_value = "imok"
+    s.recv.return_value = "imok".encode()
 
     def collector_side_effect(clus, data):
       self.assertEqual(data['name'], alert_meta['name'])
@@ -510,7 +510,7 @@ class TestPortAlert(TestCase):
     alert.configuration_builder = MagicMock()
     
     s = socket()
-    s.recv.return_value = "imok"
+    s.recv.return_value = "imok".encode()
 
     def collector_side_effect(clus, data):
       self.assertEqual(data['name'], alert_meta['name'])


### PR DESCRIPTION
… due to Python 2 to 3 upgrade

## What changes were proposed in this pull request?
After fixing the ZooKeeper port alert, this unit test failed due to changes in Python 3 behavior. In Python 3, socket.recv should return bytes instead of a string. The original unit test was returning a string, causing subsequent assertions to fail. This PR updates the test to handle the byte return type correctly, ensuring compatibility with Python 3 while maintaining the test's integrity.
![image](https://github.com/user-attachments/assets/9f862988-2baf-4135-8116-6260db1df151)

(Please fill in changes proposed in this fix)

## How was this patch tested?
manual test and CI test
![image](https://github.com/user-attachments/assets/77a1441e-3a11-4bbd-a549-558942681b95)

(Please explain how this patch was tested. Ex: unit tests, manual tests)
(If this patch involves UI changes, please attach a screen-shot; otherwise, remove this)

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.