### PR TITLE
AMBARI-26107: Migrate away from DOMNodeInserted to MutationObserver

### DIFF
--- a/ambari-web/app/views/application.js
+++ b/ambari-web/app/views/application.js
@@ -48,13 +48,20 @@ App.ApplicationView = Em.View.extend({
    */
   initNavigationBar: function () {
     if (App.get('router.mainController.isClusterDataLoaded')) {
-      $('body').on('DOMNodeInserted', '.navigation-bar', () => {
-        $('.navigation-bar').navigationBar({
-          fitHeight: true,
-          collapseNavBarClass: 'icon-double-angle-left',
-          expandNavBarClass: 'icon-double-angle-right'
-        });
-        $('body').off('DOMNodeInserted', '.navigation-bar');
+      const observer = new MutationObserver(mutations => {
+        if (document.querySelector('.navigation-bar')) {
+          observer.disconnect();
+          $('.navigation-bar').navigationBar({
+            fitHeight: true,
+            collapseNavBarClass: 'icon-double-angle-left',
+            expandNavBarClass: 'icon-double-angle-right'
+          });
+        }
+      });
+
+      observer.observe(document.body, {
+        childList: true,
+        subtree: true
       });
     }
   }.observes('App.router.mainController.isClusterDataLoaded')

--- a/ambari-web/app/views/application.js
+++ b/ambari-web/app/views/application.js
@@ -59,6 +59,11 @@ App.ApplicationView = Em.View.extend({
         }
       });
 
+      setTimeout(() => {
+        // remove observer if selected element is not found in 10secs.
+        observer.disconnect();
+      }, 10000)
+
       observer.observe(document.body, {
         childList: true,
         subtree: true

--- a/ambari-web/app/views/application.js
+++ b/ambari-web/app/views/application.js
@@ -49,12 +49,13 @@ App.ApplicationView = Em.View.extend({
   initNavigationBar: function () {
     if (App.get('router.mainController.isClusterDataLoaded')) {
       const observer = new MutationObserver(mutations => {
-        if (document.querySelector('.navigation-bar')) {
+        var targetNode
+        if (mutations.some((mutation) => mutation.type === 'childList' && (targetNode = $('.navigation-bar')).length)) {
           observer.disconnect();
-          $('.navigation-bar').navigationBar({
+          targetNode.navigationBar({
             fitHeight: true,
             collapseNavBarClass: 'icon-double-angle-left',
-            expandNavBarClass: 'icon-double-angle-right'
+            expandNavBarClass: 'icon-double-angle-right',
           });
         }
       });

--- a/ambari-web/app/views/main/service/info/metrics_view.js
+++ b/ambari-web/app/views/main/service/info/metrics_view.js
@@ -280,8 +280,9 @@ App.MainServiceInfoMetricsView = Em.View.extend(App.Persist, App.TimeRangeMixin,
   makeSortable: function (selector, isNSLayout) {
     var self = this;
     var controller = this.get('controller');
-    const observer = new MutationObserver(() => {
-      if (document.querySelector(selector)) {
+    const observer = new MutationObserver(mutations => {
+      var targetNode
+      if (mutations.some((mutation) => mutation.type === 'childList' && (targetNode = $(selector)).length)) {
         observer.disconnect();
         $(this).sortable({
           items: "> div",

--- a/ambari-web/app/views/main/service/info/metrics_view.js
+++ b/ambari-web/app/views/main/service/info/metrics_view.js
@@ -305,6 +305,11 @@ App.MainServiceInfoMetricsView = Em.View.extend(App.Persist, App.TimeRangeMixin,
       }
     });
 
+    setTimeout(() => {
+      // remove observer if selected element is not found in 10secs.
+      observer.disconnect();
+    }, 10000)
+
     observer.observe(document.body, {
       childList: true,
       subtree: true

--- a/ambari-web/app/views/main/service/info/metrics_view.js
+++ b/ambari-web/app/views/main/service/info/metrics_view.js
@@ -280,27 +280,34 @@ App.MainServiceInfoMetricsView = Em.View.extend(App.Persist, App.TimeRangeMixin,
   makeSortable: function (selector, isNSLayout) {
     var self = this;
     var controller = this.get('controller');
-    $('html').on('DOMNodeInserted', selector, function () {
-      $(this).sortable({
-        items: "> div",
-        cursor: "move",
-        tolerance: "pointer",
-        scroll: false,
-        update: function () {
-          var layout = isNSLayout ? controller.get('selectedNSWidgetLayout') : controller.get('activeWidgetLayout');
-          var widgets = misc.sortByOrder($(selector + " .widget").map(function () {
-            return this.id;
-          }), layout.get('widgets').toArray());
-          controller.saveWidgetLayout(widgets, layout);
-        },
-        activate: function () {
-          self.set('isMoving', true);
-        },
-        deactivate: function () {
-          self.set('isMoving', false);
-        }
-      }).disableSelection();
-      $('html').off('DOMNodeInserted', selector);
+    const observer = new MutationObserver(() => {
+      if (document.querySelector(selector)) {
+        observer.disconnect();
+        $(this).sortable({
+          items: "> div",
+          cursor: "move",
+          tolerance: "pointer",
+          scroll: false,
+          update: function () {
+            var layout = isNSLayout ? controller.get('selectedNSWidgetLayout') : controller.get('activeWidgetLayout');
+            var widgets = misc.sortByOrder($(selector + " .widget").map(function () {
+              return this.id;
+            }), layout.get('widgets').toArray());
+            controller.saveWidgetLayout(widgets, layout);
+          },
+          activate: function () {
+            self.set('isMoving', true);
+          },
+          deactivate: function () {
+            self.set('isMoving', false);
+          }
+        }).disableSelection();
+      }
+    });
+
+    observer.observe(document.body, {
+      childList: true,
+      subtree: true
     });
   }
 });

--- a/ambari-web/app/views/main/service/info/metrics_view.js
+++ b/ambari-web/app/views/main/service/info/metrics_view.js
@@ -284,7 +284,7 @@ App.MainServiceInfoMetricsView = Em.View.extend(App.Persist, App.TimeRangeMixin,
       var targetNode
       if (mutations.some((mutation) => mutation.type === 'childList' && (targetNode = $(selector)).length)) {
         observer.disconnect();
-        $(this).sortable({
+        $(targetNode).sortable({
           items: "> div",
           cursor: "move",
           tolerance: "pointer",

--- a/ambari-web/test/views/main/service/info/metrics_view_test.js
+++ b/ambari-web/test/views/main/service/info/metrics_view_test.js
@@ -214,19 +214,20 @@ describe('App.MainServiceInfoMetricsView', function() {
       mock.sortable.restore();
     });
 
-    it("on() should be called", function() {
+    it("MutationObserver callback should be called", function() {
       view.makeSortable('#widget_layout');
-      expect(mock.on.calledWith('DOMNodeInserted', '#widget_layout')).to.be.true;
-    });
-
-    it("sortable() should be called", function() {
-      view.makeSortable('#widget_layout');
-      expect(mock.sortable.called).to.be.true;
-    });
-
-    it("off() should be called", function() {
-      view.makeSortable('#widget_layout');
-      expect(mock.off.calledWith('DOMNodeInserted', '#widget_layout')).to.be.true;
+      const callback = function () {
+        expect(true).to.be.true;
+        expect(document.querySelector('#widget_layout')).to.not.be.null;
+        observer.disconnect();
+        done();
+      };
+      const observer = new MutationObserver(callback);
+      const body = document.body;
+      observer.observe(body, { childList: true });
+      const elementWidget = document.createElement('div');
+      elementWidget.id='widget_layout';
+      body.appendChild(elementWidget);
     });
   });
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Migrate away from DOMNodeInserted to MutationObserver

## How was this patch tested?

This was tested manually on localhost. 

Screenshot attached:

<img width="1728" alt="image" src="https://github.com/user-attachments/assets/187fc7ec-a4c2-4ca0-9874-cd9e8e97483d">
