### PR TITLE
AMBARI-26108: ambari-server install error and  ambari-server setup failed on RockLinux8.10

### DIFF
--- a/ambari-server/conf/unix/ambari-env.sh
+++ b/ambari-server/conf/unix/ambari-env.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.

--- a/ambari-server/conf/unix/install-helper.sh
+++ b/ambari-server/conf/unix/install-helper.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information rega4rding copyright ownership.


### PR DESCRIPTION
## What changes were proposed in this pull request?
RockyLinux8.10, Local repo
I used  cmd>> yum install ambari-server ,and i found the error message.
![微信截图_20240802113442](https://issues.apache.org/jira/secure/attachment/13070639/13070639_%E5%BE%AE%E4%BF%A1%E6%88%AA%E5%9B%BE_20240802113442.png)

After run "ambari-server setup" and exec faild
[root@node1 opt]#  ambari-server setup 
/usr/sbin/ambari-server: line 91: line: unbound variable

Finally, I found that install-helper.sh and ambari-env.sh did not have +x  permission
![微信截图_20240802114735.png](https://issues.apache.org/jira/secure/attachment/13070640/13070640_%E5%BE%AE%E4%BF%A1%E6%88%AA%E5%9B%BE_20240802114735.png)

## How was this patch tested?
1.build ambari-server
2.install ambari-server_xxx.rpm and check result
3.check  install-helper.sh and ambari-env.sh file permission


