### PR TITLE
AMBARI-26110: Metrics view test cases fail in some cases.

### DIFF
--- a/ambari-web/test/views/main/service/info/metrics_view_test.js
+++ b/ambari-web/test/views/main/service/info/metrics_view_test.js
@@ -214,17 +214,16 @@ describe('App.MainServiceInfoMetricsView', function() {
       mock.sortable.restore();
     });
 
-    it("MutationObserver callback should be called", function() {
+    it("MutationObserver callback should be called", function(done) {
       view.makeSortable('#widget_layout');
       const callback = function () {
-        expect(true).to.be.true;
         expect(document.querySelector('#widget_layout')).to.not.be.null;
         observer.disconnect();
         done();
       };
       const observer = new MutationObserver(callback);
       const body = document.body;
-      observer.observe(body, { childList: true });
+      observer.observe(body, { childList: true, subtree: true });
       const elementWidget = document.createElement('div');
       elementWidget.id='widget_layout';
       body.appendChild(elementWidget);


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fixed the test cases: added the `done` declaration and removed unnecessary assertions.

PR to reproduce:

- #3804 

Related PR:

- #3801

## How was this patch tested?

```bash
mvn -T 2C -am test -pl ambari-web -Dmaven.artifact.threads=10 -Drat.skip
```

Before:

![image](https://github.com/user-attachments/assets/7e2945fd-5369-4531-a9ff-280f2cff5308)


After:

![image](https://github.com/user-attachments/assets/62d58fc6-22bc-46a3-97c7-a45cc30d9a9c)
