### PR TITLE
AMBARI-26112: Fix agent add faild by webUI

### DIFF
--- a/ambari-server/src/main/python/bootstrap.py
+++ b/ambari-server/src/main/python/bootstrap.py
@@ -345,7 +345,7 @@ class BootstrapWindows(Bootstrap):
     user_run_as = self.shared_state.user_run_as
     server = self.shared_state.ambari_server
     version = self.getAmbariVersion()
-    return ' '.join(['python', setupFile, expected_hostname, passphrase, server, user_run_as, version])
+    return ' '.join(['python3', setupFile, expected_hostname, passphrase, server, user_run_as, version])
 
   def runSetupAgent(self):
     self.host_log.write("==========================\n")
@@ -609,7 +609,7 @@ class BootstrapDefault(Bootstrap):
     version = self.getAmbariVersion()
     port = self.getAmbariPort()
     passwordFile = self.getPasswordFile()
-    return "{sudo} -S python ".format(sudo=AMBARI_SUDO) + str(setupFile) + " " + str(expected_hostname) + \
+    return "{sudo} -S python3 ".format(sudo=AMBARI_SUDO) + str(setupFile) + " " + str(expected_hostname) + \
            " " + str(passphrase) + " " + str(server)+ " " + quote_bash_args(str(user_run_as)) + " " + str(version) + \
            " " + str(port) + " < " + str(passwordFile)
 
@@ -620,7 +620,7 @@ class BootstrapDefault(Bootstrap):
     user_run_as = self.shared_state.user_run_as
     version=self.getAmbariVersion()
     port=self.getAmbariPort()
-    return "{sudo} python ".format(sudo=AMBARI_SUDO) + str(setupFile) + " " + str(expected_hostname) + \
+    return "{sudo} python3 ".format(sudo=AMBARI_SUDO) + str(setupFile) + " " + str(expected_hostname) + \
            " " + str(passphrase) + " " + str(server)+ " " + quote_bash_args(str(user_run_as)) + " " + str(version) + \
            " " + str(port)
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
When I add agent on the page, the error message is：
![微信图片_20240809093515](https://issues.apache.org/jira/secure/attachment/13070780/13070780_%E5%BE%AE%E4%BF%A1%E5%9B%BE%E7%89%87_20240809093515.png)
And my OS(RockyLinux8.10) is new，after installing ambari-server-xxx.rpm, only generate the python3 environment.
![微信图片_20240809094955](https://issues.apache.org/jira/secure/attachment/13070781/13070781_%E5%BE%AE%E4%BF%A1%E5%9B%BE%E7%89%87_20240809094955.png)
I think we don't need to manually create a python symlink,so fix this directly use python3

## How was this patch tested?
build amabir-server and add agent by web page