### PR TITLE
AMBARI-26115: $PYTHONPATH was not correctly resolved.

### DIFF
--- a/ambari-agent/pom.xml
+++ b/ambari-agent/pom.xml
@@ -250,7 +250,7 @@
                 <argument>${python.test.mask}</argument>
               </arguments>
               <environmentVariables>
-                <PYTHONPATH>${path.python.1}${pathsep}$PYTHONPATH</PYTHONPATH>
+                <PYTHONPATH>${path.python.1}${pathsep}${env.PYTHONPATH}</PYTHONPATH>
               </environmentVariables>
               <skip>${skipPythonTests}</skip>
             </configuration>
@@ -269,7 +269,7 @@
                 <argument>${target.cache.dir}</argument>
               </arguments>
               <environmentVariables>
-                <PYTHONPATH>target${dirsep}ambari-agent-${project.version}${pathsep}$PYTHONPATH</PYTHONPATH>
+                <PYTHONPATH>target${dirsep}ambari-agent-${project.version}${pathsep}${env.PYTHONPATH}</PYTHONPATH>
               </environmentVariables>
             </configuration>
             <id>generate-hash-files</id>

--- a/ambari-server/pom.xml
+++ b/ambari-server/pom.xml
@@ -754,7 +754,7 @@
                 <argument>${python.test.mask}</argument>
               </arguments>
               <environmentVariables>
-                  <PYTHONPATH>${path.python.1}${pathsep}$PYTHONPATH</PYTHONPATH>
+                  <PYTHONPATH>${path.python.1}${pathsep}${env.PYTHONPATH}</PYTHONPATH>
               </environmentVariables>
               <skip>${skipPythonTests}</skip>
             </configuration>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Use `${env.PYTHONPATH}` instead of `$PYTHONPATH`, and environment variables can now be correctly resolved: 
![image](https://github.com/user-attachments/assets/c5611a55-9043-4abc-b058-574fc7c0abac)


## How was this patch tested?

Github Action: [#63](https://github.com/akioee/ambari/actions/runs/10375102408/job/28724030059)
Manual testing:

```bash
$ mvn -Dmaven.test.failure.ignore=true -am test -pl ambari-agent -Dmaven.artifact.threads=10 -Drat.skip
$ mvn -am test -pl ambari-server -DskipSurefireTests -Dmaven.test.failure.ignore -Dmaven.artifact.threads=10 -Drat.skip -Dcheckstyle.skip
$ mvn -am test -pl ambari-server -DskipPythonTests -Dmaven.test.failure.ignore -Dmaven.artifact.threads=10 -Drat.skip
```

Ambari-agent:
![image](https://github.com/user-attachments/assets/15e1ebe5-1e4b-48f3-89fc-817895217a0b)

Ambari-server:
![image](https://github.com/user-attachments/assets/904a12a2-9f0f-42a7-a6b3-5f8ec88ed13d)
![image](https://github.com/user-attachments/assets/fe2b8895-66df-4dc0-9d28-dcb6f4ca8b4e)
