### PR TITLE
[AMBARI-26118] Fix the default SSL Ciphers of port 8440/8441 are too weak issue

### DIFF
--- a/ambari-server/conf/unix/ambari-env.sh
+++ b/ambari-server/conf/unix/ambari-env.sh
@@ -16,7 +16,7 @@
 
 
 AMBARI_PASSHPHRASE="DEV"
-export AMBARI_JVM_ARGS="$AMBARI_JVM_ARGS -Xms512m -Xmx2048m -XX:MaxPermSize=128m -Djava.security.auth.login.config=$ROOT/etc/ambari-server/conf/krb5JAASLogin.conf -Djava.security.krb5.conf=/etc/krb5.conf -Djavax.security.auth.useSubjectCredsOnly=false -Dcom.sun.jndi.ldap.connect.pool.protocol=\"plain ssl\" -Dcom.sun.jndi.ldap.connect.pool.maxsize=20 -Dcom.sun.jndi.ldap.connect.pool.timeout=300000"
+export AMBARI_JVM_ARGS="$AMBARI_JVM_ARGS -Xms512m -Xmx2048m -XX:MaxPermSize=128m -Djdk.tls.ephemeralDHKeySize=2048 -Djava.security.auth.login.config=$ROOT/etc/ambari-server/conf/krb5JAASLogin.conf -Djava.security.krb5.conf=/etc/krb5.conf -Djavax.security.auth.useSubjectCredsOnly=false -Dcom.sun.jndi.ldap.connect.pool.protocol=\"plain ssl\" -Dcom.sun.jndi.ldap.connect.pool.maxsize=20 -Dcom.sun.jndi.ldap.connect.pool.timeout=300000"
 export PATH=$PATH:$ROOT/var/lib/ambari-server
 export PYTHONPATH=$ROOT/usr/lib/ambari-server/lib:$PYTHONPATH
 

--- a/ambari-server/conf/windows/ambari-env.cmd
+++ b/ambari-server/conf/windows/ambari-env.cmd
@@ -16,4 +16,4 @@ rem limitations under the License.
 
 
 set AMBARI_PASSHPHRASE=DEV
-set AMBARI_JVM_ARGS=%AMBARI_JVM_ARGS% -Xms512m -Xmx2048m -Djava.security.auth.login.config=conf\krb5JAASLogin.conf -Djava.security.krb5.conf=conf\krb5.conf -Djavax.security.auth.useSubjectCredsOnly=false
+set AMBARI_JVM_ARGS=%AMBARI_JVM_ARGS% -Xms512m -Xmx2048m -Djdk.tls.ephemeralDHKeySize=2048 -Djava.security.auth.login.config=conf\krb5JAASLogin.conf -Djava.security.krb5.conf=conf\krb5.conf -Djavax.security.auth.useSubjectCredsOnly=false


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix the default SSL Ciphers of port 8440/8441 are too weak issue

## How was this patch tested?

I think this  is a common java configuration setting change, so do not need additional testing for this simple fix. 