### PR TITLE
AMBARI-26119: Add dependency python3-distro for ambari-server

### DIFF
--- a/ambari-server/src/main/package/dependencies.properties
+++ b/ambari-server/src/main/package/dependencies.properties
@@ -28,6 +28,6 @@
 # Such a format is respected by install_ambari_tarball.py by default, 
 # however should be encouraged manually in pom.xml.
 
-rpm.dependency.list=postgresql-server >= 8.1,\nRequires: openssl,\nRequires: python3
+rpm.dependency.list=postgresql-server >= 8.1,\nRequires: openssl,\nRequires: python3,\nRequires: python3-distro
 rpm.dependency.list.suse=postgresql-server >= 8.1,\nRequires: openssl,\nRequires: python-xml,\nRequires: python3
 deb.dependency.list=openssl, postgresql (>= 8.1), python3, curl


### PR DESCRIPTION
## What changes were proposed in this pull request?
ambari-server setup failed, missing package python3-distro
![微信图片_20240822154116](https://issues.apache.org/jira/secure/attachment/13071036/13071036_%E5%BE%AE%E4%BF%A1%E5%9B%BE%E7%89%87_20240822154116.png)

## How was this patch tested?
1. build and install ambari
2. exec >>> ambari-server setup