### PR TITLE
AMBARI-26120:When selecting all hosts in install wizard step 6 page, the disabled host should be excluded.

### DIFF
--- a/ambari-web/app/controllers/wizard/step6_controller.js
+++ b/ambari-web/app/controllers/wizard/step6_controller.js
@@ -250,7 +250,9 @@ App.WizardStep6Controller = Em.Controller.extend(App.HostComponentValidationMixi
     this.get('hosts').forEach(function (host) {
       host.checkboxes.filterProperty('isInstalled', false).forEach(function (checkbox) {
         if (checkbox.component === component) {
-          Em.set(checkbox, 'checked', checked);
+          if (!checkbox.isDisabled) {
+            Em.set(checkbox, 'checked', checked);
+          }
         }
       });
     });


### PR DESCRIPTION
## What changes were proposed in this pull request?

When selecting all hosts in install wizard step 6 page, the disabled host should be excluded.

## How was this patch tested?

A simple fix, don't need additional testing.