### PR TITLE
AMBARI-26121: Fix Python3 compilation error when packaging Ambari on CentOS 7

### DIFF
--- a/ambari-agent/pom.xml
+++ b/ambari-agent/pom.xml
@@ -314,6 +314,9 @@
           <license>2012, Apache Software Foundation</license>
           <group>Development</group>
           <description>Maven Recipe: RPM Package.</description>
+          <defineStatements>
+            <defineStatement>__python 3</defineStatement>
+          </defineStatements>
           <requires>
             <require>${rpm.dependency.list}</require>
           </requires>

--- a/ambari-server/pom.xml
+++ b/ambari-server/pom.xml
@@ -529,6 +529,9 @@
           <license>2012, Apache Software Foundation</license>
           <group>Development</group>
           <description>Maven Recipe: RPM Package.</description>
+          <defineStatements>
+             <defineStatement>__python 3</defineStatement>
+          </defineStatements>
           <autoRequires>no</autoRequires>
           <prefix>/</prefix>
           <requires>


### PR DESCRIPTION
## What changes were proposed in this pull request?
fix SyntaxError: invalid syntax error when compile in centos 7 with python 3 
![Snipaste_2024-08-28_18-08-12](https://github.com/user-attachments/assets/1b7cb548-b080-4a4c-b603-99373b3adf88)

(Please fill in changes proposed in this fix)
add defineStatement python 3 in ambari-server and ambari-agent pom.xml
## How was this patch tested?

(Please explain how this patch was tested. Ex: unit tests, manual tests)
(If this patch involves UI changes, please attach a screen-shot; otherwise, remove this)
compile in centos 7 with python 3.6.8 installed
Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.