### PR TITLE
AMBARI-26132: Building ambari-admin will enter the testing phase

### DIFF
--- a/ambari-admin/pom.xml
+++ b/ambari-admin/pom.xml
@@ -142,6 +142,7 @@
               <goal>exec</goal>
             </goals>
             <configuration>
+              <skip>${skipTests}</skip>
               <workingDirectory>${basedir}/src/main/resources/ui/admin-web</workingDirectory>
               <executable>npm</executable>
               <arguments>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add the `skipTests` parameter to ensure the phase is properly skipped.

## How was this patch tested?

Manual testing.

```bash
$ cd ambari-admin
$ mvn -B clean install package -Drat.skip=true -DskipTests -Dmaven.test.skip=true -Dfindbugs.skip=true
```

<details>
  <summary>Full log</summary>
  

  ```text
Picked up _JAVA_OPTIONS: -Xmx2048m -XX:MaxPermSize=512m -Djava.awt.headless=true
OpenJDK 64-Bit Server VM warning: ignoring option MaxPermSize=512m; support was removed in 8.0
[INFO] Scanning for projects...
[INFO] 
[INFO] -------------------< org.apache.ambari:ambari-admin >-------------------
[INFO] Building Ambari Admin View 3.0.0.0-SNAPSHOT
[INFO]   from pom.xml
[INFO] --------------------------------[ jar ]---------------------------------
[INFO] 
[INFO] --- clean:2.5:clean (default-clean) @ ambari-admin ---
[INFO] Deleting /home/ambari/ambari-admin/target
[INFO] Deleting /home/ambari/ambari-admin (includes = [**/*.pyc], excludes = [])
[INFO] 
[INFO] --- flatten:1.0.1:clean (flatten.clean) @ ambari-admin ---
[INFO] 
[INFO] --- build-helper:1.8:regex-property (parse-package-version) @ ambari-admin ---
[INFO] 
[INFO] --- build-helper:1.8:regex-property (parse-package-release) @ ambari-admin ---
[INFO] 
[INFO] --- build-helper:1.8:parse-version (parse-version) @ ambari-admin ---
[INFO] 
[INFO] --- build-helper:1.8:regex-property (regex-property) @ ambari-admin ---
[INFO] 
[INFO] --- enforcer:3.0.0-M2:enforce (enforce-maven-version) @ ambari-admin ---
[INFO] 
[INFO] --- enforcer:3.0.0-M2:enforce (enforce-versions) @ ambari-admin ---
[INFO] 
[INFO] --- frontend:1.3:install-node-and-npm (install node and npm) @ ambari-admin ---
[INFO] Node v4.5.0 is already installed.
[INFO] NPM 2.15.0 is already installed.
[INFO] 
[INFO] --- frontend:1.3:npm (npm install) @ ambari-admin ---
[INFO] npm not inheriting proxy config from Maven
[INFO] Running 'npm install --unsafe-perm' in /home/ambari/ambari-admin/src/main/resources/ui/admin-web
[WARNING] npm WARN package.json adminconsole@0.0.0 No description
[WARNING] npm WARN package.json adminconsole@0.0.0 No repository field.
[WARNING] npm WARN package.json adminconsole@0.0.0 No README data
[WARNING] npm WARN package.json adminconsole@0.0.0 No license field.
[INFO] 
[INFO] --- exec:1.2.1:exec (Bower install) @ ambari-admin ---
[INFO] 
[INFO] --- exec:1.2.1:exec (Gulp build) @ ambari-admin ---
[13:58:53] Using gulpfile /home/ambari/ambari-admin/src/main/resources/ui/admin-web/gulpfile.js
[13:58:53] Starting 'styles'...
[13:58:53] Starting 'views'...
[13:58:53] Starting 'images'...
[13:58:53] Starting 'fonts'...
[13:58:54] Starting 'extras'...
[13:58:54] Finished 'extras' after 17 ms
[13:58:54] gulp-size: total 8.35 kB
[13:58:54] Finished 'images' after 205 ms
[13:58:54] gulp-size: total 87.69 kB
[13:58:54] Finished 'styles' after 465 ms
[13:58:54] Starting 'html'...
[13:58:54] gulp-size: total 3.07 MB
[13:58:54] Finished 'html' after 251 ms
[13:58:54] gulp-size: total 1.93 MB
[13:58:54] Finished 'fonts' after 575 ms
[13:58:54] Finished 'views' after 601 ms
[13:58:54] Starting 'build'...
[13:58:54] Finished 'build' after 16 μs
[INFO] 
[INFO] --- remote-resources:1.5:process (process-resource-bundles) @ ambari-admin ---
[INFO] 
[INFO] --- resources:3.1.0:resources (default-resources) @ ambari-admin ---
[INFO] Using 'UTF-8' encoding to copy filtered resources.
[INFO] Copying 0 resource
[INFO] Copying 57 resources
[INFO] Copying 3 resources
[INFO] 
[INFO] --- flatten:1.0.1:flatten (flatten) @ ambari-admin ---
[INFO] Generating flattened POM of project org.apache.ambari:ambari-admin:jar:3.0.0.0-SNAPSHOT...
[INFO] 
[INFO] --- compiler:3.2:compile (default-compile) @ ambari-admin ---
[INFO] No sources to compile
[INFO] 
[INFO] --- exec:1.2.1:exec (set-ambari-version) @ ambari-admin ---
Setting Ambari version to 3.0.0.0
[INFO] 
[INFO] --- resources:3.1.0:testResources (default-testResources) @ ambari-admin ---
[INFO] Not copying test resources
[INFO] 
[INFO] --- compiler:3.2:testCompile (default-testCompile) @ ambari-admin ---
[INFO] Not compiling test sources
[INFO] 
[INFO] --- surefire:2.20:test (default-test) @ ambari-admin ---
[INFO] Tests are skipped.
[INFO] 
[INFO] --- exec:1.2.1:exec (unit test) @ ambari-admin ---
[INFO] skipping execute as per configuraion
[INFO] 
[INFO] --- apache-rat:0.12:check (default) @ ambari-admin ---
[INFO] RAT will not execute since it is configured to be skipped via system property 'rat.skip'.
[INFO] 
[INFO] --- jar:3.1.0:jar (default-jar) @ ambari-admin ---
[INFO] Building jar: /home/ambari/ambari-admin/target/ambari-admin-3.0.0.0-SNAPSHOT.jar
[INFO] 
[INFO] --- assembly:2.2-beta-5:single (make-assembly) @ ambari-admin ---
[INFO] Reading assembly descriptor: src/main/assemblies/empty.xml
[INFO] 
[INFO] --- site:3.7.1:attach-descriptor (attach-descriptor) @ ambari-admin ---
[INFO] Skipping because packaging 'jar' is not pom.
[INFO] 
[INFO] --- install:2.5.2:install (default-install) @ ambari-admin ---
[INFO] Installing /home/ambari/ambari-admin/target/ambari-admin-3.0.0.0-SNAPSHOT.jar to /data/cache/maven/org/apache/ambari/ambari-admin/3.0.0.0-SNAPSHOT/ambari-admin-3.0.0.0-SNAPSHOT.jar
[INFO] Installing /home/ambari/ambari-admin/target/.flattened-pom.xml to /data/cache/maven/org/apache/ambari/ambari-admin/3.0.0.0-SNAPSHOT/ambari-admin-3.0.0.0-SNAPSHOT.pom
[INFO] 
[INFO] --- build-helper:1.8:regex-property (parse-package-version) @ ambari-admin ---
[INFO] 
[INFO] --- build-helper:1.8:regex-property (parse-package-release) @ ambari-admin ---
[INFO] 
[INFO] --- build-helper:1.8:parse-version (parse-version) @ ambari-admin ---
[INFO] 
[INFO] --- build-helper:1.8:regex-property (regex-property) @ ambari-admin ---
[INFO] 
[INFO] --- enforcer:3.0.0-M2:enforce (enforce-maven-version) @ ambari-admin ---
[INFO] 
[INFO] --- enforcer:3.0.0-M2:enforce (enforce-versions) @ ambari-admin ---
[INFO] 
[INFO] --- frontend:1.3:install-node-and-npm (install node and npm) @ ambari-admin ---
[INFO] Node v4.5.0 is already installed.
[INFO] NPM 2.15.0 is already installed.
[INFO] 
[INFO] --- frontend:1.3:npm (npm install) @ ambari-admin ---
[INFO] npm not inheriting proxy config from Maven
[INFO] Running 'npm install --unsafe-perm' in /home/ambari/ambari-admin/src/main/resources/ui/admin-web
[WARNING] npm WARN package.json adminconsole@0.0.0 No description
[WARNING] npm WARN package.json adminconsole@0.0.0 No repository field.
[WARNING] npm WARN package.json adminconsole@0.0.0 No README data
[WARNING] npm WARN package.json adminconsole@0.0.0 No license field.
[INFO] 
[INFO] --- exec:1.2.1:exec (Bower install) @ ambari-admin ---
[INFO] 
[INFO] --- exec:1.2.1:exec (Gulp build) @ ambari-admin ---
[13:59:00] Using gulpfile /home/ambari/ambari-admin/src/main/resources/ui/admin-web/gulpfile.js
[13:59:00] Starting 'styles'...
[13:59:00] Starting 'views'...
[13:59:00] Starting 'images'...
[13:59:00] Starting 'fonts'...
[13:59:00] Starting 'extras'...
[13:59:00] Finished 'extras' after 17 ms
[13:59:00] gulp-size: total 8.35 kB
[13:59:00] Finished 'images' after 197 ms
[13:59:00] gulp-size: total 87.69 kB
[13:59:00] Finished 'styles' after 454 ms
[13:59:00] Starting 'html'...
[13:59:01] gulp-size: total 3.07 MB
[13:59:01] Finished 'html' after 206 ms
[13:59:01] gulp-size: total 1.93 MB
[13:59:01] Finished 'fonts' after 516 ms
[13:59:01] Finished 'views' after 535 ms
[13:59:01] Starting 'build'...
[13:59:01] Finished 'build' after 10 μs
[INFO] 
[INFO] --- remote-resources:1.5:process (process-resource-bundles) @ ambari-admin ---
[INFO] 
[INFO] --- resources:3.1.0:resources (default-resources) @ ambari-admin ---
[INFO] Using 'UTF-8' encoding to copy filtered resources.
[INFO] Copying 0 resource
[INFO] Copying 57 resources
[INFO] Copying 3 resources
[INFO] Copying 3 resources
[INFO] 
[INFO] --- flatten:1.0.1:flatten (flatten) @ ambari-admin ---
[INFO] Generating flattened POM of project org.apache.ambari:ambari-admin:jar:3.0.0.0-SNAPSHOT...
[INFO] 
[INFO] --- compiler:3.2:compile (default-compile) @ ambari-admin ---
[INFO] No sources to compile
[INFO] 
[INFO] --- exec:1.2.1:exec (set-ambari-version) @ ambari-admin ---
Setting Ambari version to 3.0.0.0
[INFO] 
[INFO] --- resources:3.1.0:testResources (default-testResources) @ ambari-admin ---
[INFO] Not copying test resources
[INFO] 
[INFO] --- compiler:3.2:testCompile (default-testCompile) @ ambari-admin ---
[INFO] Not compiling test sources
[INFO] 
[INFO] --- surefire:2.20:test (default-test) @ ambari-admin ---
[INFO] Tests are skipped.
[INFO] 
[INFO] --- exec:1.2.1:exec (unit test) @ ambari-admin ---
[INFO] skipping execute as per configuraion
[INFO] 
[INFO] --- apache-rat:0.12:check (default) @ ambari-admin ---
[INFO] RAT will not execute since it is configured to be skipped via system property 'rat.skip'.
[INFO] 
[INFO] --- jar:3.1.0:jar (default-jar) @ ambari-admin ---
[INFO] Building jar: /home/ambari/ambari-admin/target/ambari-admin-3.0.0.0-SNAPSHOT.jar
[INFO] 
[INFO] --- assembly:2.2-beta-5:single (make-assembly) @ ambari-admin ---
[INFO] Reading assembly descriptor: src/main/assemblies/empty.xml
[INFO] 
[INFO] --- site:3.7.1:attach-descriptor (attach-descriptor) @ ambari-admin ---
[INFO] Skipping because packaging 'jar' is not pom.
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  13.224 s
[INFO] Finished at: 2024-09-11T13:59:01Z
[INFO] ------------------------------------------------------------------------
  ```
</details>
