### PR TITLE
AMBARI-26129: Remove hive.load.data.owner from hive configuration

### DIFF
--- a/ambari-server/src/main/resources/stacks/BIGTOP/3.2.0/services/HIVE/configuration/hive-site.xml
+++ b/ambari-server/src/main/resources/stacks/BIGTOP/3.2.0/services/HIVE/configuration/hive-site.xml
@@ -660,11 +660,6 @@ limitations under the License.
     <on-ambari-upgrade add="false"/>
   </property>
   <property>
-    <name>hive.load.data.owner</name>
-    <value>hive</value>
-    <on-ambari-upgrade add="false"/>
-  </property>
-  <property>
     <name>hive.txn.strict.locking.mode</name>
     <value>false</value>
     <on-ambari-upgrade add="false"/>


### PR DESCRIPTION
## What changes were proposed in this pull request?

The configuration in Ambari Hive:

```xml
<property>
  <name>hive.load.data.owner</name>
  <value>hive</value>
  <on-ambari-upgrade add="false"/>
</property>
```

This setting causes permission errors when users attempt to load data. The only solution is to remove this configuration, but Ambari's web interface doesn't allow direct removal of configurations. As a result, users are forced to delete this configuration from the database using scripts, which is cumbersome.

To address this issue, we propose removing this configuration by default. Users who require this setting can still add it manually through custom configurations if needed.

This change will:
1. Eliminate permission errors during data loading
2. Reduce the need for manual database interventions
3. Provide flexibility for users who may still need this configuration
4. Improve overall user experience and reduce support requests related to this issue

## How was this patch tested?
manual test and ci
(Please explain how this patch was tested. Ex: unit tests, manual tests)
(If this patch involves UI changes, please attach a screen-shot; otherwise, remove this)

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.