### PR TITLE
AMBARI-26128: Add UnlockExperimentalVMOptions to Hive startup parameters in Ambari

### DIFF
--- a/ambari-server/src/main/resources/stacks/BIGTOP/3.2.0/services/HIVE/configuration/hive-env.xml
+++ b/ambari-server/src/main/resources/stacks/BIGTOP/3.2.0/services/HIVE/configuration/hive-env.xml
@@ -373,14 +373,14 @@
 if [ "$SERVICE" = "metastore" ]; then
 
   export HADOOP_HEAPSIZE={{hive_metastore_heapsize}} # Setting for HiveMetastore
-  export HADOOP_OPTS="$HADOOP_OPTS -Xloggc:{{hive_log_dir}}/hivemetastore-gc-%t.log -XX:+UseG1GC -XX:+PrintGCDetails -XX:+PrintGCTimeStamps -XX:+PrintGCCause -XX:+UseGCLogFileRotation -XX:NumberOfGCLogFiles=10 -XX:GCLogFileSize=10M -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath={{hive_log_dir}}/hms_heapdump.hprof -Dhive.log.dir={{hive_log_dir}} -Dhive.log.file=hivemetastore.log"
+  export HADOOP_OPTS="$HADOOP_OPTS -XX:+UnlockExperimentalVMOptions -Xloggc:{{hive_log_dir}}/hivemetastore-gc-%t.log -XX:+UseG1GC -XX:+PrintGCDetails -XX:+PrintGCTimeStamps -XX:+PrintGCCause -XX:+UseGCLogFileRotation -XX:NumberOfGCLogFiles=10 -XX:GCLogFileSize=10M -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath={{hive_log_dir}}/hms_heapdump.hprof -Dhive.log.dir={{hive_log_dir}} -Dhive.log.file=hivemetastore.log"
 
 fi
 
 if [ "$SERVICE" = "hiveserver2" ]; then
 
   export HADOOP_HEAPSIZE={{hive_heapsize}} # Setting for HiveServer2 and Client
-  export HADOOP_OPTS="$HADOOP_OPTS -Xloggc:{{hive_log_dir}}/hiveserver2-gc-%t.log -XX:+UseG1GC -XX:+PrintGCDetails -XX:+PrintGCTimeStamps -XX:+PrintGCCause -XX:+UseGCLogFileRotation -XX:NumberOfGCLogFiles=10 -XX:GCLogFileSize=10M -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath={{hive_log_dir}}/hs2_heapdump.hprof -Dhive.log.dir={{hive_log_dir}} -Dhive.log.file=hiveserver2.log"
+  export HADOOP_OPTS="$HADOOP_OPTS -XX:+UnlockExperimentalVMOptions -Xloggc:{{hive_log_dir}}/hiveserver2-gc-%t.log -XX:+UseG1GC -XX:+PrintGCDetails -XX:+PrintGCTimeStamps -XX:+PrintGCCause -XX:+UseGCLogFileRotation -XX:NumberOfGCLogFiles=10 -XX:GCLogFileSize=10M -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath={{hive_log_dir}}/hs2_heapdump.hprof -Dhive.log.dir={{hive_log_dir}} -Dhive.log.file=hiveserver2.log"
 
 fi
 


### PR DESCRIPTION
## What changes were proposed in this pull request?


Currently, the Hive startup parameters in Ambari do not include the `-XX:+UnlockExperimentalVMOptions` flag. This omission causes errors when using the G1 garbage collector, preventing Hive from starting successfully. To resolve this issue, we propose adding the missing flag to the HADOOP_OPTS environment variable.

Rationale:
1. The `-XX:+UnlockExperimentalVMOptions` flag is required for certain G1 GC optimizations.
2. Without this flag, Hive fails to start when configured to use the G1 garbage collector.
3. This change ensures compatibility with G1 GC and prevents startup failures.


## How was this patch tested?
manual test and CI 
(Please explain how this patch was tested. Ex: unit tests, manual tests)
(If this patch involves UI changes, please attach a screen-shot; otherwise, remove this)

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.