### PR TITLE
AMBARI-26137:Add whitelist setting for host access control

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/configuration/Configuration.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/configuration/Configuration.java
@@ -706,6 +706,15 @@ public class Configuration {
       "security.server.disabled.protocols", "");
 
   /**
+   * The list of hosts which will be allowed to access Ambari server.
+   */
+  @Markdown(
+      description = "The list of hosts which will be allowed to access this server.",
+      examples = { "192.168.0.118-168,192.168.1.5" })
+  public static final ConfigurationProperty<String> SRVR_ACCESS_WHITELIST = new ConfigurationProperty<>(
+      "security.server.access.whitelist", "");
+
+  /**
    * The location on the Ambari Server where all resources exist, including common services, stacks, and scripts.
    */
   @Markdown(description = "The location on the Ambari Server where all resources exist, including common services, stacks, and scripts.")
@@ -2899,6 +2908,7 @@ public class Configuration {
     configsMap.put(SRVR_CRT_PASS_LEN.getKey(), getProperty(SRVR_CRT_PASS_LEN));
     configsMap.put(SRVR_DISABLED_CIPHERS.getKey(), getProperty(SRVR_DISABLED_CIPHERS));
     configsMap.put(SRVR_DISABLED_PROTOCOLS.getKey(), getProperty(SRVR_DISABLED_PROTOCOLS));
+    configsMap.put(SRVR_ACCESS_WHITELIST.getKey(), getProperty(SRVR_ACCESS_WHITELIST));
 
     configsMap.put(CLIENT_API_SSL_KSTR_DIR_NAME.getKey(),
         properties.getProperty(CLIENT_API_SSL_KSTR_DIR_NAME.getKey(),
@@ -4338,6 +4348,11 @@ public class Configuration {
   public String getSrvrDisabledProtocols() {
     String disabledProtocols = getProperty(SRVR_DISABLED_PROTOCOLS);
     return disabledProtocols.trim();
+  }
+
+  public String getSrvrAccessWhiteList() {
+    String whiteLists = getProperty(SRVR_ACCESS_WHITELIST);
+    return whiteLists.trim();
   }
 
   public int getOneWayAuthPort() {

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/AmbariServer.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/AmbariServer.java
@@ -25,6 +25,7 @@ import java.net.Authenticator;
 import java.net.BindException;
 import java.net.PasswordAuthentication;
 import java.net.URL;
+import java.util.Arrays;
 import java.util.EnumSet;
 import java.util.Enumeration;
 import java.util.Map;
@@ -140,6 +141,7 @@ import org.eclipse.jetty.server.ServerConnector;
 import org.eclipse.jetty.server.SessionIdManager;
 import org.eclipse.jetty.server.SslConnectionFactory;
 import org.eclipse.jetty.server.handler.HandlerCollection;
+import org.eclipse.jetty.server.handler.InetAccessHandler;
 import org.eclipse.jetty.server.handler.RequestLogHandler;
 import org.eclipse.jetty.server.handler.gzip.GzipHandler;
 import org.eclipse.jetty.server.session.DefaultSessionIdManager;
@@ -485,6 +487,16 @@ public class AmbariServer {
       }
 
       server.setHandler(handlerList);
+
+      String srvrAccessWhiteList = configs.getSrvrAccessWhiteList();
+      if (!srvrAccessWhiteList.isEmpty())
+      {
+        String[] whiteListHosts = srvrAccessWhiteList.split(",");
+        InetAccessHandler inetAccessHandler = new InetAccessHandler();
+        Arrays.asList(whiteListHosts).forEach(host -> inetAccessHandler.include(host.trim()));
+        inetAccessHandler.setHandler(server.getHandler());
+        server.setHandler(inetAccessHandler);
+      }
 
       ServletHolder agent = new ServletHolder(ServletContainer.class);
       agent.setInitParameter("com.sun.jersey.config.property.resourceConfigClass",


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add a whitelist configuration setting to control which host will be allowed to access Ambari server.

## How was this patch tested?

1. Add a comma-separated whitelist setting(security.server.access.whitelist) in ambari.properties configuration file. 
   Supported values are IP、hostname or IP range as following. 
   host1,192.168.0.118-168,192.168.1.5
2. Restart Ambari server
3. You can try to access Ambari server. The configured hosts can access succeed, and others are forbidden.