### PR TITLE
[AMBARI-24140] HBASE SHELL : Excess Zookeeper and Hadoop logging issue

### DIFF
--- a/ambari-server/src/main/resources/common-services/AMBARI_METRICS/3.0.0/configuration/ams-hbase-log4j.xml
+++ b/ambari-server/src/main/resources/common-services/AMBARI_METRICS/3.0.0/configuration/ams-hbase-log4j.xml
@@ -158,9 +158,9 @@ log4j.appender.console.layout.ConversionPattern=%d{ISO8601} %-5p [%t] %c{2}: %m%
 
 # Custom Logging levels
 
-log4j.logger.org.apache.zookeeper=INFO
+log4j.logger.org.apache.zookeeper=ERROR
 #log4j.logger.org.apache.hadoop.fs.FSNamesystem=DEBUG
-log4j.logger.org.apache.hadoop.hbase=INFO
+log4j.logger.org.apache.hadoop.hbase=ERROR
 # Make these two classes INFO-level. Make them DEBUG to see more zk debug.
 log4j.logger.org.apache.hadoop.hbase.zookeeper.ZKUtil=INFO
 log4j.logger.org.apache.hadoop.hbase.zookeeper.ZooKeeperWatcher=INFO

--- a/ambari-server/src/main/resources/stacks/BIGTOP/3.2.0/services/HBASE/configuration/hbase-log4j.xml
+++ b/ambari-server/src/main/resources/stacks/BIGTOP/3.2.0/services/HBASE/configuration/hbase-log4j.xml
@@ -158,9 +158,9 @@ log4j.appender.console.layout.ConversionPattern=%d{ISO8601} %-5p [%t] %c{2}: %m%
 
 # Custom Logging levels
 
-log4j.logger.org.apache.zookeeper=INFO
+log4j.logger.org.apache.zookeeper=ERROR
 #log4j.logger.org.apache.hadoop.fs.FSNamesystem=DEBUG
-log4j.logger.org.apache.hadoop.hbase=INFO
+log4j.logger.org.apache.hadoop.hbase=ERROR
 # Make these two classes INFO-level. Make them DEBUG to see more zk debug.
 log4j.logger.org.apache.hadoop.hbase.zookeeper.ZKUtil=INFO
 log4j.logger.org.apache.hadoop.hbase.zookeeper.ZooKeeperWatcher=INFO

--- a/ambari-server/src/main/resources/stacks/BIGTOP/3.2.0/services/YARN/configuration/yarn-hbase-log4j.xml
+++ b/ambari-server/src/main/resources/stacks/BIGTOP/3.2.0/services/YARN/configuration/yarn-hbase-log4j.xml
@@ -158,9 +158,9 @@
 
             # Custom Logging levels
 
-            log4j.logger.org.apache.zookeeper=INFO
+            log4j.logger.org.apache.zookeeper=ERROR
             #log4j.logger.org.apache.hadoop.fs.FSNamesystem=DEBUG
-            log4j.logger.org.apache.hadoop.hbase=INFO
+            log4j.logger.org.apache.hadoop.hbase=ERROR
             # Make these two classes INFO-level. Make them DEBUG to see more zk debug.
             log4j.logger.org.apache.hadoop.hbase.zookeeper.ZKUtil=INFO
             log4j.logger.org.apache.hadoop.hbase.zookeeper.ZooKeeperWatcher=INFO


### PR DESCRIPTION
### **Issue: Excessive Logging in HBase Shell**

While launching the HBase shell, we encountered excessive logging in the console output. This was primarily due to two specific logging configurations being set to `INFO` mode, which caused a high volume of unnecessary logs, making it difficult for users to focus on important output.

### **Fix: Adjust Logging Levels to `ERROR`**

To address this issue, I have modified the logging configuration for the HBase shell:

- Changed the logging levels for the two problematic configurations from `INFO` to `ERROR`.
- This adjustment ensures that only critical error messages are logged, reducing log noise and improving the overall user experience when interacting with the HBase shell.

### **Impact**

- The fix significantly reduces unnecessary log output, providing a cleaner and more focused console experience.
- No functionality of the HBase shell is impacted; the change only affects logging verbosity.

### **Testing**

- Verified that after the changes, only error-level messages are logged when opening and interacting with the HBase shell.
- Ensured that important error messages are still captured without being overwhelmed by less relevant information.
