### PR TITLE
AMBARI-26139 : Add host and user to the tagsync log's file name

### DIFF
--- a/ambari-server/src/main/resources/stacks/BIGTOP/3.3.0/services/RANGER/properties/tagsync-logback.xml.j2
+++ b/ambari-server/src/main/resources/stacks/BIGTOP/3.3.0/services/RANGER/properties/tagsync-logback.xml.j2
@@ -21,12 +21,12 @@
         <!--See http://logback.qos.ch/manual/appenders.html#RollingFileAppender-->
         <!--and http://logback.qos.ch/manual/appenders.html#TimeBasedRollingPolicy-->
         <!--for further documentation-->
-        <file>{{tagsync_log_dir}}/tagsync.log</file>
+        <file>{{tagsync_log_dir}}/tagsync-${hostname}-${user}.log</file>
         <encoder>
             <pattern>%d{dd MMM yyyy HH:mm:ss} %5p %c{1} [%t] - %L %m%n</pattern>
         </encoder>
         <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
-            <fileNamePattern>{{tagsync_log_dir}}/tagsync.log.%d{yyyy-MM-dd}</fileNamePattern>
+            <fileNamePattern>{{tagsync_log_dir}}/tagsync-${hostname}-${user}.log.%d{yyyy-MM-dd}</fileNamePattern>
             <maxHistory>15</maxHistory>
             <cleanHistoryOnStart>true</cleanHistoryOnStart>
         </rollingPolicy>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add host and user to the tagsync log's file name

## How was this patch tested?

(Please explain how this patch was tested. Ex: unit tests, manual tests)
(If this patch involves UI changes, please attach a screen-shot; otherwise, remove this)

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.