### PR TITLE
AMBARI-26141: Handling module 'status_params' has no attribute ''router_pid_file'

### DIFF
--- a/ambari-server/src/main/resources/stacks/BIGTOP/3.2.0/services/HDFS/package/scripts/status_params.py
+++ b/ambari-server/src/main/resources/stacks/BIGTOP/3.2.0/services/HDFS/package/scripts/status_params.py
@@ -51,6 +51,7 @@ else:
   journalnode_pid_file = format("{hadoop_pid_dir}/hadoop-{hdfs_user}-journalnode.pid")
   zkfc_pid_file = format("{hadoop_pid_dir}/hadoop-{hdfs_user}-zkfc.pid")
   nfsgateway_pid_file = format("{hadoop_pid_dir_prefix}/root/hadoop_privileged_nfs3.pid")
+  router_pid_file = format("{hadoop_pid_dir}/hadoop-{hdfs_user}-dfsrouter.pid")
 
   # Security related/required params
   hostname = config['agentLevelParams']['hostname']


### PR DESCRIPTION

## What changes were proposed in this pull request?

Adding router_pid_file attribute in status_params.py file

## How was this patch tested?
this patch tested in local ambari cluster  during router start, after adding the proposed fix , router able to start.

