### PR TITLE
AMBARI-26144: Handling HS2 failure  - java.lang.NumberFormatException: input string

### DIFF
--- a/ambari-server/src/main/resources/stacks/BIGTOP/3.2.0/services/HIVE/service_advisor.py
+++ b/ambari-server/src/main/resources/stacks/BIGTOP/3.2.0/services/HIVE/service_advisor.py
@@ -257,7 +257,7 @@ class HiveRecommender(service_advisor.ServiceAdvisor):
     cpu_count = 0
     for hostData in hive_server_hosts:
       cpu_count = max(cpu_count, hostData["Hosts"]["cpu_count"])
-    putHiveSiteProperty("hive.compactor.worker.threads", str(max(cpu_count / 8, 1)))
+    putHiveSiteProperty("hive.compactor.worker.threads", str(round(max(cpu_count / 8, 1))))
 
     hiveMetastoreHost = self.getHostWithComponent("HIVE", "HIVE_METASTORE", services, hosts)
     if hiveMetastoreHost is not None and len(hiveMetastoreHost) > 0:


### PR DESCRIPTION
## What changes were proposed in this pull request?

It handles NFE  issue during the HS2 starts in py3 env, and this change also works in py2 env. 

## How was this patch tested?

This Patch was tested in my local cluster with py2 and py3 env, works as expcetd to start the HS2 service.