### PR TITLE
AMBARI-26143 : Fix HiveServer2 Startup Failure Due to Python Division Handling Difference

### DIFF
--- a/ambari-server/src/main/resources/stacks/BIGTOP/3.2.0/services/HIVE/service_advisor.py
+++ b/ambari-server/src/main/resources/stacks/BIGTOP/3.2.0/services/HIVE/service_advisor.py
@@ -257,7 +257,7 @@ class HiveRecommender(service_advisor.ServiceAdvisor):
     cpu_count = 0
     for hostData in hive_server_hosts:
       cpu_count = max(cpu_count, hostData["Hosts"]["cpu_count"])
-    putHiveSiteProperty("hive.compactor.worker.threads", str(max(cpu_count / 8, 1)))
+    putHiveSiteProperty("hive.compactor.worker.threads", str(int(max(cpu_count / 8, 1))))
 
     hiveMetastoreHost = self.getHostWithComponent("HIVE", "HIVE_METASTORE", services, hosts)
     if hiveMetastoreHost is not None and len(hiveMetastoreHost) > 0:


### PR DESCRIPTION
## What changes were proposed in this pull request?

Modified python code to handle division to return int in python3, without which HiveServer2 fails to start

## How was this patch tested?

This patch tested in local ambari cluster, was able to start hive normally with this fix