### PR TITLE
[AMBARI-26149] Fix RockyLinux-8 support

### DIFF
--- a/ambari-common/src/main/python/ambari_commons/os_check.py
+++ b/ambari-common/src/main/python/ambari_commons/os_check.py
@@ -248,7 +248,7 @@ class OSCheck:
       operatingSystem = 'sles'
     elif operatingSystem.startswith('red hat enterprise linux'):
       operatingSystem = 'redhat'
-    elif operatingSystem.startswith('rocky linux'):
+    elif operatingSystem.startswith('rocky'):
       operatingSystem = 'redhat'
     elif operatingSystem.startswith('darwin'):
       operatingSystem = 'mac'


### PR DESCRIPTION
## What changes were proposed in this pull request?

When I install the ambari-server on Rocky Linux 8.10, I found that Ambari Server did not recognize Rocky Linux 8 OS. Then I changed the rocky linux to rocky, the installation went on smoothly.

## How was this patch tested?

![image](https://github.com/user-attachments/assets/f64ce3c5-7781-429c-ba40-c6eb23b7c83e)

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.