### PR TITLE
AMBARI-26183 Fix Redirection Issue of cluster creation flow

### DIFF
--- a/ambari-web/app/routes/installer.js
+++ b/ambari-web/app/routes/installer.js
@@ -42,7 +42,7 @@ module.exports = Em.Route.extend(App.RouterRedirections, {
             if (App.isAuthorized('AMBARI.ADD_DELETE_CLUSTERS')) {
               router.get('mainController').stopPolling();
               Em.run.next(function () {
-                App.clusterStatus.updateFromServer().then(function () {
+                App.clusterStatus.updateFromServer().complete(function () {
                   var currentClusterStatus = App.clusterStatus.get('value');
                   //@TODO: Clean up  following states. Navigation should be done solely via currentStep stored in the localDb and API persist endpoint.
                   //       Actual currentStep value for the installer controller should always remain in sync with localdb and at persist store in the server.


### PR DESCRIPTION
## What changes were proposed in this pull request?
Redirect the user to next page irrespective of the api status of persisting user state. As of now the user persist api is failing which in turn blocks the redirection to required URL.  
![Screenshot 2024-10-16 at 5 00 50 PM](https://github.com/user-attachments/assets/51233671-354e-448c-974e-a8cfaf0f1056)
## How was this patch tested?
The system is setup in local and the change was tested by considering the redirection flows from admin and login page. The change was further tested by trying to hit the intended URL which verified the change.

(Please explain how this patch was tested. Ex: unit tests, manual tests)
Manual testing was performed