### PR TITLE
AMBARI-26186 : Add Java 17 support to getJavaVersion method

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/configuration/Configuration.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/configuration/Configuration.java
@@ -3384,6 +3384,8 @@ public class Configuration {
       return 7;
     } else if (versionStr.startsWith("1.8")) {
       return 8;
+    } else if (versionStr.startsWith("17")) {
+      return 17;
     } else { // Some unsupported java version
       return -1;
     }


### PR DESCRIPTION
## What changes were proposed in this pull request?

AMBARI-26186 : Add Java 17 support to getJavaVersion method

## How was this patch tested?

Took that function snippet out and ran seperatly in jdk17 env and its recognising the java version correctly as follows
```
$ > java JavaVersionCheck
Detected Java Version: 17
```
otherwise it would be like
```
$ > java JavaVersionCheck
Detected Java Version: -1 
```
