### PR TITLE
AMBARI-26194: Ambari host page action button can't work

### DIFF
--- a/ambari-web/app/templates/common/configs/widgets/combo_config_widget.hbs
+++ b/ambari-web/app/templates/common/configs/widgets/combo_config_widget.hbs
@@ -20,7 +20,7 @@
   <div class="input-group">
     <div class="btn-group config-groups-dropdown">
       {{view Em.TextField valueBinding="view.content.value" disabled="disabled" class="form-control"}}
-      <button {{bindAttr class="view.disabled:disabled :btn :btn-default :dropdown-toggle :btn-icon"}} data-toggle="dropdown">
+      <button {{bindAttr class="view.disabled:disabled :btn :btn-default :dropdown-toggle :btn-icon"}} data-bs-toggle="dropdown">
         <span class="caret"></span>
       </button>
       <ul class="dropdown-menu config-groups-dropdown-menu">

--- a/ambari-web/app/templates/main/alerts/manage_alert_notifications_popup.hbs
+++ b/ambari-web/app/templates/main/alerts/manage_alert_notifications_popup.hbs
@@ -38,7 +38,7 @@
               {{bindAttr disabled="view.isRemoveButtonDisabled"}}
               {{action deleteAlertNotification target="controller"}}><i class="glyphicon glyphicon-minus"></i></button>
             <div class="btn-group notification-actions-button dropup">
-              <button class="btn btn-default dropdown-toggle" data-toggle="dropdown">
+              <button class="btn btn-default dropdown-toggle" data-bs-toggle="dropdown">
                 <i class="glyphicon glyphicon-cog"></i>&nbsp;<span class="caret"></span>
               </button>
               <ul class="dropdown-menu">

--- a/ambari-web/app/templates/main/host/details/host_component.hbs
+++ b/ambari-web/app/templates/main/host/details/host_component.hbs
@@ -68,7 +68,7 @@
 <td class="align-center">
   {{#havePermissions "SERVICE.DECOMMISSION_RECOMMISSION"}}
     <div class="dropdown">
-      <a {{bindAttr class=":dropdown-toggle view.isDisabled:disabled"}} data-toggle="dropdown" href="javascript:void(null)">
+      <a {{bindAttr class=":dropdown-toggle view.isDisabled:disabled"}} data-bs-toggle="dropdown" href="javascript:void(null)">
         <i class="glyphicon glyphicon-option-horizontal action-icon"></i>
       </a>
       {{#unless isDisabled}}

--- a/ambari-web/app/views/main/host/details/host_component_view.js
+++ b/ambari-web/app/views/main/host/details/host_component_view.js
@@ -23,6 +23,7 @@ App.HostComponentView = Em.View.extend({
 
   templateName: require('templates/main/host/details/host_component'),
   tagName: 'tr',
+  classNames: ['more-actions'],
 
   /**
    * @type {App.HostComponent}


### PR DESCRIPTION
## What changes were proposed in this pull request?

Change prop 'data-toggle' to 'data-bs-toggle', add class to remove caret.

Before:
<img width="241" alt="image" src="https://github.com/user-attachments/assets/acd6523a-bd8f-4bae-bbe9-b0d6aedef005">

After:
<img width="247" alt="image" src="https://github.com/user-attachments/assets/70dbbb35-f63e-4173-896f-710d52365242">

<img width="352" alt="image" src="https://github.com/user-attachments/assets/3c60ce6c-b270-4823-82f5-23ddf2b935a8">



## How was this patch tested?

Manual test.

```bash
mvn -T 2C -am test -pl ambari-web -Dmaven.artifact.threads=10 -Drat.skip
```

<img width="829" alt="image" src="https://github.com/user-attachments/assets/4478f84f-f4a4-4de9-9d00-066704081424">
