### PR TITLE
AMBARI-26201: Add server link for ZK Admin server

### DIFF
--- a/ambari-server/src/main/resources/stacks/BIGTOP/3.2.0/services/ZOOKEEPER/metainfo.xml
+++ b/ambari-server/src/main/resources/stacks/BIGTOP/3.2.0/services/ZOOKEEPER/metainfo.xml
@@ -70,6 +70,13 @@
         </component>
       </components>
 
+      <quickLinksConfigurations>
+        <quickLinksConfiguration>
+          <fileName>quicklinks.json</fileName>
+          <default>true</default>
+        </quickLinksConfiguration>
+      </quickLinksConfigurations>
+
       <osSpecifics>
         <osSpecific>
           <osFamily>redhat7,redhat8,redhat9,openeuler22</osFamily>

--- a/ambari-server/src/main/resources/stacks/BIGTOP/3.2.0/services/ZOOKEEPER/quicklinks/quicklinks.json
+++ b/ambari-server/src/main/resources/stacks/BIGTOP/3.2.0/services/ZOOKEEPER/quicklinks/quicklinks.json
@@ -1,0 +1,28 @@
+{
+  "name": "default",
+  "description": "default quick links configuration",
+  "configuration": {
+    "protocol":
+    {
+      "type":"http"
+    },
+
+    "links": [
+      {
+        "name": "admin_server",
+        "label": "Admin Server",
+        "component_name": "ZOOKEEPER_SERVER",
+        "url":"%@://%@:%@/commands",
+        "requires_user_name": "false",
+        "port":{
+          "http_property": "admin.serverPort",
+          "http_default_port": "8080",
+          "https_property": "admin.serverPort",
+          "https_default_port": "8443",
+          "regex": "^(\\d+)$",
+          "site": "zoo.cfg"
+        }
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add server link for ZK Admin server in Ambari UI

## How was this patch tested?

Install ZK server, then you can see the admin server links in the right links area.