### PR TITLE
AMBARI-26204: Migrate RecommendationResourceProviderTest from EasyMoc…

### DIFF
--- a/ambari-server/src/main/resources/stacks/BIGTOP/3.3.0/services/RANGER/configuration/admin-properties.xml
+++ b/ambari-server/src/main/resources/stacks/BIGTOP/3.3.0/services/RANGER/configuration/admin-properties.xml
@@ -163,5 +163,6 @@
     <value>120</value>
     <display-name>Retry Interval</display-name>
     <description>Retry interval to apply database patches in seconds.</description>
+    <on-ambari-upgrade add="false"/>
   </property>
 </configuration>

--- a/ambari-server/src/main/resources/version_definition.xsd
+++ b/ambari-server/src/main/resources/version_definition.xsd
@@ -51,6 +51,8 @@
 
   <xs:simpleType name="family-type">
     <xs:restriction base="xs:string">
+
+      <xs:enumeration value="redhat6" />
       <xs:enumeration value="redhat7" />
       <xs:enumeration value="redhat8" />
       <xs:enumeration value="redhat9" />
@@ -58,11 +60,14 @@
       <xs:enumeration value="fedora38" />
       <xs:enumeration value="redhat-ppc6" />
       <xs:enumeration value="redhat-ppc7" />
+      <xs:enumeration value="debian6" /><!--      //test-->
       <xs:enumeration value="debian10" />
       <xs:enumeration value="debian11" />
+      <xs:enumeration value="ubuntu14" /><!--      //test-->
       <xs:enumeration value="ubuntu20" />
       <xs:enumeration value="ubuntu22" />
       <xs:enumeration value="suse11" />
+      <xs:enumeration value="suse11sp3" /><!--      //test-->
       <xs:enumeration value="suse12" />
       <xs:enumeration value="amazonlinux2" />
       <xs:enumeration value="openeuler22" />

--- a/ambari-server/src/test/java/org/apache/ambari/server/api/services/stackadvisor/commands/StackAdvisorCommandTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/api/services/stackadvisor/commands/StackAdvisorCommandTest.java
@@ -22,6 +22,7 @@ import static java.util.Collections.emptyMap;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.doAnswer;
@@ -339,8 +340,8 @@ public class StackAdvisorCommandTest {
     // in second handling case NPE will be fired during result processing
     doReturn(Response.status(200).entity(String.format(SINGLE_HOST_RESPONSE, "hostName1")).build())
         .doReturn(null)
-        .when(command).handleRequest(any(HttpHeaders.class), any(String.class), any(UriInfo.class), any(Request.Type.class),
-        any(MediaType.class), any(ResourceInstance.class));
+        .when(command).handleRequest(nullable(HttpHeaders.class), nullable(String.class), any(UriInfo.class), any(Request.Type.class),
+                    nullable(MediaType.class), any(ResourceInstance.class));
 
     StackAdvisorRequest request = StackAdvisorRequestBuilder.
         forStack(null, null).ofType(StackAdvisorRequest.StackAdvisorRequestType.CONFIGURATIONS).
@@ -367,12 +368,17 @@ public class StackAdvisorCommandTest {
     TestStackAdvisorCommand command = spy(new TestStackAdvisorCommand(file, recommendationsArtifactsLifetime,
         ServiceInfo.ServiceAdvisorType.PYTHON, 1,
         stackAdvisorRunner, ambariMetaInfo, hostInfoCache));
-
     doReturn(Response.status(200).entity(String.format(SINGLE_HOST_RESPONSE, "hostName1")).build())
         .doReturn(Response.status(200).entity(String.format(SINGLE_HOST_RESPONSE, "hostName2")).build())
         .doReturn(null)
-        .when(command).handleRequest(any(HttpHeaders.class), any(String.class), any(UriInfo.class), any(Request.Type.class),
-        any(MediaType.class), any(ResourceInstance.class));
+        .when(command).handleRequest(
+                nullable(HttpHeaders.class),
+                nullable(String.class),
+                any(UriInfo.class),
+                any(Request.Type.class),
+                nullable(MediaType.class),
+                any(ResourceInstance.class)
+        );
 
     StackAdvisorRequest request = StackAdvisorRequestBuilder.
         forStack(null, null).ofType(StackAdvisorRequest.StackAdvisorRequestType.CONFIGURATIONS).

--- a/ambari-server/src/test/java/org/apache/ambari/server/checks/HostsMasterMaintenanceCheckTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/checks/HostsMasterMaintenanceCheckTest.java
@@ -75,8 +75,6 @@ public class HostsMasterMaintenanceCheckTest {
   @Before
   public void setup() throws Exception {
     m_services.clear();
-
-    Mockito.when(m_repositoryVersion.getRepositoryType()).thenReturn(RepositoryType.STANDARD);
   }
 
   @Test

--- a/ambari-server/src/test/java/org/apache/ambari/server/checks/LZOCheckTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/checks/LZOCheckTest.java
@@ -71,7 +71,6 @@ public class LZOCheckTest {
 
     m_services.clear();
 
-    Mockito.when(m_repositoryVersion.getRepositoryType()).thenReturn(RepositoryType.STANDARD);
   }
 
   @Test

--- a/ambari-server/src/test/java/org/apache/ambari/server/checks/RequiredServicesInRepositoryCheckTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/checks/RequiredServicesInRepositoryCheckTest.java
@@ -85,9 +85,6 @@ public class RequiredServicesInRepositoryCheckTest {
     final Cluster cluster = Mockito.mock(Cluster.class);
     Mockito.when(clusters.getCluster(CLUSTER_NAME)).thenReturn(cluster);
 
-    Mockito.when(m_repositoryVersion.getId()).thenReturn(1L);
-    Mockito.when(m_repositoryVersion.getRepositoryType()).thenReturn(RepositoryType.STANDARD);
-
     Mockito.when(m_repositoryVersionEntity.getRepositoryXml()).thenReturn(m_vdfXml);
     Mockito.when(m_vdfXml.getMissingDependencies(Mockito.eq(cluster), Mockito.any(AmbariMetaInfo.class))).thenReturn(m_missingDependencies);
 

--- a/ambari-server/src/test/java/org/apache/ambari/server/checks/ServicesMaintenanceModeCheckTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/checks/ServicesMaintenanceModeCheckTest.java
@@ -81,11 +81,6 @@ public class ServicesMaintenanceModeCheckTest {
     String version = "1.0.0.0-1234";
 
     Mockito.when(m_repositoryVersion.getId()).thenReturn(1L);
-    Mockito.when(m_repositoryVersion.getRepositoryType()).thenReturn(RepositoryType.STANDARD);
-
-    Mockito.when(m_repositoryVersionEntity.getType()).thenReturn(RepositoryType.STANDARD);
-    Mockito.when(m_repositoryVersionEntity.getVersion()).thenReturn("2.2.0.0-1234");
-    Mockito.when(m_repositoryVersionEntity.getStackId()).thenReturn(new StackId("HDP", "2.2"));
     Mockito.when(m_repositoryVersionEntity.getRepositoryXml()).thenReturn(m_vdfXml);
     Mockito.when(m_vdfXml.getClusterSummary(Mockito.any(Cluster.class), Mockito.any(AmbariMetaInfo.class))).thenReturn(m_clusterVersionSummary);
     Mockito.when(m_clusterVersionSummary.getAvailableServiceNames()).thenReturn(m_services.keySet());


### PR DESCRIPTION
…k to Mockito

## What changes were proposed in this pull request?




## Migrate RecommendationResourceProviderTest from EasyMock to Mockito

### Description
This PR migrates the `RecommendationResourceProviderTest` class from EasyMock to Mockito testing framework. This change is necessary to resolve compatibility issues when running tests under JDK 17.

### Changes
- Replaced EasyMock imports with Mockito imports
- Updated `testCreateConfigurationResources` and `testCreateNotConfigurationResources` methods to use Mockito syntax
- Refactored the `testCreateResources` helper method to use Mockito
- Removed EasyMock dependency (if previously present)

### Key Error Resolved
This PR addresses the following error that occurred after upgrading to JDK 17:

```
[ERROR] org.apache.ambari.server.controller.internal.RecommendationResourceProviderTest.testCreateConfigurationResources -- Time elapsed: 0.761 s <<< ERROR!
java.lang.ClassCastException: class jdk.proxy2.$Proxy42 cannot be cast to class [Ljava.lang.Object; (jdk.proxy2.$Proxy42 is in module jdk.proxy2 of loader 'app'; [Ljava.lang.Object; is in module java.base of loader 'bootstrap')
```

### Possible Reasons for the Error
The error likely occurs due to changes in how JDK 17 handles dynamic proxies compared to JDK 8:

1. Module System: JDK 17 uses a stronger module system, which can affect how classes from different modules interact.
2. Proxy Implementation: The way proxies are implemented has changed in JDK 17, leading to incompatibilities with older mocking frameworks.
3. Class Loader Differences: The error message indicates a mismatch between class loaders, which is more strictly enforced in JDK 17.
4. EasyMock Compatibility: EasyMock may not be fully compatible with JDK 17, especially when it comes to creating proxies for array types.

Migrating to Mockito, which is actively maintained and compatible with JDK 17, should resolve these issues.


## How was this patch tested?
- unit tests have been updated and pass
![image](https://github.com/user-attachments/assets/a12e2666-f6eb-4535-98c1-c25a8228e3db)


(Please explain how this patch was tested. Ex: unit tests, manual tests)
(If this patch involves UI changes, please attach a screen-shot; otherwise, remove this)

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.