### PR TITLE
Ambari-26211: Fix TaskActionScheduler test failed

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -117,7 +117,7 @@ pipeline {
         }
         stage('Ambari Server JTests') {
             steps {
-                sh 'mvn -am test -pl ambari-server -DskipPythonTests -Dmaven.test.failure.ignore -Dmaven.artifact.threads=10 -Drat.skip'
+                sh 'mvn -am test -pl ambari-server -DskipPythonTests  -Dmaven.artifact.threads=10 -Drat.skip'
             }
         }
     }

--- a/ambari-server/src/test/java/org/apache/ambari/server/actionmanager/TestActionScheduler.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/actionmanager/TestActionScheduler.java
@@ -24,6 +24,7 @@ import static org.easymock.EasyMock.replay;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyBoolean;
 import static org.mockito.Matchers.anyCollectionOf;
@@ -426,7 +427,7 @@ public class TestActionScheduler {
     ServiceComponentHost sch = mock(ServiceComponentHost.class);
     UnitOfWork unitOfWork = mock(UnitOfWork.class);
     AgentCommandsPublisher agentCommandsPublisher = mock(AgentCommandsPublisher.class);
-    when(fsm.getCluster(anyString())).thenReturn(oneClusterMock);
+    when(fsm.getCluster(nullable(String.class))).thenReturn(oneClusterMock);
     when(oneClusterMock.getService(anyString())).thenReturn(serviceObj);
     when(serviceObj.getServiceComponent(anyString())).thenReturn(scomp);
     when(scomp.getServiceComponentHost(anyString())).thenReturn(sch);
@@ -475,7 +476,7 @@ public class TestActionScheduler {
         command.setStatus(HostRoleStatus.TIMEDOUT);
         return null;
       }
-    }).when(db).timeoutHostRole(anyString(), anyLong(), anyLong(), anyString(), anyBoolean(), eq(false));
+    }).when(db).timeoutHostRole(nullable(String.class), anyLong(), anyLong(), anyString(), anyBoolean(), eq(false));
 
 
     //Small action timeout to test rescheduling
@@ -526,7 +527,7 @@ public class TestActionScheduler {
     ServiceComponentHost sch = mock(ServiceComponentHost.class);
     UnitOfWork unitOfWork = mock(UnitOfWork.class);
     AgentCommandsPublisher agentCommandsPublisher = mock(AgentCommandsPublisher.class);
-    when(fsm.getCluster(anyString())).thenReturn(oneClusterMock);
+    when(fsm.getCluster(nullable(String.class))).thenReturn(oneClusterMock);
     when(oneClusterMock.getService(anyString())).thenReturn(serviceObj);
     when(serviceObj.getServiceComponent(anyString())).thenReturn(scomp);
     when(scomp.getServiceComponentHost(anyString())).thenReturn(sch);
@@ -566,7 +567,7 @@ public class TestActionScheduler {
         command.setStatus(HostRoleStatus.ABORTED);
         return null;
       }
-    }).when(db).timeoutHostRole(anyString(), anyLong(), anyLong(), anyString(), anyBoolean(), eq(true));
+    }).when(db).timeoutHostRole(nullable(String.class), anyLong(), anyLong(), anyString(), anyBoolean(), eq(true));
 
     //Small action timeout to test rescheduling
     AmbariEventPublisher aep = EasyMock.createNiceMock(AmbariEventPublisher.class);
@@ -624,7 +625,7 @@ public class TestActionScheduler {
 
     UnitOfWork unitOfWork = mock(UnitOfWork.class);
     AgentCommandsPublisher agentCommandsPublisher = mock(AgentCommandsPublisher.class);
-    when(fsm.getCluster(anyString())).thenReturn(oneClusterMock);
+    when(fsm.getCluster(nullable(String.class))).thenReturn(oneClusterMock);
     when(oneClusterMock.getService(anyString())).thenReturn(serviceObj);
     when(serviceObj.getServiceComponent(anyString())).thenReturn(scomp);
     when(serviceObj.getCluster()).thenReturn(oneClusterMock);
@@ -657,7 +658,7 @@ public class TestActionScheduler {
         command.setStatus(HostRoleStatus.ABORTED);
         return null;
       }
-    }).when(db).timeoutHostRole(anyString(), anyLong(), anyLong(), anyString(), anyBoolean(), eq(true));
+    }).when(db).timeoutHostRole(nullable(String.class), anyLong(), anyLong(), anyString(), anyBoolean(), eq(true));
 
     doAnswer(new Answer<Collection<HostRoleCommandEntity>>() {
       @Override
@@ -782,7 +783,7 @@ public class TestActionScheduler {
         command.setStatus(HostRoleStatus.valueOf(commandReport.getStatus()));
         return null;
       }
-    }).when(db).updateHostRoleState(anyString(), anyLong(), anyLong(), anyString(), any(CommandReport.class));
+    }).when(db).updateHostRoleState(nullable(String.class), anyLong(), anyLong(), anyString(), any(CommandReport.class));
 
     doAnswer(new Answer<HostRoleCommand>() {
       @Override
@@ -944,7 +945,7 @@ public class TestActionScheduler {
         command.setStatus(HostRoleStatus.valueOf(commandReport.getStatus()));
         return null;
       }
-    }).when(db).updateHostRoleState(anyString(), anyLong(), anyLong(), anyString(), any(CommandReport.class));
+    }).when(db).updateHostRoleState(nullable(String.class), anyLong(), anyLong(), anyString(), any(CommandReport.class));
 
     doAnswer(new Answer<HostRoleCommand>() {
       @Override
@@ -1160,7 +1161,7 @@ public class TestActionScheduler {
         command.setStatus(HostRoleStatus.valueOf(commandReport.getStatus()));
         return null;
       }
-    }).when(db).updateHostRoleState(anyString(), anyLong(), anyLong(), anyString(), any(CommandReport.class));
+    }).when(db).updateHostRoleState(nullable(String.class), anyLong(), anyLong(), anyString(), any(CommandReport.class));
 
     doAnswer(new Answer<HostRoleCommand>() {
       @Override
@@ -2426,7 +2427,7 @@ public class TestActionScheduler {
         command.setStatus(HostRoleStatus.valueOf(commandReport.getStatus()));
         return null;
       }
-    }).when(db).updateHostRoleState(anyString(), anyLong(), anyLong(), anyString(), any(CommandReport.class));
+    }).when(db).updateHostRoleState(nullable(String.class), anyLong(), anyLong(), anyString(), any(CommandReport.class));
 
     doAnswer(new Answer<List<HostRoleCommand>>() {
       @Override

--- a/ambari-server/src/test/java/org/apache/ambari/server/checks/HostsRepositoryVersionCheckTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/checks/HostsRepositoryVersionCheckTest.java
@@ -53,6 +53,8 @@ import org.mockito.runners.MockitoJUnitRunner;
 
 import com.google.inject.Provider;
 
+import static org.mockito.ArgumentMatchers.nullable;
+
 /**
  * Unit tests for HostsRepositoryVersionCheck
  *
@@ -185,7 +187,7 @@ public class HostsRepositoryVersionCheckTest {
     Mockito.when(
         hostVersionDAO.findByClusterStackVersionAndHost(Mockito.anyString(),
             Mockito.any(StackId.class), Mockito.anyString(),
-            Mockito.anyString())).thenReturn(hostVersion);
+            nullable(String.class))).thenReturn(hostVersion);
 
     check = hostsRepositoryVersionCheck.perform(request);
     Assert.assertEquals(UpgradeCheckStatus.PASS, check.getStatus());

--- a/ambari-server/src/test/java/org/apache/ambari/server/checks/ServicesUpCheckTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/checks/ServicesUpCheckTest.java
@@ -61,6 +61,8 @@ import org.powermock.modules.junit4.PowerMockRunner;
 
 import com.google.inject.Provider;
 
+import static org.mockito.ArgumentMatchers.nullable;
+
 
 /**
  * Unit tests for ServicesUpCheck
@@ -191,7 +193,7 @@ public class ServicesUpCheckTest {
     Mockito.when(cluster.getService("AMBARI_METRICS")).thenReturn(amsService);
 
     Mockito.when(ambariMetaInfo.getComponent(Mockito.anyString(), Mockito.anyString(),
-        Mockito.anyString(), Mockito.anyString())).thenAnswer(new Answer<ComponentInfo>() {
+            nullable(String.class), Mockito.anyString())).thenAnswer(new Answer<ComponentInfo>() {
       @Override
       public ComponentInfo answer(InvocationOnMock invocation) throws Throwable {
         ComponentInfo anyInfo = Mockito.mock(ComponentInfo.class);

--- a/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/BlueprintConfigurationProcessorTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/BlueprintConfigurationProcessorTest.java
@@ -91,6 +91,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.powermock.api.easymock.PowerMock;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
@@ -107,6 +108,7 @@ import com.google.common.collect.Sets;
  */
 @RunWith(PowerMockRunner.class)
 @PrepareForTest(AmbariServer.class)
+@PowerMockIgnore({"org.apache.logging.log4j.*","org.slf4j.*"})
 public class BlueprintConfigurationProcessorTest extends EasyMockSupport {
 
   private static final Configuration EMPTY_CONFIG = new Configuration(emptyMap(), emptyMap());

--- a/ambari-server/src/test/java/org/apache/ambari/server/security/ldap/AmbariLdapDataPopulatorTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/security/ldap/AmbariLdapDataPopulatorTest.java
@@ -69,6 +69,7 @@ import org.easymock.IAnswer;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.powermock.api.easymock.PowerMock;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 import org.springframework.ldap.control.PagedResultsCookie;
@@ -86,6 +87,7 @@ import com.google.inject.Provider;
 
 @RunWith(PowerMockRunner.class)
 @PrepareForTest(AmbariLdapUtils.class)
+@PowerMockIgnore({"org.apache.logging.log4j.*","org.slf4j.*"})
 public class AmbariLdapDataPopulatorTest {
   public static class AmbariLdapDataPopulatorTestInstance extends TestAmbariLdapDataPopulator {
     public AmbariLdapDataPopulatorTestInstance(Provider<AmbariLdapConfiguration> configurationProvider, Users users) {

--- a/ambari-server/src/test/java/org/apache/ambari/server/stack/upgrade/orchestrate/UpgradeHelperTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/stack/upgrade/orchestrate/UpgradeHelperTest.java
@@ -2722,33 +2722,6 @@ public class UpgradeHelperTest extends EasyMockSupport {
     assertEquals("three-changed", expectedBazType.get("3"));
   }
 
-
-  private static class ClusterEnvCaptureWrapper {
-    private final Capture<Map<String, Map<String, String>>> capture;
-    private final Map<String, String> clusterEnvMap;
-
-    public ClusterEnvCaptureWrapper(Map<String, String> clusterEnvMap) {
-      this.capture = Capture.newInstance();
-      this.clusterEnvMap = clusterEnvMap;
-    }
-
-    public Capture<Map<String, Map<String, String>>> getCapture() {
-      return capture;
-    }
-
-    public void handleCapturedValue() {
-      Map<String, Map<String, String>> value = capture.getValue();
-      System.out.println("Captured value: " + value); // Debug print
-
-      if (value.containsKey("cluster-env")) {
-        clusterEnvMap.putAll(value.get("cluster-env"));
-      }
-      System.out.println("ClusterEnvMap after handling: " + clusterEnvMap); // Debug print
-
-    }
-  }
-
-
   @Test
   public void testMergeConfigurationsWithClusterEnv() throws Exception {
     Cluster cluster = makeCluster(true);

--- a/ambari-server/src/test/java/org/apache/ambari/server/stack/upgrade/orchestrate/UpgradeHelperTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/stack/upgrade/orchestrate/UpgradeHelperTest.java
@@ -122,15 +122,13 @@ import org.apache.ambari.spi.RepositoryType;
 import org.apache.ambari.spi.upgrade.OrchestrationOptions;
 import org.apache.ambari.spi.upgrade.UpgradeType;
 import org.apache.commons.io.FileUtils;
-import org.easymock.Capture;
-import org.easymock.EasyMock;
-import org.easymock.EasyMockSupport;
-import org.easymock.IAnswer;
+import org.easymock.*;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
+import org.mockito.ArgumentMatcher;
 import org.springframework.security.core.context.SecurityContextHolder;
 
 import com.google.common.collect.ImmutableMap;
@@ -2549,7 +2547,6 @@ public class UpgradeHelperTest extends EasyMockSupport {
     }
   }
 
-
   /**
    * Tests merging configurations between existing and new stack values on
    * upgrade.
@@ -2725,6 +2722,33 @@ public class UpgradeHelperTest extends EasyMockSupport {
     assertEquals("three-changed", expectedBazType.get("3"));
   }
 
+
+  private static class ClusterEnvCaptureWrapper {
+    private final Capture<Map<String, Map<String, String>>> capture;
+    private final Map<String, String> clusterEnvMap;
+
+    public ClusterEnvCaptureWrapper(Map<String, String> clusterEnvMap) {
+      this.capture = Capture.newInstance();
+      this.clusterEnvMap = clusterEnvMap;
+    }
+
+    public Capture<Map<String, Map<String, String>>> getCapture() {
+      return capture;
+    }
+
+    public void handleCapturedValue() {
+      Map<String, Map<String, String>> value = capture.getValue();
+      System.out.println("Captured value: " + value); // Debug print
+
+      if (value.containsKey("cluster-env")) {
+        clusterEnvMap.putAll(value.get("cluster-env"));
+      }
+      System.out.println("ClusterEnvMap after handling: " + clusterEnvMap); // Debug print
+
+    }
+  }
+
+
   @Test
   public void testMergeConfigurationsWithClusterEnv() throws Exception {
     Cluster cluster = makeCluster(true);
@@ -2735,12 +2759,12 @@ public class UpgradeHelperTest extends EasyMockSupport {
     ConfigFactory cf = injector.getInstance(ConfigFactory.class);
 
     Config clusterEnv = cf.createNew(cluster, "cluster-env", "version1",
-        ImmutableMap.<String, String>builder().put("a", "b").build(),
-        Collections.emptyMap());
+            ImmutableMap.<String, String>builder().put("a", "b").build(),
+            Collections.emptyMap());
 
     Config zooCfg = cf.createNew(cluster, "zoo.cfg", "version1",
-        ImmutableMap.<String, String>builder().put("c", "d").build(),
-        Collections.emptyMap());
+            ImmutableMap.<String, String>builder().put("c", "d").build(),
+            Collections.emptyMap());
 
     cluster.addDesiredConfig("admin", Sets.newHashSet(clusterEnv, zooCfg));
 
@@ -2748,25 +2772,8 @@ public class UpgradeHelperTest extends EasyMockSupport {
     stackMap.put("cluster-env", new HashMap<>());
     stackMap.put("hive-site", new HashMap<>());
 
-    final Map<String, String> clusterEnvMap = new HashMap<>();
-
-    Capture<Cluster> captureCluster = Capture.newInstance();
-    Capture<StackId> captureStackId = Capture.newInstance();
-    Capture<AmbariManagementController> captureAmc = Capture.newInstance();
-
-    Capture<Map<String, Map<String, String>>> cap = Capture.newInstance();
-
-    /*Capture<Map<String, Map<String, String>>> cap = new Capture<Map<String, Map<String, String>>>() {
-      @Override
-      public void setValue(Map<String, Map<String, String>> value) {
-        if (value.containsKey("cluster-env")) {
-          clusterEnvMap.putAll(value.get("cluster-env"));
-        }
-      }
-    };*/
-
-    Capture<String> captureUsername = Capture.newInstance();
-    Capture<String> captureNote = Capture.newInstance();
+    final ClusterEnvWrapper clusterEnvWrapper = new ClusterEnvWrapper();
+    System.out.println("Initial clusterEnvMap: " + clusterEnvWrapper.getClusterEnvMap()); // Debug print
 
     EasyMock.reset(m_configHelper);
     expect(m_configHelper.getDefaultProperties(oldStack, "HIVE")).andReturn(stackMap).atLeastOnce();
@@ -2774,14 +2781,13 @@ public class UpgradeHelperTest extends EasyMockSupport {
     expect(m_configHelper.getDefaultProperties(oldStack, "ZOOKEEPER")).andReturn(stackMap).atLeastOnce();
     expect(m_configHelper.getDefaultProperties(newStack, "ZOOKEEPER")).andReturn(stackMap).atLeastOnce();
     expect(m_configHelper.createConfigTypes(
-        EasyMock.capture(captureCluster),
-        EasyMock.capture(captureStackId),
-        EasyMock.capture(captureAmc),
-        EasyMock.capture(cap),
-
-        EasyMock.capture(captureUsername),
-        EasyMock.capture(captureNote))).andReturn(true);
-
+            EasyMock.anyObject(Cluster.class),
+            EasyMock.anyObject(StackId.class),
+            EasyMock.anyObject(AmbariManagementController.class),
+            eqClusterEnv(clusterEnvWrapper),
+            EasyMock.anyString(),
+            EasyMock.anyString()
+    )).andReturn(true);
     replay(m_configHelper);
 
     RepositoryVersionEntity repoVersionEntity = helper.getOrCreateRepositoryVersion(new StackId("HDP-2.5.0"), "2.5.0-1234");
@@ -2798,13 +2804,52 @@ public class UpgradeHelperTest extends EasyMockSupport {
     UpgradeHelper upgradeHelper = injector.getInstance(UpgradeHelper.class);
     upgradeHelper.updateDesiredRepositoriesAndConfigs(context);
 
-    assertNotNull(clusterEnvMap);
-    assertTrue(clusterEnvMap.containsKey("a"));
+    assertEquals("b",clusterEnvWrapper.getClusterEnvMap().get("a"));
 
+    assertTrue(clusterEnvWrapper.getClusterEnvMap().containsKey("a"));
     // Do stacks cleanup
     stackManagerMock.invalidateCurrentPaths();
     ambariMetaInfo.init();
   }
+
+  // Custom matcher for cluster-env map
+  private static Map<String, Map<String, String>> eqClusterEnv(final ClusterEnvWrapper wrapper) {
+    EasyMock.reportMatcher(new IArgumentMatcher() {
+      @Override
+      public boolean matches(Object argument) {
+        if (argument instanceof Map) {
+          Map<String, Map<String, String>> map = (Map<String, Map<String, String>>) argument;
+          if (map.containsKey("cluster-env")) {
+            wrapper.updateClusterEnvMap(map.get("cluster-env"));
+            return true;
+          }
+        }
+        return false;
+      }
+
+      @Override
+      public void appendTo(StringBuffer buffer) {
+        buffer.append("eqClusterEnv(");
+        buffer.append(wrapper);
+        buffer.append(")");
+      }
+    });
+    return null;
+  }
+
+  // Custom wrapper class to hold and update clusterEnvMap
+  private static class ClusterEnvWrapper {
+    private final Map<String, String> clusterEnvMap = new HashMap<>();
+
+    public void updateClusterEnvMap(Map<String, String> newMap) {
+      clusterEnvMap.putAll(newMap);
+    }
+
+    public Map<String, String> getClusterEnvMap() {
+      return clusterEnvMap;
+    }
+  }
+
 
   @Test
   public void testSequentialServiceChecks() throws Exception {


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR primarily addresses issues arising from the upgrade from JDK 8 to JDK 17, specifically related to Mockito's stricter 'when' matching, which caused some mocks to fail. Through debugging and comparing with JDK 8 code, nullable handling was implemented for potentially null values. Secondly, the upgrade made the Capture constructor private, preventing the creation of anonymous classes that override its setValue method through 'new Capture()'. The tests were rewritten to maintain the original test logic without changing the underlying implementation.

## How was this patch tested?
 unit tests, manual tests


Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.