### PR TITLE
AMBARI-26220: Fix ConfigureClusterTaskTest & AsyncCallableServiceTest error

### DIFF
--- a/ambari-server/src/test/java/org/apache/ambari/server/topology/AsyncCallableServiceTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/topology/AsyncCallableServiceTest.java
@@ -152,7 +152,7 @@ public class AsyncCallableServiceTest extends EasyMockSupport {
   @Test
   public void testCallableServiceShouldRetryTaskExecutionTillTimeoutExceededWhenTaskThrowsException() throws Exception {
     // GIVEN
-    expect(taskMock.call()).andThrow(new IllegalStateException("****************** TESTING ****************")).times(2, 3);
+    expect(taskMock.call()).andThrow(new IllegalStateException("****************** TESTING ****************")).times(2, 20);
     onErrorMock.accept(anyObject(IllegalStateException.class));
     replayAll();
     asyncCallableService = new AsyncCallableService<>(taskMock, TIMEOUT, RETRY_DELAY,  "test", onErrorMock);

--- a/ambari-server/src/test/java/org/apache/ambari/server/topology/ConfigureClusterTaskTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/topology/ConfigureClusterTaskTest.java
@@ -90,6 +90,9 @@ public class ConfigureClusterTaskTest extends EasyMockSupport {
     // GIVEN
     expect(clusterConfigurationRequest.getRequiredHostGroups()).andReturn(Collections.emptyList());
     expect(clusterTopology.getHostGroupInfo()).andReturn(Collections.emptyMap());
+    expect(clusterTopology.getClusterId()).andReturn(1L).anyTimes();
+    expect(clusterTopology.getAmbariContext()).andReturn(ambariContext);
+    expect(ambariContext.getClusterName(1L)).andReturn("testCluster");
     clusterConfigurationRequest.process();
     replayAll();
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

fix ConfigureClusterTaskTest Unexpected method calls: ClusterConfigurationRequest.getRequiredHostGroups()
fix AsyncCallableServiceTest Unexpected method calls: Callable.call() error

## How was this patch tested?

run ConfigureClusterTaskTest & AsyncCallableServiceTest

ConfigureClusterTaskTest

![image](https://github.com/user-attachments/assets/dae506a3-4e6a-4e2c-ab9a-1df74c087db9)

AsyncCallableServiceTest

![image](https://github.com/user-attachments/assets/5499a2cd-622e-40e8-9552-ad61b7cd86e2)
