### PR TITLE
AMBARI-26224 Wrong order of imports for WidgetResourceProvider.java

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/WidgetResourceProvider.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/WidgetResourceProvider.java
@@ -56,10 +56,10 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
-import com.google.gson.JsonSerializer;
 import com.google.gson.JsonElement;
-import com.google.gson.JsonSerializationContext;
 import com.google.gson.JsonPrimitive;
+import com.google.gson.JsonSerializationContext;
+import com.google.gson.JsonSerializer;
 import com.google.inject.Inject;
 
 /**


### PR DESCRIPTION
## What changes were proposed in this pull request?

Change the order of imports for WidgetResourceProvider.java, resolving the issue of import order check during compilation.

Details see: [AMBARI-26224](https://issues.apache.org/jira/browse/AMBARI-26224)

## How was this patch tested?

Applying this changes, we can compile Ambari on centos7 successfully by the follow comand.
```shell
mvn clean install rpm:rpm -DskipTests -Drat.skip=true
```

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.