### PR TITLE
AMBARI-26232: There will be failure when executing shell.py and wrong order of imports for WidgetResourceProvider.java

### DIFF
--- a/ambari-common/src/main/python/resource_management/core/shell.py
+++ b/ambari-common/src/main/python/resource_management/core/shell.py
@@ -105,7 +105,7 @@ def checked_call(command, quiet=False, logoutput=None, stdout=subprocess.PIPE,st
 @log_function_call
 def call(command, quiet=False, logoutput=None, stdout=subprocess.PIPE,stderr=subprocess.STDOUT,
          cwd=None, env=None, preexec_fn=preexec_fn, user=None, wait_for_finish=True, timeout=None, on_timeout=None,
-         path=None, sudo=False, on_new_line=None, tries=1, try_sleep=0, timeout_kill_strategy=TerminateStrategy.TERMINATE_PARENT, returns=[0]):
+         path=None, sudo=False, on_new_line=None, tries=1, try_sleep=0, timeout_kill_strategy=TerminateStrategy.TERMINATE_PARENT, shell=True, returns=[0]):
   """
   Execute the shell command despite failures.
   @return: return_code, output
@@ -213,11 +213,8 @@ def _call(command, logoutput=None, throw_on_failure=True, stdout=subprocess.PIPE
   # replace placeholder from as_sudo / as_user if present
   env_str = _get_environment_str(env)
   for placeholder, replacement in PLACEHOLDERS_TO_STR.items():
-    command = command.replace(placeholder, replacement.format(env_str=env_str))
     subprocess_command = [cmd.replace(placeholder, replacement.format(env_str=env_str)) for cmd in subprocess_command]
 
-  # --noprofile is used to preserve PATH set for ambari-agent
-  subprocess_command = ["/bin/bash","--login","--noprofile","-c", command]
   if shell:
     # --noprofile is used to preserve PATH set for ambari-agent
     subprocess_command = ["/bin/bash","--login","--noprofile","-c"] + subprocess_command

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/WidgetResourceProvider.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/WidgetResourceProvider.java
@@ -56,10 +56,10 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
-import com.google.gson.JsonSerializer;
 import com.google.gson.JsonElement;
-import com.google.gson.JsonSerializationContext;
 import com.google.gson.JsonPrimitive;
+import com.google.gson.JsonSerializationContext;
+import com.google.gson.JsonSerializer;
 import com.google.inject.Inject;
 
 /**

--- a/ambari-server/src/main/resources/custom_actions/scripts/check_host.py
+++ b/ambari-server/src/main/resources/custom_actions/scripts/check_host.py
@@ -454,7 +454,10 @@ class CheckHost(Script):
       db_connection_check_command = "LD_LIBRARY_PATH=$LD_LIBRARY_PATH:{0}{1} {2}".format(agent_cache_dir,
                                                                 LIBS_PATH_IN_ARCHIVE_SQLA, db_connection_check_command)
 
-    code, out = shell.call(split(db_connection_check_command, comments=True), shell=False)
+    if isinstance(db_connection_check_command, str):
+      code, out = shell.call(split(db_connection_check_command, comments=True), shell=False)
+    else:
+      code, out = shell.call(db_connection_check_command, shell=False)
 
     if code == 0:
       db_connection_check_structured_output = {"exit_code" : 0, "message": "DB connection check completed successfully!" }


### PR DESCRIPTION
## What changes were proposed in this pull request?

The shell.py is executed when installing services by ambari.
However, there will be no failure when executing the shell.py because of some syntax error and undefined variables.

This changes will fix the syntax error and undefined variables in shell.py, and make the shell.py work well.


In addition, when we compile Ambari using the following command, an error occurs:  Wrong order for 'com.google.gson.JsonElement' import.
 This changes can fix the issue.


## How was this patch tested?

Applying this changes, and manual test

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.