### PR TITLE
AMBARI-26233: Fix ambari-env.sh after jdk upgrade

### DIFF
--- a/ambari-agent/conf/unix/ambari-env.sh
+++ b/ambari-agent/conf/unix/ambari-env.sh
@@ -16,13 +16,7 @@
 # To change a passphrase used by the agent adjust the line below. This value is used when no passphrase is
 # given through environment variable
 
-AMBARI_JVM_ARGS="$AMBARI_JVM_ARGS --add-opens java.base/java.lang=ALL-UNNAMED "
-AMBARI_JVM_ARGS="$AMBARI_JVM_ARGS --add-opens java.base/java.util.regex=ALL-UNNAMED "
-AMBARI_JVM_ARGS="$AMBARI_JVM_ARGS --add-opens java.base/java.util=ALL-UNNAMED "
-export AMBARI_JVM_ARGS="$AMBARI_JVM_ARGS  --add-opens java.base/java.lang.reflect=ALL-UNNAMED "
-
 AMBARI_PASSPHRASE="DEV"
-export AMBARI_JVM_ARGS="$AMBARI_JVM_ARGS -Xms512m -Xmx2048m -Djava.security.auth.login.config=$ROOT/etc/ambari-server/conf/krb5JAASLogin.conf -Djava.security.krb5.conf=/etc/krb5.conf -Djavax.security.auth.useSubjectCredsOnly=false -Dcom.sun.jndi.ldap.connect.pool.protocol=\"plain ssl\" -Dcom.sun.jndi.ldap.connect.pool.maxsize=20 -Dcom.sun.jndi.ldap.connect.pool.timeout=300000"
 export PATH=$PATH:/var/lib/ambari-agent
 export PYTHONPATH=/usr/lib/ambari-agent/lib:$PYTHONPATH
 

--- a/ambari-server/conf/ambari-env.sh
+++ b/ambari-server/conf/ambari-env.sh
@@ -12,7 +12,12 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
+: "${AMBARI_JVM_ARGS:=}"
+AMBARI_JVM_ARGS="$AMBARI_JVM_ARGS --add-opens java.base/java.lang=ALL-UNNAMED "
+AMBARI_JVM_ARGS="$AMBARI_JVM_ARGS --add-opens java.base/java.util.regex=ALL-UNNAMED "
+AMBARI_JVM_ARGS="$AMBARI_JVM_ARGS --add-opens java.base/java.util=ALL-UNNAMED "
+export AMBARI_JVM_ARGS="$AMBARI_JVM_ARGS  --add-opens java.base/java.lang.reflect=ALL-UNNAMED "
+export AMBARI_JVM_ARGS="$AMBARI_JVM_ARGS -Xms512m -Xmx2048m -Djava.security.auth.login.config=$ROOT/etc/ambari-server/conf/krb5JAASLogin.conf -Djava.security.krb5.conf=/etc/krb5.conf -Djavax.security.auth.useSubjectCredsOnly=false -Dcom.sun.jndi.ldap.connect.pool.protocol=\"plain ssl\" -Dcom.sun.jndi.ldap.connect.pool.maxsize=20 -Dcom.sun.jndi.ldap.connect.pool.timeout=300000"
 AMBARI_PID_DIR=/var/run/ambari-server
 AMBARI_PASSPHRASE="DEV"
 export PYTHONPATH=/usr/lib/ambari-server/lib:$PYTHONPATH

--- a/ambari-server/conf/ambari-env.sh
+++ b/ambari-server/conf/ambari-env.sh
@@ -12,12 +12,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-: "${AMBARI_JVM_ARGS:=}"
-AMBARI_JVM_ARGS="$AMBARI_JVM_ARGS --add-opens java.base/java.lang=ALL-UNNAMED "
-AMBARI_JVM_ARGS="$AMBARI_JVM_ARGS --add-opens java.base/java.util.regex=ALL-UNNAMED "
-AMBARI_JVM_ARGS="$AMBARI_JVM_ARGS --add-opens java.base/java.util=ALL-UNNAMED "
-export AMBARI_JVM_ARGS="$AMBARI_JVM_ARGS  --add-opens java.base/java.lang.reflect=ALL-UNNAMED "
-export AMBARI_JVM_ARGS="$AMBARI_JVM_ARGS -Xms512m -Xmx2048m -Djava.security.auth.login.config=$ROOT/etc/ambari-server/conf/krb5JAASLogin.conf -Djava.security.krb5.conf=/etc/krb5.conf -Djavax.security.auth.useSubjectCredsOnly=false -Dcom.sun.jndi.ldap.connect.pool.protocol=\"plain ssl\" -Dcom.sun.jndi.ldap.connect.pool.maxsize=20 -Dcom.sun.jndi.ldap.connect.pool.timeout=300000"
 AMBARI_PID_DIR=/var/run/ambari-server
 AMBARI_PASSPHRASE="DEV"
 export PYTHONPATH=/usr/lib/ambari-server/lib:$PYTHONPATH

--- a/ambari-server/conf/unix/ambari-env.sh
+++ b/ambari-server/conf/unix/ambari-env.sh
@@ -13,14 +13,14 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-
-AMBARI_PASSHPHRASE="DEV"
-export AMBARI_JVM_ARGS="$AMBARI_JVM_ARGS -Xms512m -Xmx2048m -XX:MaxPermSize=128m -Djdk.tls.ephemeralDHKeySize=2048 -Djava.security.auth.login.config=$ROOT/etc/ambari-server/conf/krb5JAASLogin.conf -Djava.security.krb5.conf=/etc/krb5.conf -Djavax.security.auth.useSubjectCredsOnly=false -Dcom.sun.jndi.ldap.connect.pool.protocol=\"plain ssl\" -Dcom.sun.jndi.ldap.connect.pool.maxsize=20 -Dcom.sun.jndi.ldap.connect.pool.timeout=300000"
-export PATH=$PATH:$ROOT/var/lib/ambari-server
-export PYTHONPATH=$ROOT/usr/lib/ambari-server/lib:$PYTHONPATH
-# customize python binary for ambari
-# export PYTHON=/usr/bin/python3
-
+: "${AMBARI_JVM_ARGS:=}"
+AMBARI_JVM_ARGS="$AMBARI_JVM_ARGS --add-opens java.base/java.lang=ALL-UNNAMED "
+AMBARI_JVM_ARGS="$AMBARI_JVM_ARGS --add-opens java.base/java.util.regex=ALL-UNNAMED "
+AMBARI_JVM_ARGS="$AMBARI_JVM_ARGS --add-opens java.base/java.util=ALL-UNNAMED "
+export AMBARI_JVM_ARGS="$AMBARI_JVM_ARGS  --add-opens java.base/java.lang.reflect=ALL-UNNAMED "
+export AMBARI_JVM_ARGS="$AMBARI_JVM_ARGS -Xms512m -Xmx2048m -Djava.security.auth.login.config=$ROOT/etc/ambari-server/conf/krb5JAASLogin.conf -Djava.security.krb5.conf=/etc/krb5.conf -Djavax.security.auth.useSubjectCredsOnly=false -Dcom.sun.jndi.ldap.connect.pool.protocol=\"plain ssl\" -Dcom.sun.jndi.ldap.connect.pool.maxsize=20 -Dcom.sun.jndi.ldap.connect.pool.timeout=300000"
+AMBARI_PID_DIR=/var/run/ambari-server
+AMBARI_PASSPHRASE="DEV"
+export PYTHONPATH=/usr/lib/ambari-server/lib:$PYTHONPATH
 # to add additional directory or jar to server classpath use SERVER_CLASSPATH variable
 # export SERVER_CLASSPATH=/etc/hadoop/conf/secure

--- a/ambari-server/conf/unix/ambari-env.sh
+++ b/ambari-server/conf/unix/ambari-env.sh
@@ -19,7 +19,6 @@ AMBARI_PASSHPHRASE="DEV"
 export AMBARI_JVM_ARGS="$AMBARI_JVM_ARGS -Xms512m -Xmx2048m -XX:MaxPermSize=128m -Djdk.tls.ephemeralDHKeySize=2048 -Djava.security.auth.login.config=$ROOT/etc/ambari-server/conf/krb5JAASLogin.conf -Djava.security.krb5.conf=/etc/krb5.conf -Djavax.security.auth.useSubjectCredsOnly=false -Dcom.sun.jndi.ldap.connect.pool.protocol=\"plain ssl\" -Dcom.sun.jndi.ldap.connect.pool.maxsize=20 -Dcom.sun.jndi.ldap.connect.pool.timeout=300000"
 export PATH=$PATH:$ROOT/var/lib/ambari-server
 export PYTHONPATH=$ROOT/usr/lib/ambari-server/lib:$PYTHONPATH
-
 # customize python binary for ambari
 # export PYTHON=/usr/bin/python3
 

--- a/ambari-server/conf/unix/ambari-env.sh
+++ b/ambari-server/conf/unix/ambari-env.sh
@@ -13,14 +13,31 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-: "${AMBARI_JVM_ARGS:=}"
-AMBARI_JVM_ARGS="$AMBARI_JVM_ARGS --add-opens java.base/java.lang=ALL-UNNAMED "
-AMBARI_JVM_ARGS="$AMBARI_JVM_ARGS --add-opens java.base/java.util.regex=ALL-UNNAMED "
-AMBARI_JVM_ARGS="$AMBARI_JVM_ARGS --add-opens java.base/java.util=ALL-UNNAMED "
-export AMBARI_JVM_ARGS="$AMBARI_JVM_ARGS  --add-opens java.base/java.lang.reflect=ALL-UNNAMED "
-export AMBARI_JVM_ARGS="$AMBARI_JVM_ARGS -Xms512m -Xmx2048m -Djava.security.auth.login.config=$ROOT/etc/ambari-server/conf/krb5JAASLogin.conf -Djava.security.krb5.conf=/etc/krb5.conf -Djavax.security.auth.useSubjectCredsOnly=false -Dcom.sun.jndi.ldap.connect.pool.protocol=\"plain ssl\" -Dcom.sun.jndi.ldap.connect.pool.maxsize=20 -Dcom.sun.jndi.ldap.connect.pool.timeout=300000"
-AMBARI_PID_DIR=/var/run/ambari-server
+# Exit immediately if a command exits with a non-zero status
+set -e
+# Set Ambari passphrase
 AMBARI_PASSPHRASE="DEV"
-export PYTHONPATH=/usr/lib/ambari-server/lib:$PYTHONPATH
-# to add additional directory or jar to server classpath use SERVER_CLASSPATH variable
+
+# Set JVM arguments for Ambari
+AMBARI_JVM_ARGS="--add-opens java.base/java.lang=ALL-UNNAMED "
+AMBARI_JVM_ARGS+="--add-opens java.base/java.util.regex=ALL-UNNAMED "
+AMBARI_JVM_ARGS+="--add-opens java.base/java.util=ALL-UNNAMED "
+AMBARI_JVM_ARGS+="--add-opens java.base/java.lang.reflect=ALL-UNNAMED "
+AMBARI_JVM_ARGS+="-Xms512m -Xmx2048m "
+AMBARI_JVM_ARGS+="-Djava.security.auth.login.config=$ROOT/etc/ambari-server/conf/krb5JAASLogin.conf "
+AMBARI_JVM_ARGS+="-Djava.security.krb5.conf=/etc/krb5.conf "
+AMBARI_JVM_ARGS+="-Djavax.security.auth.useSubjectCredsOnly=false "
+AMBARI_JVM_ARGS+="-Dcom.sun.jndi.ldap.connect.pool.protocol=\"plain ssl\" "
+AMBARI_JVM_ARGS+="-Dcom.sun.jndi.ldap.connect.pool.maxsize=20 "
+AMBARI_JVM_ARGS+="-Dcom.sun.jndi.ldap.connect.pool.timeout=300000"
+export AMBARI_JVM_ARGS
+
+# Update PATH to include Ambari server directory
+export PATH="$PATH:$ROOT/var/lib/ambari-server"
+
+# Set Python path for Ambari server
+export PYTHONPATH="/usr/lib/ambari-server/lib:$PYTHONPATH"
+
+# Additional server classpath can be set using SERVER_CLASSPATH
+# Uncomment the following line to add additional directories or jars
 # export SERVER_CLASSPATH=/etc/hadoop/conf/secure

--- a/ambari-server/src/main/python/ambari_server_main.py
+++ b/ambari-server/src/main/python/ambari_server_main.py
@@ -56,7 +56,7 @@ if ambari_provider_module is not None:
   ambari_provider_module_option = "-Dprovider.module.class=" + \
                                   ambari_provider_module + " "
 
-jvm_args = os.getenv('AMBARI_JVM_ARGS', '-Xms512m -Xmx2048m -XX:MaxPermSize=128m')
+jvm_args = os.getenv('AMBARI_JVM_ARGS', '-Xms512m -Xmx2048m')
 
 ENV_FOREGROUND_KEY = "AMBARI_SERVER_RUN_IN_FOREGROUND"
 CHECK_DATABASE_HELPER_CMD = "{0} -cp {1} org.apache.ambari.server.checks.DatabaseConsistencyChecker"


### PR DESCRIPTION
## What changes were proposed in this pull request?

1. Remove the JVM parameters for the Ambari agent, as they are not needed. In the trunk branch, there are no JVM parameters in the Ambari agent's `ambari-env`.
2. Add default values to the Ambari server's environment, otherwise, there will be an error due to missing JVM parameters during startup.
3. Remove JVM parameters that are incompatible with JDK 17.

## How was this patch tested?

unit tests, manual tests
(If this patch involves UI changes, please attach a screen-shot; otherwise, remove this)

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.