### PR TITLE
AMBARI-26234: ClusterNotFoundException in stage Confirm Hosts during deploying a cluster

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/events/publishers/AgentCommandsPublisher.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/events/publishers/AgentCommandsPublisher.java
@@ -109,8 +109,12 @@ public class AgentCommandsPublisher {
             if (ac instanceof ExecutionCommand) {
               try {
                 clusterId = Long.valueOf(((ExecutionCommand)ac).getClusterId());
-                if (!clusterDesiredConfigs.containsKey(clusterId)) {
-                  clusterDesiredConfigs.put(clusterId, clusters.getCluster(clusterId).getDesiredConfigs());
+                if (clusterId >= 0) {
+                  if (!clusterDesiredConfigs.containsKey(clusterId)) {
+                    clusterDesiredConfigs.put(clusterId, clusters.getCluster(clusterId).getDesiredConfigs());
+                  }
+                } else {
+                  LOG.warn("The cluster not found or has not been created yet. clusterID={}.", clusterId);
                 }
               } catch (NumberFormatException|AmbariException e) {
                 LOG.error("Exception on sendAgentCommand", e);


### PR DESCRIPTION
## What changes were proposed in this pull request?
Modified file AgentCommandsPublisher.java.

Fix the issue that may occur ClusterNotFoundException in stage Confirm Hosts during deploying a cluster

## How was this patch tested?

1. Compile Ambari
2. Install Abari 
3. Deploy a cluster by Ambari
4. Check ambari-server.log when entring stage Confirm Hosts

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.