### PR TITLE
AMBARI-26235: Unable to check firewalld status when setup ambari

### DIFF
--- a/ambari-common/src/main/python/ambari_commons/firewall.py
+++ b/ambari-common/src/main/python/ambari_commons/firewall.py
@@ -83,7 +83,7 @@ class FirewallChecks(object):
   def run_command(self):
     try:
       retcode, out, err = shell.call(self.get_command(), stdout = subprocess.PIPE, stderr = subprocess.PIPE,
-                                     timeout = 5, quiet = True, universal_newlines=True)
+                                     timeout = 5, quiet = True)
       self.returncode = retcode
       self.stdoutdata = out
       self.stderrdata = err


### PR DESCRIPTION
## What changes were proposed in this pull request?

We would failed to check firewall status when setup ambari.

These changes can fix the issue.



## How was this patch tested?

Applying this change, and executing the following command.
```shell
 ambari-server setup -j /usr/local/jdk1.8.0_231/
```
We woud get the following logs.
```shell
 # ambari-server setup -j /usr/local/jdk1.8.0_231/
Using python  /usr/bin/python3
Setup ambari-server
Checking SELinux...
SELinux status is 'enabled'
SELinux mode is 'enforcing'
Temporarily disabling SELinux
WARNING: SELinux is set to 'permissive' mode and temporarily disabled.
OK to continue [y/n] (y)? y
Customize user account for ambari-server daemon [y/n] (n)? y
Enter user account for ambari-server daemon (root):
Adjusting ambari-server permissions and ownership...
Checking firewall status...
Checking JDK...
WARNING: JAVA_HOME /usr/local/jdk1.8.0_231/ must be valid on ALL hosts
...
```


Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.