### PR TITLE
AMBARI-26236: The database password character type requirement is too few

### DIFF
--- a/ambari-server/src/main/python/ambari_server/dbConfiguration_linux.py
+++ b/ambari-server/src/main/python/ambari_server/dbConfiguration_linux.py
@@ -224,9 +224,8 @@ class LinuxDBMSConfig(DBMSConfig):
       passwordPrompt = 'Enter Database Password (' + passwordDefault + '): '
     else:
       passwordPrompt = 'Enter Database Password: '
-    passwordPattern = "^[a-zA-Z0-9_-]*$"
-    passwordDescr = "Invalid characters in password. Use only alphanumeric or " \
-                    "_ or - characters"
+    passwordPattern = "^[a-zA-Z0-9!#$%@_-]*$"
+    passwordDescr = "Invalid characters in password. Use only alphanumeric or !#$%@_- characters"
 
     password = read_password(passwordDefault, passwordPattern, passwordPrompt,
       passwordDescr)

--- a/ambari-server/src/main/python/ambari_server/dbConfiguration_linux.py
+++ b/ambari-server/src/main/python/ambari_server/dbConfiguration_linux.py
@@ -224,8 +224,9 @@ class LinuxDBMSConfig(DBMSConfig):
       passwordPrompt = 'Enter Database Password (' + passwordDefault + '): '
     else:
       passwordPrompt = 'Enter Database Password: '
-    passwordPattern = "^[a-zA-Z0-9!#$%@_-]*$"
-    passwordDescr = "Invalid characters in password. Use only alphanumeric or !#$%@_- characters"
+    passwordPattern = "^[a-zA-Z0-9!#$%@^&=+\\[\\]\\{\\}\\(\\)<>.*?;:'\"_-]*$"
+    passwordDescr = "Invalid characters in password. Use only alphanumeric or " \
+      "some special characters, such as !#$%@^&=+[]{}()<>.*?;:'\"_- "
 
     password = read_password(passwordDefault, passwordPattern, passwordPrompt,
       passwordDescr)

--- a/ambari-server/src/test/python/TestAmbariServer.py
+++ b/ambari-server/src/test/python/TestAmbariServer.py
@@ -83,7 +83,7 @@ with patch.object(distro, "linux_distribution", return_value = MagicMock(return_
                     print_info_msg, print_warning_msg, print_error_msg
                   from ambari_commons.os_utils import run_os_command, search_file, set_file_permissions, remove_file, copy_file, \
                     is_valid_filepath
-                  from ambari_server.dbConfiguration import DBMSConfigFactory, check_jdbc_drivers, DBMSConfig
+                  from ambari_server.dbConfiguration import DBMSConfigFactory, check_jdbc_drivers, DBMSConfig, DEFAULT_PASSWORD
                   from ambari_server.dbConfiguration_linux import PGConfig, LinuxDBMSConfig, OracleConfig
                   from ambari_server.properties import Properties
                   from ambari_server.resourceFilesKeeper import ResourceFilesKeeper, KeeperException
@@ -8065,6 +8065,34 @@ class TestAmbariServer(TestCase):
 
     sys.stdout = sys.__stdout__
     pass
+
+  @patch("ambari_server.userInput.get_password")
+  def test_configure_database_password(self, get_password_method):
+    ''' Test default password '''
+    get_password_method.side_effect = ['', '']
+    password = LinuxDBMSConfig._configure_database_password(True)
+    self.assertEqual(DEFAULT_PASSWORD, password)
+
+    get_password_method.reset_mock()
+
+    ''' Test password string only contains alphanumeric characters '''
+    get_password_method.side_effect = ['bigdata123', 'bigdata123']
+    password = LinuxDBMSConfig._configure_database_password(True)
+    self.assertEqual("bigdata123", password)
+
+    get_password_method.reset_mock()
+
+    ''' Test password string contains special characters '''
+    get_password_method.side_effect = ['admin@_123', 'admin@_123']
+    password = LinuxDBMSConfig._configure_database_password(True)
+    self.assertEqual("admin@_123", password)
+
+    get_password_method.reset_mock()
+   
+    ''' Test password string contains multiple special characters '''
+    get_password_method.side_effect = ['admin@_123!#$%@^=+[]{}<>.*?;:"\'-&', 'admin@_123!#$%@^=+[]{}<>.*?;:"\'-&']
+    password = LinuxDBMSConfig._configure_database_password(True)
+    self.assertEqual('admin@_123!#$%@^=+[]{}<>.*?;:"\'-&', password)
 
   @patch("ambari_server.userInput.get_validated_string_input")
   def test_read_password(self, get_validated_string_input_method):

--- a/ambari-server/src/test/python/TestAmbariServer.py
+++ b/ambari-server/src/test/python/TestAmbariServer.py
@@ -8083,9 +8083,9 @@ class TestAmbariServer(TestCase):
     get_password_method.reset_mock()
 
     ''' Test password string contains special characters '''
-    get_password_method.side_effect = ['admin@_123', 'admin@_123']
+    get_password_method.side_effect = ['admin@123', 'admin@123']
     password = LinuxDBMSConfig._configure_database_password(True)
-    self.assertEqual("admin@_123", password)
+    self.assertEqual("admin@123", password)
 
     get_password_method.reset_mock()
    


### PR DESCRIPTION
## What changes were proposed in this pull request?

The database password character type requirement is too few.
It is recommended to support more character sets, For example: `!#$%@`. 

When the database password we set contains some special characters，we can still setup ambari-server succefully after applying this changes.


## How was this patch tested?

1. Applying this changes
2. Set the database password used by Ambari to contain special characters (eg `a-zA-Z0-9!#$%@_-`)
3. Setup ambari-server 

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.