### PR TITLE
AMBARI-26241: _threadlocal has no uid because it is always None

### DIFF
--- a/ambari-agent/src/test/python/ambari_agent/TestShell.py
+++ b/ambari-agent/src/test/python/ambari_agent/TestShell.py
@@ -23,6 +23,7 @@ import signal
 from mock.mock import patch, MagicMock, call
 from ambari_commons import shell
 from ambari_commons import OSCheck
+from ambari_commons.shell import shellRunnerLinux
 from io import StringIO
 
 ROOT_PID = 10
@@ -144,3 +145,8 @@ class TestShell(unittest.TestCase):
     os_kill_pids = [item[0][0] for item in os_kill_mock.call_args_list]
     self.assertEqual(len(os_kill_pids), 1)
     self.assertEqual([10], os_kill_pids)
+
+  def test_shellRunnerLinux_run(self):
+    shell_runner = shellRunnerLinux()
+    result = shell_runner.run(["ls", "-l"])
+    self.assertTrue(shell_runner._threadLocal is None)

--- a/ambari-common/src/main/python/ambari_commons/shell.py
+++ b/ambari-common/src/main/python/ambari_commons/shell.py
@@ -823,7 +823,8 @@ class shellRunnerLinux(shellRunner):
         user = pwd.getpwnam(user)[2]
       else:
         user = os.getuid()
-      self._threadLocal.uid = user
+      if self._threadLocal is not None:
+        self._threadLocal.uid = user
     except Exception as e:
       _logger.warn(f"Unable to switch user for RUN_COMMAND. Error details: {e}")
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Details see: [AMBARI-26241](https://issues.apache.org/jira/browse/AMBARI-26241)

## How was this patch tested?

Unit test

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.