### PR TITLE
AMBARI-26248: Timeline Service Reader failed to start if hbase is not installed

### DIFF
--- a/ambari-server/src/main/resources/stacks/BIGTOP/3.2.0/services/YARN/metainfo.xml
+++ b/ambari-server/src/main/resources/stacks/BIGTOP/3.2.0/services/YARN/metainfo.xml
@@ -52,6 +52,13 @@
                 <enabled>true</enabled>
               </auto-deploy>
             </dependency>
+            <dependency>
+              <name>HBASE/HBASE_CLIENT</name>
+              <scope>host</scope>
+              <auto-deploy>
+                <enabled>true</enabled>
+              </auto-deploy>
+            </dependency>
           </dependencies>
         </component>
 
@@ -239,6 +246,9 @@
             </package>
             <package>
               <name>ranger_${stack_version}-yarn-plugin</name>
+            </package>
+            <package>
+              <name>hbase_${stack_version}</name>
             </package>
           </packages>
         </osSpecific>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Timeline Service Reader failed to start if hbase is not installed, because the  {stack_root}/{version}/usr/lib/hbase/bin/hbase-daemon.sh does not exist.

So, timeline reader should depend hbase client in the same node.

Details see: [AMBARI-26248](https://issues.apache.org/jira/browse/AMBARI-26248)

## How was this patch tested?

Manual testing

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.