### PR TITLE
AMBARI-26249: Timeline Service v2 failed to start because of unable to create leveldb state store directory

### DIFF
--- a/ambari-server/src/main/resources/stacks/BIGTOP/3.2.0/services/YARN/package/scripts/application_timeline_server.py
+++ b/ambari-server/src/main/resources/stacks/BIGTOP/3.2.0/services/YARN/package/scripts/application_timeline_server.py
@@ -30,7 +30,7 @@ from resource_management.libraries.functions.security_commons import build_expec
   FILE_TYPE_XML
 from resource_management.libraries.functions.format import format
 from resource_management.core.logger import Logger
-from resource_management.core.resources.system import Execute
+from resource_management.core.resources.system import Execute, Directory
 
 from yarn import yarn
 from service import service
@@ -56,6 +56,12 @@ class ApplicationTimelineServer(Script):
   def configure(self, env):
     import params
     env.set_params(params)
+
+    Directory(params.yarn_timeline_service_leveldb_state_store_path,
+              create_parents=True,
+              owner=params.yarn_user,
+              group=params.user_group)
+    
     yarn(name='apptimelineserver')
 
 

--- a/ambari-server/src/main/resources/stacks/BIGTOP/3.2.0/services/YARN/package/scripts/params_linux.py
+++ b/ambari-server/src/main/resources/stacks/BIGTOP/3.2.0/services/YARN/package/scripts/params_linux.py
@@ -639,6 +639,7 @@ if 'zoo.cfg' in config['configurations'] and 'clientPort' in config['configurati
   cluster_zookeeper_clientPort = config['configurations']['zoo.cfg']['clientPort']
 else:
   cluster_zookeeper_clientPort = '2181'
+yarn_timeline_service_leveldb_state_store_path = config['configurations']['yarn-site']['yarn.timeline-service.leveldb-state-store.path']
 
 zookeeper_quorum_hosts = cluster_zookeeper_quorum_hosts
 zookeeper_clientPort = cluster_zookeeper_clientPort


### PR DESCRIPTION
## What changes were proposed in this pull request?

fix the issue that timeline Service v2 failed to start because of unable to create leveldb state store directory.

Details see: AMBARI-26249

## How was this patch tested?

Manual testing

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.