### PR TITLE
AMBARI-26253: Can't download all client configs

### DIFF
--- a/ambari-server/src/main/resources/stacks/BIGTOP/3.2.0/services/HBASE/package/scripts/params_linux.py
+++ b/ambari-server/src/main/resources/stacks/BIGTOP/3.2.0/services/HBASE/package/scripts/params_linux.py
@@ -41,7 +41,6 @@ from resource_management.libraries.functions import get_unique_id_and_date
 from resource_management.libraries.functions.get_not_managed_resources import get_not_managed_resources
 from resource_management.libraries.script.script import Script
 from resource_management.libraries.functions.expect import expect
-from ambari_commons.ambari_metrics_helper import select_metric_collector_hosts_from_hostnames
 from resource_management.libraries.functions.setup_ranger_plugin_xml import get_audit_configs, generate_ranger_service_config
 
 # server configurations


### PR DESCRIPTION
## What changes were proposed in this pull request?

Can't download all client configs
![image](https://github.com/user-attachments/assets/b7dbea99-5005-44f7-a752-49379553bd37)
errors:
![image](https://github.com/user-attachments/assets/378297d4-23c8-40a5-af9e-7e510667d891)

## How was this patch tested?
manual test and unit test
after apply this patch, it can be downloaded smoothly.
![image](https://github.com/user-attachments/assets/93e39f77-8977-4bad-b032-9759769e2ed6)

(Please explain how this patch was tested. Ex: unit tests, manual tests)
(If this patch involves UI changes, please attach a screen-shot; otherwise, remove this)

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.