### PR TITLE
AMBARI-26251: tooltip display issue

### DIFF
--- a/ambari-web/app/views/common/controls_view.js
+++ b/ambari-web/app/views/common/controls_view.js
@@ -41,7 +41,7 @@ App.ServiceConfigPopoverSupport = Ember.Mixin.create({
   serviceConfig: null,
   attributeBindings:['readOnly'],
   isPopoverEnabled: true,
-  popoverPlacement: 'auto right',
+  popoverPlacement: 'right',
 
   didInsertElement: function () {
     App.tooltip(this.$('[data-bs-toggle=tooltip]'), {placement: 'top'});


### PR DESCRIPTION
## What changes were proposed in this pull request?

In Bootstrap v5, the `auto right` popper placement is no longer supported. It has been replaced with `right`.

After:
<img width="557" alt="image" src="https://github.com/user-attachments/assets/775b92a1-865c-4279-adf0-5adcd5a72aff">


## How was this patch tested?

Manual test.