### PR TITLE
AMBARI-26255: fix can't add capacity-scheduler views

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/view/ViewArchiveUtility.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/view/ViewArchiveUtility.java
@@ -65,7 +65,7 @@ public class ViewArchiveUtility {
    */
   public ViewConfig getViewConfigFromArchive(File archiveFile)
       throws JAXBException, IOException {
-    ClassLoader cl = URLClassLoader.newInstance(new URL[]{archiveFile.toURI().toURL()});
+    ClassLoader cl = URLClassLoader.newInstance(new URL[]{archiveFile.toURI().toURL()}, null);
 
     InputStream configStream = cl.getResourceAsStream(VIEW_XML);
     if (configStream == null) {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Improve View Loading Mechanism in Ambari

The current implementation of the getViewConfigFromArchive method in ViewArchiveUtility.java is not robust enough when loading views via the SPI mechanism in Ambari. The purpose of this method is to retrieve views from a specified JAR file and instantiate a ViewConfig object containing the view metadata.

Problem Description
The method currently uses the following code to load the view configuration:

```JAVA
ClassLoader cl = URLClassLoader.newInstance(new URL[]{archiveFile.toURI().toURL()});
InputStream configStream = cl.getResourceAsStream(VIEW_XML);
```
In normal scenarios, all views are stored in /var/lib/ambari-server/resources/views, and this works as expected. However, when ambari-admin-3.0.0.0-SNAPSHOT.jar or any other view JAR file exists in the /usr/lib/ambari-server/ directory, the call to cl.getResourceAsStream(VIEW_XML); will always return the first view loaded from /usr/lib/ambari-server/, rather than the intended views.xml file from the specified archiveFile. This results in the retrieval of incorrect configuration and can lead to a corrupted view system.

Proposed Solution
To resolve this issue, we propose to modify the loading mechanism to prevent the delegation of the class loader, ensuring that the correct resource is loaded from the specified JAR file. By creating a URLClassLoader with a parent class loader set to null, we can isolate the resource loading process:

```JAVA
try (URLClassLoader cl = new URLClassLoader(new URL[]{archiveFile.toURI().toURL()}, null)) {
    // Load the configuration stream safely
}
```
This change will ensure that the method only loads resources from the specified JAR file, avoiding conflicts with other JARs present in the classpath.


This improvement will enhance the reliability of the view loading mechanism in Ambari, preventing configuration errors and ensuring that the correct view metadata is always retrieved. We recommend merging this change to improve the robustness of the system.

## How was this patch tested?
manual test and unit tests
Before the patch was applied, an error occurred when clicking the Ambari Manager button.
![image](https://github.com/user-attachments/assets/3e4a7b2f-599c-4e6b-b114-08d3e25aaa19)


After applying the patch, everything functions properly.
![image](https://github.com/user-attachments/assets/c01d23c1-d603-4d2a-916f-425dae8998e4)

(Please explain how this patch was tested. Ex: unit tests, manual tests)
(If this patch involves UI changes, please attach a screen-shot; otherwise, remove this)

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.