### PR TITLE
AMBARI-26268: Remove default value for ambari-java-home in ambari-server.py to fix setup handling

### DIFF
--- a/ambari-server/src/main/python/ambari-server.py
+++ b/ambari-server/src/main/python/ambari-server.py
@@ -490,7 +490,7 @@ def init_setup_parser_options(parser):
 
   other_group.add_option('-j', '--java-home', default=None,
                          help="Use specified java_home.  Must be valid on all hosts")
-  other_group.add_option('--ambari-java-home',dest="ambari_java_home", default=None,
+  other_group.add_option('--ambari-java-home',dest="ambari_java_home",
                          help="Use specified java_home for ambari.  Must be valid on Ambari server hosts")
   other_group.add_option('--stack-java-home', dest="stack_java_home", default=None,
                     help="Use specified java_home for stack services.  Must be valid on all hosts")


### PR DESCRIPTION
ambari server setup failure
![image](https://github.com/user-attachments/assets/2e4181cd-b050-4d6c-a64d-1c750ba045eb)

cause: In ambari-server/src/main/python/ambari-server.py,
the default value for ambari-java-home should not be set, otherwise it will cause incorrect handling of ambari-java-home in ambari-server/src/main/python/ambari_server/serverSetup.py during setup.
as shown in the image
![image](https://github.com/user-attachments/assets/c3823e95-e039-4f81-87f9-a744d1aecf84)

test：
manual test and unit test
after apply this patch:
ambari server setup work smoonthly
![image](https://github.com/user-attachments/assets/79de3d6e-d782-4d7f-a259-393848c8d4cd)


