### PR TITLE
AMBARI-26269: Fix regex pattern flag position in ambari_jinja2 filters

### DIFF
--- a/ambari-common/src/main/python/ambari_jinja2/ambari_jinja2/filters.py
+++ b/ambari-common/src/main/python/ambari_jinja2/ambari_jinja2/filters.py
@@ -19,7 +19,7 @@ from ambari_jinja2.runtime import Undefined
 from ambari_jinja2.exceptions import FilterArgumentError, SecurityError
 
 
-_word_re = re.compile(r'\w+(?u)')
+_word_re = re.compile(r"(?u)\w+")
 
 
 def contextfilter(f):

--- a/ambari-server/src/main/python/ambari-server.py
+++ b/ambari-server/src/main/python/ambari-server.py
@@ -490,7 +490,7 @@ def init_setup_parser_options(parser):
 
   other_group.add_option('-j', '--java-home', default=None,
                          help="Use specified java_home.  Must be valid on all hosts")
-  other_group.add_option('--ambari-java-home',dest="ambari_java_home", default=None,
+  other_group.add_option('--ambari-java-home',dest="ambari_java_home",
                          help="Use specified java_home for ambari.  Must be valid on Ambari server hosts")
   other_group.add_option('--stack-java-home', dest="stack_java_home", default=None,
                     help="Use specified java_home for stack services.  Must be valid on all hosts")


### PR DESCRIPTION
Error Message:
re.error: global flags not at the start of the expression at position 3

![image](https://github.com/user-attachments/assets/a5762bb4-89ff-4e34-9eea-41cc4046790a)

Issue:
This error occurs specifically in Python 11 when using regular expressions with global flags. The problem is that in Python 11, the regex flag (?u) must be placed at the beginning of the regular expression pattern, not in the middle or end.
File Location:
[ambari-common](https://issues.apache.org/jira/browse/AMBARI-common)/src/main/python/ambari_jinja2/ambari_jinja2/filters.py
Solution:
Change the regular expression pattern from:
_word_re = re.compile(r"\w+(?u)")
to:
_word_re = re.compile(r"(?u)\w+")
Explanation:
● The (?u) flag enables Unicode matching
● In Python 11, all flags must be specified at the start of the regular expression pattern
● This issue only appears in Python 11; earlier Python versions work fine with flags in any position
● Moving the (?u) flag to the beginning of the pattern resolves the error while maintaining the same functionality