### PR TITLE
AMBARI-26270: Add quicklink of hiveserver2 web ui

### DIFF
--- a/ambari-server/src/main/resources/stacks/BIGTOP/3.2.0/services/HIVE/quicklinks/quicklinks.json
+++ b/ambari-server/src/main/resources/stacks/BIGTOP/3.2.0/services/HIVE/quicklinks/quicklinks.json
@@ -34,17 +34,17 @@
       },
       {
         "name": "hiveserver2_ui",
-        "label": "HiveServer2 Interactive UI",
+        "label": "HiveServer2 UI",
         "requires_user_name": "false",
-        "component_name": "HIVE_SERVER_INTERACTIVE",
-        "url": "%@://%@:%@/llap.html",
+        "component_name": "HIVE_SERVER",
+        "url": "%@://%@:%@",
         "port":{
           "http_property": "hive.server2.webui.port",
-          "http_default_port": "10502",
+          "http_default_port": "10002",
           "https_property": "hive.server2.webui.port",
-          "https_default_port": "10502",
+          "https_default_port": "10002",
           "regex": "\\w*:(\\d+)",
-          "site": "hive-interactive-site"
+          "site": "hive-site"
         },
         "protocol":{
           "type":"https",
@@ -52,7 +52,7 @@
             {
               "property":"hive.server2.webui.use.ssl",
               "desired":"true",
-              "site":"hive-interactive-site"
+              "site":"hive-site"
             }
           ]
         }


### PR DESCRIPTION
## What changes were proposed in this pull request?
Details see: [AMBARI-26270](https://issues.apache.org/jira/browse/AMBARI-26270)
Improve: Hiveserver2 has web UI, so we should provide a quicklink of hiveserver2 web ui.

(Please fill in changes proposed in this fix)

## How was this patch tested?
Applying these changes, and restart ambari-server, the quicklink of HiveServer2 UI would been displayed on hive SUMMARY webpage.

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.