### PR TITLE
AMBARI-26271: Invalid parameter was provided when using shell.call in HostInfo.py

### DIFF
--- a/ambari-agent/src/main/python/ambari_agent/HostInfo.py
+++ b/ambari-agent/src/main/python/ambari_agent/HostInfo.py
@@ -461,8 +461,7 @@ class HostInfoLinux(HostInfo):
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         timeout=5,
-        quiet=True,
-        universal_newlines=True,
+        quiet=True
       )
       return out, err, code
     except Exception as ex:


### PR DESCRIPTION
## What changes were proposed in this pull request?

Details see: [AMBARI-26271](https://issues.apache.org/jira/browse/AMBARI-26271)

(Please fill in changes proposed in this fix)

## How was this patch tested?
Applying these changes, and viewing `ambari-agent.log`, will not print the following log information
```shell
Event to server at /reports/host_status (correlation_id=9697): {'agentEnv': {'hostHealth': {'liveServices': [{'name': 'chronyd', 'status': 'Unhealthy', 'desc': "call() got an unexpected keyword argument 'universal_newlines'\ncall() got an unexpected keyword argument 'universal_newlines'"}], 'agentTimeStampAtReporting': 1733388927283}, 'umask': '18', 'transparentHugePage': '', 'firewallRunning': False, 'firewallName': 'iptables', 'reverseLookup': True, 'hasUnlimitedJcePolicy': True, 'alternatives': [], 'stackFoldersAndFiles': [], 'existingUsers': []}, 'mounts': [{'device': '/dev/mapper/centos-root', 'type': 'xfs', 'size': '52403200', 'used': '6640636', 'available': '45762564', 'percent': '13%', 'mountpoint': '/'}]
```
Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.