### PR TITLE
AMBARI-26249: Addendum, adjusting the location code of creating directory 

### DIFF
--- a/ambari-server/src/main/resources/stacks/BIGTOP/3.2.0/services/YARN/package/scripts/application_timeline_server.py
+++ b/ambari-server/src/main/resources/stacks/BIGTOP/3.2.0/services/YARN/package/scripts/application_timeline_server.py
@@ -34,7 +34,7 @@ from resource_management.libraries.functions.security_commons import (
 )
 from resource_management.libraries.functions.format import format
 from resource_management.core.logger import Logger
-from resource_management.core.resources.system import Execute, Directory
+from resource_management.core.resources.system import Execute
 
 from yarn import yarn
 from service import service
@@ -61,16 +61,7 @@ class ApplicationTimelineServer(Script):
 
   def configure(self, env):
     import params
-
     env.set_params(params)
-
-    Directory(
-      params.yarn_timeline_service_leveldb_state_store_path,
-      create_parents=True,
-      owner=params.yarn_user,
-      group=params.user_group,
-    )
-
     yarn(name="apptimelineserver")
 
 

--- a/ambari-server/src/main/resources/stacks/BIGTOP/3.2.0/services/YARN/package/scripts/yarn.py
+++ b/ambari-server/src/main/resources/stacks/BIGTOP/3.2.0/services/YARN/package/scripts/yarn.py
@@ -101,6 +101,12 @@ def yarn(name=None, config_dir=None):
     create_parents=True,
     cd_access="a",
   )
+  Directory(
+    params.yarn_timeline_service_leveldb_state_store_path,
+    create_parents=True,
+    owner=params.yarn_user,
+    group=params.user_group,
+  )
 
   # Some of these function calls depend on the directories above being created first.
   if name == "resourcemanager":


### PR DESCRIPTION
This is an addendum to PR  #3905.

I found the code of creating directory is all in yarn.py file.
Therefore, in order to ensure standardization, the code for creating leveldb_state_store directory should also be moved to this file.