### PR TITLE
AMBARI-26273: Add Oceanbase Support to Ambari MySQL DDL

### DIFF
--- a/ambari-server/src/main/resources/Ambari-DDL-MySQL-CREATE.sql
+++ b/ambari-server/src/main/resources/Ambari-DDL-MySQL-CREATE.sql
@@ -246,7 +246,7 @@ CREATE TABLE servicecomponentdesiredstate (
   cluster_id BIGINT NOT NULL,
   desired_repo_version_id BIGINT NOT NULL,
   desired_state VARCHAR(255) NOT NULL,
-  service_name VARCHAR(100) NOT NULL,
+  service_name VARCHAR(255) NOT NULL,
   recovery_enabled SMALLINT NOT NULL DEFAULT 0,
   repo_state VARCHAR(255) NOT NULL DEFAULT 'NOT_REQUIRED',
   CONSTRAINT pk_sc_desiredstate PRIMARY KEY (id),
@@ -260,7 +260,7 @@ CREATE TABLE hostcomponentdesiredstate (
   component_name VARCHAR(100) NOT NULL,
   desired_state VARCHAR(255) NOT NULL,
   host_id BIGINT NOT NULL,
-  service_name VARCHAR(100) NOT NULL,
+  service_name VARCHAR(255) NOT NULL,
   admin_state VARCHAR(32),
   maintenance_state VARCHAR(32) NOT NULL DEFAULT 'ACTIVE',
   blueprint_provisioning_state VARCHAR(255) DEFAULT 'NONE',
@@ -279,7 +279,7 @@ CREATE TABLE hostcomponentstate (
   current_state VARCHAR(255) NOT NULL,
   last_live_state VARCHAR(255) NOT NULL DEFAULT 'UNKNOWN',
   host_id BIGINT NOT NULL,
-  service_name VARCHAR(100) NOT NULL,
+  service_name VARCHAR(255) NOT NULL,
   upgrade_state VARCHAR(32) NOT NULL DEFAULT 'NONE',
   CONSTRAINT pk_hostcomponentstate PRIMARY KEY (id),
   CONSTRAINT FK_hostcomponentstate_host_id FOREIGN KEY (host_id) REFERENCES hosts (host_id),
@@ -626,7 +626,7 @@ CREATE TABLE hostgroup_configuration (
   CONSTRAINT FK_hg_cfg_bp_hg_name FOREIGN KEY (blueprint_name, hostgroup_name) REFERENCES hostgroup (blueprint_name, name));
 
 CREATE TABLE viewmain (
-  view_name VARCHAR(255) NOT NULL,
+  view_name VARCHAR(100) NOT NULL,
   label VARCHAR(255),
   description VARCHAR(2048),
   version VARCHAR(255),


### PR DESCRIPTION
This PR introduces compatibility for Oceanbase within Apache Ambari, with adjustments made to the MySQL DDL script to ensure proper functioning when working with Oceanbase, which supports the MySQL protocol.

1. **Oceanbase Overview**:  
   Oceanbase is a distributed relational database developed by AntGroup , designed to be highly scalable and provide high availability. It is fully compatible with the MySQL protocol, allowing it to be used as a drop-in replacement for MySQL in many cases, which makes it suitable for large-scale applications and enterprise environments.

2. **DDL Modifications**:  
   The file `/var/lib/ambari-server/resources/Ambari-DDL-MySQL-CREATE.sql` was modified to adjust the field lengths of `service_name` and `view_name`. These adjustments help avoid errors when importing the DDL into Oceanbase, aligning the field sizes properly.

![Image of modified SQL](https://github.com/user-attachments/assets/e5c0d0c7-e693-4482-a9ab-da17f22edb23)

3. **Testing**:  
   We have thoroughly tested the modified SQL on both Oceanbase and MySQL databases. After applying the changes, the DDL was successfully imported into both databases, and the Ambari services started without issues.

   ![Image showing successful import and service start](https://github.com/user-attachments/assets/0f1d2d8c-0d02-4b49-b2f4-e3b2424767a5)
![image](https://github.com/user-attachments/assets/c3cc7d78-a46f-435b-b477-1e1c6610430b)


4. **Known Issue**:  
   A minor error occurs during the import process of the SQL into Oceanbase at line 36. This error is due to MySQL-specific syntax, but it does not impact functionality, as the syntax does not affect the overall operation of the system.

  ![Image showing error in line 36](https://github.com/user-attachments/assets/264176e9-b02b-495b-9fa3-dd39449dd945)
 ![image](https://github.com/user-attachments/assets/3ab8de2b-f911-4b73-b1d8-2ebb1da9b545)

5. **Final Validation**:  
   After making the changes, we successfully started Ambari, installed, and ran all components without any issues. This confirms that the changes ensure full compatibility with both Oceanbase and MySQL, allowing Ambari to function normally.

![image](https://github.com/user-attachments/assets/c86399ad-0cae-48a8-b971-50b8ac392969)

We believe that these changes will make Ambari more versatile for users running Oceanbase while retaining compatibility with MySQL.