### PR TITLE
AMBARI-26275: NoClassesFoundToAnalyzeException when compiling ambari with jdk17

### DIFF
--- a/ambari-server/pom.xml
+++ b/ambari-server/pom.xml
@@ -654,23 +654,32 @@
         </configuration>
       </plugin>
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>findbugs-maven-plugin</artifactId>
-        <version>3.0.5</version>
-        <configuration>
-          <failOnError>false</failOnError>
-          <threshold>Low</threshold>
-          <findbugsXmlOutputDirectory>${project.basedir}/target/findbugs</findbugsXmlOutputDirectory>
-          <excludeFilterFile>${project.basedir}/findbugs.exclude.xml</excludeFilterFile>
-        </configuration>
+        <groupId>com.github.spotbugs</groupId>
+        <artifactId>spotbugs-maven-plugin</artifactId>
+        <version>4.8.6.4</version>
         <executions>
           <execution>
+            <id>spotbugs-check</id>
             <phase>verify</phase>
             <goals>
               <goal>check</goal>
             </goals>
           </execution>
         </executions>
+        <configuration>
+          <failOnError>false</failOnError>
+          <threshold>Low</threshold>
+          <xmlOutput>true</xmlOutput>
+          <xmlOutputDirectory>target/spotbugs</xmlOutputDirectory>
+          <excludeFilterFile>${project.basedir}/findbugs.exclude.xml</excludeFilterFile>
+        </configuration>
+        <dependencies>
+          <dependency>
+            <groupId>com.github.spotbugs</groupId>
+            <artifactId>spotbugs</artifactId>
+            <version>4.8.6</version>
+          </dependency>
+        </dependencies>
       </plugin>
       <plugin>
         <groupId>org.codehaus.mojo</groupId>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Details see: [AMBARI-26275](https://issues.apache.org/jira/browse/AMBARI-26275)

## How was this patch tested?

For example, on Centos, compiling ambari with jdk17 by the following command.
```
mvn -B clean install rpm:rpm -DnewVersion=2.7.9.0.0 -DbuildNumber=da8f1b9b5a799bfa8e2d8aa9ab31d6d5a1cc31a0 -DskipTests -Dpython.ver="python >= 2.6"
```

We can compile ambari successfully.
```shell
[INFO]
[INFO] Ambari Main ........................................ SUCCESS [  6.090 s]
[INFO] Apache Ambari Project POM .......................... SUCCESS [  0.234 s]
[INFO] Ambari Web ......................................... SUCCESS [01:00 min]
[INFO] Ambari Views ....................................... SUCCESS [  1.845 s]
[INFO] Ambari Admin View .................................. SUCCESS [ 10.980 s]
[INFO] ambari-utility ..................................... SUCCESS [  2.269 s]
[INFO] Ambari Server SPI .................................. SUCCESS [  0.967 s]
[INFO] Ambari Service Advisor ............................. SUCCESS [  1.536 s]
[INFO] Ambari Server ...................................... SUCCESS [05:45 min]
[INFO] Ambari Functional Tests ............................ SUCCESS [  1.873 s]
[INFO] Ambari Agent ....................................... SUCCESS [ 33.110 s]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  07:44 min
```


Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.