### PR TITLE
AMBARI-26276: fix hdfs web service check

### DIFF
--- a/ambari-server/src/main/resources/stacks/BIGTOP/3.2.0/services/HDFS/package/files/checkWebUI.py
+++ b/ambari-server/src/main/resources/stacks/BIGTOP/3.2.0/services/HDFS/package/files/checkWebUI.py
@@ -106,7 +106,7 @@ def main():
   for host in hosts:
     httpCode = make_connection(host, port, https.lower() == "true", protocol)
 
-    if httpCode != 200:
+    if httpCode != 200 and httpCode != 302:
       print(
         "Cannot access WEB UI on: http://" + host + ":" + port
         if not https.lower() == "true"


### PR DESCRIPTION
Description:
This PR addresses an issue with the HDFS web service check. Currently, the check does not consider the HTTP 302 status code as a valid response, even though it is a valid and usable status for the service. This change adds a condition to include the 302 status code as an acceptable response, ensuring the service check works correctly in scenarios where a 302 redirect is returned.

Changes:

Modified the HDFS web service check logic to include a check for the 302 status code.

Updated the relevant test cases to verify the new behavior.

Testing:

Manually tested the service check with a 302 response to ensure it is recognized as valid.

![image](https://github.com/user-attachments/assets/682ccf6a-7406-4ced-a659-5df4574870a5)
