### PR TITLE
AMBARI-26277:Fix kerberos encryption error, Update Supported Encryption Types in Kerberos Configuration

### DIFF
--- a/ambari-server/src/main/resources/stacks/BIGTOP/3.2.0/services/KERBEROS/configuration/kerberos-env.xml
+++ b/ambari-server/src/main/resources/stacks/BIGTOP/3.2.0/services/KERBEROS/configuration/kerberos-env.xml
@@ -126,7 +126,7 @@
     <description>
       The supported list of session key encryption types that should be returned by the KDC.
     </description>
-    <value>aes des3-cbc-sha1 rc4 des-cbc-md5</value>
+    <value>aes256-cts-hmac-sha1-96 aes128-cts-hmac-sha1-96</value>
     <value-attributes>
       <type>multiLine</type>
       <overridable>false</overridable>

--- a/ambari-server/src/main/resources/stacks/BIGTOP/3.2.0/services/KERBEROS/properties/krb5_conf.j2
+++ b/ambari-server/src/main/resources/stacks/BIGTOP/3.2.0/services/KERBEROS/properties/krb5_conf.j2
@@ -23,8 +23,8 @@
   dns_lookup_realm = false
   dns_lookup_kdc = false
   default_ccache_name = /tmp/krb5cc_%{uid}
-  #default_tgs_enctypes = {{encryption_types}}
-  #default_tkt_enctypes = {{encryption_types}}
+  default_tgs_enctypes = {{encryption_types}}
+  default_tkt_enctypes = {{encryption_types}}
   {%- if force_tcp %}
   udp_preference_limit = 1
   {%- endif -%}


### PR DESCRIPTION
**Description:**
This PR updates the supported encryption types in the Kerberos configuration to enhance security and align with modern encryption standards. The current configuration includes outdated and less secure encryption types, which are replaced with stronger and more widely supported encryption algorithms.

**Changes:**
- Modified the `kerberos-env.xml` file in the `ambari/ambari-server/src/main/resources/stacks/BIGTOP/3.2.0/services/KERBEROS/configuration/` directory.
- Replaced the existing encryption types:
  ```xml
  <value>aes des3-cbc-sha1 rc4 des-cbc-md5</value>
  ```
  with:
  ```xml
  <value>aes256-cts-hmac-sha1-96 aes128-cts-hmac-sha1-96</value>
  ```

**Reason for Change:**
- The previous encryption types (`des3-cbc-sha1`, `rc4`, and `des-cbc-md5`) are considered weak and vulnerable to attacks.
- The new encryption types (`aes256-cts-hmac-sha1-96` and `aes128-cts-hmac-sha1-96`) are more secure and widely supported in modern Kerberos implementations.

**Impact:**
- This change ensures that only strong encryption types are used for Kerberos session keys, improving overall security.
- Systems relying on older encryption types may need to update their Kerberos configurations to remain compatible.


ambari/ambari-server/src/main/resources/stacks/BIGTOP/3.2.0/services/KERBEROS/configuration/kerberos-env.xml
![image](https://github.com/user-attachments/assets/95cf2759-e779-479e-bc63-24d6b50ee74a)

ambari/ambari-server/src/main/resources/stacks/BIGTOP/3.2.0/services/KERBEROS/properties/krb5_conf.j2
![image](https://github.com/user-attachments/assets/558e58bb-1ba9-4dde-af3b-7119c129f8d0)


