### PR TITLE
AMBARI-26286: refactor(ambari-ruff): convert .format() to f-strings

### DIFF
--- a/ambari-agent/src/main/python/ambari_agent/alerts/metric_alert.py
+++ b/ambari-agent/src/main/python/ambari_agent/alerts/metric_alert.py
@@ -271,9 +271,7 @@ class MetricAlert(BaseAlert):
             response.close()
           except:
             logger.debug(
-              "[Alert][{0}] Unable to close JMX URL connection to {1}".format(
-                self.get_name(), url
-              )
+              f"[Alert][{self.get_name()}] Unable to close JMX URL connection to {url}"
             )
 
       json_is_valid = True

--- a/ambari-agent/src/main/python/ambari_agent/alerts/recovery_alert.py
+++ b/ambari-agent/src/main/python/ambari_agent/alerts/recovery_alert.py
@@ -70,9 +70,7 @@ class RecoveryAlert(BaseAlert):
 
     if logger.isEnabledFor(logging.DEBUG):
       logger.debug(
-        "[Alert][{0}] Checking recovery operations for {1}".format(
-          self.get_name(), component
-        )
+        f"[Alert][{self.get_name()}] Checking recovery operations for {component}"
       )
 
     recovery_action_info = {}

--- a/ambari-agent/src/main/python/ambari_agent/alerts/script_alert.py
+++ b/ambari-agent/src/main/python/ambari_agent/alerts/script_alert.py
@@ -179,16 +179,12 @@ class ScriptAlert(BaseAlert):
 
     if logger.isEnabledFor(logging.DEBUG):
       logger.debug(
-        "[Alert][{0}] Executing script check {1}".format(
-          self.get_name(), self.path_to_script
-        )
+        f"[Alert][{self.get_name()}] Executing script check {self.path_to_script}"
       )
 
     if not self.path_to_script.endswith(".py"):
       logger.error(
-        "[Alert][{0}] Unable to execute script {1}".format(
-          self.get_name(), self.path_to_script
-        )
+        f"[Alert][{self.get_name()}] Unable to execute script {self.path_to_script}"
       )
 
       return None

--- a/ambari-agent/src/main/python/ambari_agent/apscheduler/util.py
+++ b/ambari-agent/src/main/python/ambari_agent/apscheduler/util.py
@@ -168,7 +168,7 @@ def get_callable_name(func):
     return func.__class__.__name__
 
   raise TypeError(
-    "Unable to determine a name for %s -- " "maybe it is not a callable?" % repr(func)
+    f"Unable to determine a name for {repr(func)} -- maybe it is not a callable?"
   )
 
 

--- a/ambari-agent/src/test/python/ambari_agent/TestHostCleanup.py
+++ b/ambari-agent/src/test/python/ambari_agent/TestHostCleanup.py
@@ -477,7 +477,7 @@ class TestHostCleanup(TestCase):
     self.assertTrue(get_os_type_method.called)
     self.assertTrue(run_os_command_method.called)
     run_os_command_method.assert_called_with(
-      "yum erase -y {0}".format(" ".join(["abcd", "wxyz"]))
+      f"yum erase -y {' '.join(['abcd', 'wxyz'])}"
     )
     self.assertEqual(0, retval)
 
@@ -492,7 +492,7 @@ class TestHostCleanup(TestCase):
     self.assertTrue(get_os_type_method.called)
     self.assertTrue(run_os_command_method.called)
     run_os_command_method.assert_called_with(
-      "zypper -n -q remove {0}".format(" ".join(["abcd", "wxyz"]))
+      f"zypper -n -q remove {' '.join(['abcd', 'wxyz'])}"
     )
     self.assertEqual(0, retval)
 

--- a/ambari-agent/src/test/python/resource_management/TestUtils.py
+++ b/ambari-agent/src/test/python/resource_management/TestUtils.py
@@ -38,7 +38,5 @@ class TestUtils(TestCase):
       self.assertEqual(
         expected,
         bitmask,
-        'Test set "{0}" failed, expected: {1} but got {2}'.format(
-          test_pattern, expected, bitmask
-        ),
+        f'Test set "{test_pattern}" failed, expected: {expected} but got {bitmask}',
       )

--- a/ambari-common/src/main/python/ambari_commons/exceptions.py
+++ b/ambari-common/src/main/python/ambari_commons/exceptions.py
@@ -25,7 +25,7 @@ class FatalException(Exception):
     self.reason = reason
 
   def __str__(self):
-    return repr("Fatal exception: %s, exit code %s" % (self.reason, self.code))
+    return repr(f"Fatal exception: {self.reason}, exit code {self.code}")
 
 
 class NonFatalException(Exception):
@@ -33,9 +33,9 @@ class NonFatalException(Exception):
     self.reason = reason
 
   def __str__(self):
-    return repr("NonFatal exception: %s" % self.reason)
+    return repr(f"NonFatal exception: {self.reason}")
 
 
 class TimeoutError(Exception):
   def __str__(self):
-    return repr("Timeout error: %s" % self.message)
+    return repr(f"Timeout error: {self.message}")

--- a/ambari-common/src/main/python/ambari_commons/firewall.py
+++ b/ambari-common/src/main/python/ambari_commons/firewall.py
@@ -73,11 +73,7 @@ class FirewallChecks(object):
     return self.FIREWALL_SERVICE_NAME
 
   def get_command(self):
-    return "%s %s %s" % (
-      self.SERVICE_CMD,
-      self.FIREWALL_SERVICE_NAME,
-      self.SERVICE_SUBCMD,
-    )
+    return f"{self.SERVICE_CMD} {self.FIREWALL_SERVICE_NAME} {self.SERVICE_SUBCMD}"
 
   def check_result(self):
     result = False
@@ -117,7 +113,7 @@ class UbuntuFirewallChecks(FirewallChecks):
     self.FIREWALL_SERVICE_NAME = "ufw"
 
   def get_command(self):
-    return "%s %s" % (self.FIREWALL_SERVICE_NAME, self.SERVICE_SUBCMD)
+    return f"{self.FIREWALL_SERVICE_NAME} {self.SERVICE_SUBCMD}"
 
   def check_result(self):
     # On ubuntu, the status command returns 0 whether running or not
@@ -138,11 +134,7 @@ class RedHat7FirewallChecks(FirewallChecks):
   # firewalld added to support default firewall (started from RHEL7/CentOS7)
   # script default iptables checked as user can use iptables as known from previous RHEL releases.
   def get_command(self):
-    return "%(servcmd)s is-active %(fwl1)s %(fwl2)s" % {
-      "servcmd": self.SERVICE_CMD,
-      "fwl1": "iptables",
-      "fwl2": "firewalld",
-    }
+    return f"{self.SERVICE_CMD} is-active iptables firewalld"
 
   def check_result(self):
     if self.stdoutdata is None:
@@ -159,7 +151,7 @@ class Fedora18FirewallChecks(FirewallChecks):
     super(Fedora18FirewallChecks, self).__init__()
 
   def get_command(self):
-    return "systemctl is-active %s" % (self.FIREWALL_SERVICE_NAME)
+    return f"systemctl is-active {self.FIREWALL_SERVICE_NAME}"
 
   def check_result(self):
     result = False
@@ -175,7 +167,7 @@ class SuseFirewallChecks(FirewallChecks):
     self.FIREWALL_SERVICE_NAME = "rcSuSEfirewall2"
 
   def get_command(self):
-    return "%s %s" % (self.FIREWALL_SERVICE_NAME, self.SERVICE_SUBCMD)
+    return f"{self.FIREWALL_SERVICE_NAME} {self.SERVICE_SUBCMD}"
 
   def check_result(self):
     result = False

--- a/ambari-common/src/main/python/ambari_commons/get_ambari_version.py
+++ b/ambari-common/src/main/python/ambari_commons/get_ambari_version.py
@@ -40,7 +40,7 @@ def get_ambari_version_agent():
         ambari_version = f.read().strip()
     except Exception as e:
       Logger.info("Unable to determine ambari version from the agent version file.")
-      Logger.debug("Exception: %s" % str(e))
+      Logger.debug(f"Exception: {str(e)}")
       pass
     pass
   return ambari_version

--- a/ambari-common/src/main/python/ambari_commons/inet_utils.py
+++ b/ambari-common/src/main/python/ambari_commons/inet_utils.py
@@ -90,7 +90,7 @@ def download_file_anyway(link, destination, chunk_size=16 * 1024, progress_func=
   if not os.path.exists(destination):
     print(f"Trying to download {link} to {destination} with [curl] command.")
     # print_info_msg(f"Trying to download {link} to {destination} with [curl] command.")
-    curl_command = "curl --fail -k -o %s %s" % (destination, link)
+    curl_command = f"curl --fail -k -o {destination} {link}"
     retcode, out, err = os_run_os_command(curl_command)
     if retcode != 0:
       print_error_msg(
@@ -99,7 +99,7 @@ def download_file_anyway(link, destination, chunk_size=16 * 1024, progress_func=
 
   if not os.path.exists(destination):
     print_error_msg(f"Unable to download file {link}!")
-    print("ERROR: unable to donwload file %s!" % (link))
+    print(f"ERROR: unable to donwload file {link}!")
 
 
 def download_progress(file_name, downloaded_size, blockSize, totalSize):
@@ -181,7 +181,7 @@ def force_download_file(link, destination, chunk_size=16 * 1024, progress_func=N
     if partial_size > chunk_size:
       # Re-download the last chunk, to minimize the possibilities of file corruption
       resume_pos = partial_size - chunk_size
-      request.add_header("Range", "bytes=%s-" % resume_pos)
+      request.add_header("Range", f"bytes={resume_pos}-")
   else:
     # Make sure the full dir structure is in place, otherwise file open will fail
     if not os.path.exists(dest_path):
@@ -190,7 +190,7 @@ def force_download_file(link, destination, chunk_size=16 * 1024, progress_func=N
   response = urllib.request.urlopen(request)
   (file_size, seek_pos) = find_range_components(response.info())
 
-  print_info_msg("Downloading to: %s Bytes: %s" % (destination, file_size))
+  print_info_msg(f"Downloading to: {destination} Bytes: {file_size}")
 
   if partial_size < file_size:
     if seek_pos == 0:

--- a/ambari-common/src/main/python/ambari_commons/kerberos/kerberos_common.py
+++ b/ambari-common/src/main/python/ambari_commons/kerberos/kerberos_common.py
@@ -45,7 +45,7 @@ class MissingKeytabs(object):
       )
 
     def __str__(self):
-      return "Keytab: %s Principal: %s" % (self.keytab_file_path, self.principal)
+      return f"Keytab: {self.keytab_file_path} Principal: {self.principal}"
 
   @classmethod
   def from_kerberos_records(self, kerberos_record, hostname):

--- a/ambari-common/src/main/python/ambari_commons/kerberos/utils.py
+++ b/ambari-common/src/main/python/ambari_commons/kerberos/utils.py
@@ -108,6 +108,6 @@ def set_port(host, port):
     host_and_port = split_host_and_port(host)
 
     if (host_and_port is not None) and ("host" in host_and_port):
-      return "%s:%s" % (host_and_port["host"], port)
+      return f"{host_and_port['host']}:{port}"
     else:
       return host

--- a/ambari-common/src/main/python/ambari_commons/os_check.py
+++ b/ambari-common/src/main/python/ambari_commons/os_check.py
@@ -159,7 +159,7 @@ class OS_CONST_TYPE(type):
           json_data[JSON_OS_ALIASES] if JSON_OS_ALIASES in json_data else {}
         )
     except:
-      raise Exception("Couldn't load '%s' file" % OSFAMILY_JSON_RESOURCE)
+      raise Exception(f"Couldn't load '{OSFAMILY_JSON_RESOURCE}' file")
 
   def __init__(cls, name, bases, dct):
     cls.initialize_data()
@@ -177,7 +177,7 @@ class OS_CONST_TYPE(type):
       return name[3:]
     if "_family" in name and name[:-7] in cls.FAMILY_COLLECTION:
       return name[:-7]
-    raise Exception("Unknown class property '%s'" % name)
+    raise Exception(f"Unknown class property '{name}'")
 
 
 class OSConst(metaclass=OS_CONST_TYPE):

--- a/ambari-common/src/main/python/ambari_commons/os_linux.py
+++ b/ambari-common/src/main/python/ambari_commons/os_linux.py
@@ -85,7 +85,7 @@ def os_set_file_permissions(file, mod, recursive, user):
 
 
 def os_set_open_files_limit(maxOpenFiles):
-  command = "%s %s" % (ULIMIT_CMD, str(maxOpenFiles))
+  command = f"{ULIMIT_CMD} {str(maxOpenFiles)}"
   os_run_os_command(command)
 
 
@@ -96,11 +96,11 @@ def os_getpass(prompt):
 def os_is_service_exist(serviceName):
   if os.path.exists("/run/systemd/system/"):
     return (
-      os.popen('systemctl list-units --full -all | grep "%s.service"' % serviceName)
+      os.popen(f'systemctl list-units --full -all | grep "{serviceName}.service"')
       .read()
       .strip()
       != ""
     )
 
-  status = os.system("service %s status >/dev/null 2>&1" % serviceName)
+  status = os.system(f"service {serviceName} status >/dev/null 2>&1")
   return status != 256

--- a/ambari-common/src/main/python/ambari_commons/os_utils.py
+++ b/ambari-common/src/main/python/ambari_commons/os_utils.py
@@ -142,7 +142,7 @@ def set_file_permissions(file, mod, user, recursive):
   if os.path.exists(file):
     os_set_file_permissions(file, mod, recursive, user)
   else:
-    print_info_msg("File %s does not exist" % file)
+    print_info_msg(f"File {file} does not exist")
 
 
 def run_os_command(cmd, env=None, cwd=None):

--- a/ambari-common/src/main/python/ambari_commons/os_windows.py
+++ b/ambari-common/src/main/python/ambari_commons/os_windows.py
@@ -589,7 +589,7 @@ class WinServiceController:
         )
     except win32service.error as exc:
       if exc.winerror != 1056:
-        msg = "Error starting service: %s" % exc.strerror
+        msg = f"Error starting service: {exc.strerror}"
         err = exc.winerror
     return err, msg
 

--- a/ambari-common/src/main/python/ambari_commons/parallel_processing.py
+++ b/ambari-common/src/main/python/ambari_commons/parallel_processing.py
@@ -43,10 +43,7 @@ class ParallelProcess(Process):
 
   def return_name(self):
     ## NOTE: self.name is an attribute of multiprocessing.Process
-    return "Process running function '%s' for element '%s'" % (
-      self.function,
-      self.element,
-    )
+    return f"Process running function '{self.function}' for element '{self.element}'"
 
   def run(self):
     try:
@@ -65,7 +62,7 @@ class ParallelProcess(Process):
 
 
 def execute_in_parallel(function, array, params, wait_for_all=False):
-  logger.info("Started running %s for %s" % (function, array))
+  logger.info(f"Started running {function} for {array}")
   processs = []
   q = Queue()
   counter = len(array)
@@ -86,7 +83,7 @@ def execute_in_parallel(function, array, params, wait_for_all=False):
   for process in processs:
     process.terminate()
 
-  logger.info("Finished running %s for %s" % (function, array))
+  logger.info(f"Finished running {function} for {array}")
 
   return results
 

--- a/ambari-common/src/main/python/ambari_commons/repo_manager/choco_manager.py
+++ b/ambari-common/src/main/python/ambari_commons/repo_manager/choco_manager.py
@@ -67,7 +67,7 @@ class ChocoManager(GenericManager):
         cmd = cmd + [enable_repo_option]
       cmd = cmd + [name]
       cmdString = " ".join(cmd)
-      Logger.info("Installing package %s ('%s')" % (name, cmdString))
+      Logger.info(f"Installing package {name} ('{cmdString}')")
       runner = shellRunner()
       res = runner.run(cmd)
       if res["exitCode"] != 0:
@@ -79,7 +79,7 @@ class ChocoManager(GenericManager):
           + res["output"]
         )
     else:
-      Logger.info("Skipping installation of existing package %s" % (name))
+      Logger.info(f"Skipping installation of existing package {name}")
 
   def upgrade_package(self, name, context):
     """
@@ -94,7 +94,7 @@ class ChocoManager(GenericManager):
       cmd = cmd + [enable_repo_option]
     cmd = cmd + [name]
     cmdString = " ".join(cmd)
-    Logger.info("Upgrading package %s ('%s')" % (name, cmdString))
+    Logger.info(f"Upgrading package {name} ('{cmdString}')")
     runner = shellRunner()
     res = runner.run(cmd)
     if res["exitCode"] != 0:
@@ -117,7 +117,7 @@ class ChocoManager(GenericManager):
     if self._check_existence(name, context):
       cmd = REMOVE_CMD[context.log_output] + [name]
       cmdString = " ".join(cmd)
-      Logger.info("Removing package %s ('%s')" % (name, " ".join(cmd)))
+      Logger.info(f"Removing package {name} ('{' '.join(cmd)}')")
       runner = shellRunner()
       res = runner.run(cmd)
       if res["exitCode"] != 0:
@@ -129,7 +129,7 @@ class ChocoManager(GenericManager):
           + res["output"]
         )
     else:
-      Logger.info("Skipping removal of non-existing package %s" % (name))
+      Logger.info(f"Skipping removal of non-existing package {name}")
 
   def _check_existence(self, name, context):
     cmd = CHECK_CMD[context.log_output] + [name]

--- a/ambari-common/src/main/python/ambari_commons/str_utils.py
+++ b/ambari-common/src/main/python/ambari_commons/str_utils.py
@@ -44,7 +44,7 @@ def cbool(obj):
       return True
     if obj in ("false", "no", "off", "n", "f", "0"):
       return False
-    raise ValueError('Unable to interpret value "%s" as boolean' % obj)
+    raise ValueError(f'Unable to interpret value "{obj}" as boolean')
   return bool(obj)
 
 
@@ -59,7 +59,7 @@ def cint(obj):
     try:
       return int(obj)
     except ValueError:
-      raise ValueError('Unable to interpret value "%s" as integer' % obj)
+      raise ValueError(f'Unable to interpret value "{obj}" as integer')
   elif obj is None:
     return obj
 

--- a/ambari-common/src/main/python/ambari_jinja2/ambari_jinja2/_markupsafe/__init__.py
+++ b/ambari-common/src/main/python/ambari_jinja2/ambari_jinja2/_markupsafe/__init__.py
@@ -101,7 +101,7 @@ class Markup(str):
     return self.__class__(str.__mod__(self, arg))
 
   def __repr__(self):
-    return "%s(%s)" % (self.__class__.__name__, str.__repr__(self))
+    return f"{self.__class__.__name__}({str.__repr__(self)})"
 
   def join(self, seq):
     return self.__class__(str.join(self, list(map(escape, seq))))

--- a/ambari-common/src/main/python/ambari_jinja2/ambari_jinja2/_stringdefs.py
+++ b/ambari-common/src/main/python/ambari_jinja2/ambari_jinja2/_stringdefs.py
@@ -156,16 +156,16 @@ if __name__ == "__main__":
     if cat == "Cs":
       # Jython can't handle isolated surrogates
       f.write(
-        """\
-try:
-    Cs = eval(r"%r")
+        f"""try:
+    Cs = eval(r"{val!r}")
 except UnicodeDecodeError:
-    Cs = '' # Jython can't handle isolated surrogates\n\n"""
-        % val
+    Cs = '' # Jython can't handle isolated surrogates
+
+"""
       )
     else:
-      f.write("%s = %r\n\n" % (cat, val))
-  f.write("cats = %r\n\n" % sorted(categories.keys()))
+      f.write(f"{cat} = {val!r}\n\n")
+  f.write(f"cats = {sorted(categories.keys())!r}\n\n")
 
   f.write(footer)
   f.close()

--- a/ambari-common/src/main/python/ambari_jinja2/ambari_jinja2/compiler.py
+++ b/ambari-common/src/main/python/ambari_jinja2/ambari_jinja2/compiler.py
@@ -899,7 +899,7 @@ class CodeGenerator(NodeVisitor):
       if not self.has_known_extends:
         self.writeline("if parent_template is not None:")
         self.indent()
-      self.writeline(f"raise TemplateRuntimeError(extended multiple times)")
+      self.writeline(f"raise TemplateRuntimeError('extended multiple times')")
       self.outdent()
 
       # if we have a known extends already we don't need that code here

--- a/ambari-common/src/main/python/ambari_jinja2/ambari_jinja2/compiler.py
+++ b/ambari-common/src/main/python/ambari_jinja2/ambari_jinja2/compiler.py
@@ -899,7 +899,7 @@ class CodeGenerator(NodeVisitor):
       if not self.has_known_extends:
         self.writeline("if parent_template is not None:")
         self.indent()
-      self.writeline(f"raise TemplateRuntimeError('extended multiple times')")
+      self.writeline("raise TemplateRuntimeError('extended multiple times')")
       self.outdent()
 
       # if we have a known extends already we don't need that code here

--- a/ambari-common/src/main/python/ambari_jinja2/ambari_jinja2/debug.py
+++ b/ambari-common/src/main/python/ambari_jinja2/ambari_jinja2/debug.py
@@ -216,7 +216,7 @@ def fake_exc_info(exc_info, filename, lineno):
       if function == "root":
         location = "top-level template code"
       elif function.startswith("block_"):
-        location = 'block "%s"' % function[6:]
+        location = f'block "{function[6:]}"'
       else:
         location = "template"
     code = CodeType(

--- a/ambari-common/src/main/python/ambari_jinja2/ambari_jinja2/environment.py
+++ b/ambari-common/src/main/python/ambari_jinja2/ambari_jinja2/environment.py
@@ -626,11 +626,11 @@ class Environment(object):
       zip_file = ZipFile(
         target, "w", dict(deflated=ZIP_DEFLATED, stored=ZIP_STORED)[zip]
       )
-      log_function('Compiling into Zip archive "%s"' % target)
+      log_function(f'Compiling into Zip archive "{target}"')
     else:
       if not os.path.isdir(target):
         os.makedirs(target)
-      log_function('Compiling into folder "%s"' % target)
+      log_function(f'Compiling into folder "{target}"')
 
     try:
       for name in self.list_templates(extensions, filter_func):
@@ -640,7 +640,7 @@ class Environment(object):
         except TemplateSyntaxError as e:
           if not ignore_errors:
             raise
-          log_function('Could not compile "%s": %s' % (name, e))
+          log_function(f'Could not compile "{name}": {e}')
           continue
 
         filename = ModuleLoader.get_module_filename(name)
@@ -648,10 +648,10 @@ class Environment(object):
         if py_compile:
           c = self._compile(code, _encode_filename(filename))
           write_file(filename + "c", py_header + marshal.dumps(c), "wb")
-          log_function('Byte-compiled "%s" as %s' % (name, filename + "c"))
+          log_function(f"Byte-compiled \"{name}\" as {filename + 'c'}")
         else:
           write_file(filename, code, "w")
-          log_function('Compiled "%s" as %s' % (name, filename))
+          log_function(f'Compiled "{name}" as {filename}')
     finally:
       if zip:
         zip_file.close()
@@ -1028,10 +1028,10 @@ class Template(object):
 
   def __repr__(self):
     if self.name is None:
-      name = "memory:%x" % id(self)
+      name = f"memory:{id(self):x}"
     else:
       name = repr(self.name)
-    return "<%s %s>" % (self.__class__.__name__, name)
+    return f"<{self.__class__.__name__} {name}>"
 
 
 class TemplateModule(object):
@@ -1053,10 +1053,10 @@ class TemplateModule(object):
 
   def __repr__(self):
     if self.__name__ is None:
-      name = "memory:%x" % id(self)
+      name = f"memory:{id(self):x}"
     else:
       name = repr(self.__name__)
-    return "<%s %s>" % (self.__class__.__name__, name)
+    return f"<{self.__class__.__name__} {name}>"
 
 
 class TemplateExpression(object):

--- a/ambari-common/src/main/python/ambari_jinja2/ambari_jinja2/exceptions.py
+++ b/ambari-common/src/main/python/ambari_jinja2/ambari_jinja2/exceptions.py
@@ -91,7 +91,7 @@ class TemplateSyntaxError(TemplateError):
     location = "line %d" % self.lineno
     name = self.filename or self.name
     if name:
-      location = 'File "%s", %s' % (name, location)
+      location = f'File "{name}", {location}'
     lines = [self.message, "  " + location]
 
     # if the source is set, add the line to the output

--- a/ambari-common/src/main/python/ambari_jinja2/ambari_jinja2/ext.py
+++ b/ambari-common/src/main/python/ambari_jinja2/ambari_jinja2/ext.py
@@ -229,7 +229,7 @@ class InternationalizationExtension(Extension):
       name = parser.stream.expect("name")
       if name.value in variables:
         parser.fail(
-          "translatable variable %r defined twice." % name.value,
+          f"translatable variable {name.value!r} defined twice.",
           name.lineno,
           exc=TemplateAssertionError,
         )
@@ -267,7 +267,7 @@ class InternationalizationExtension(Extension):
         name = parser.stream.expect("name")
         if name.value not in variables:
           parser.fail(
-            "unknown variable %r for pluralization" % name.value,
+            f"unknown variable {name.value!r} for pluralization",
             name.lineno,
             exc=TemplateAssertionError,
           )

--- a/ambari-common/src/main/python/ambari_jinja2/ambari_jinja2/filters.py
+++ b/ambari-common/src/main/python/ambari_jinja2/ambari_jinja2/filters.py
@@ -121,7 +121,7 @@ def do_xmlattr(_eval_ctx, d, autospace=True):
   if the filter returned something unless the second parameter is false.
   """
   rv = " ".join(
-    '%s="%s"' % (escape(key), escape(value))
+    f'{escape(key)}="{escape(value)}"'
     for key, value in d.items()
     if value is not None and not isinstance(value, Undefined)
   )
@@ -308,10 +308,10 @@ def do_filesizeformat(value, binary=False):
   if bytes < base:
     return "%d Byte%s" % (bytes, bytes != 1 and "s" or "")
   elif bytes < base * base:
-    return "%.1f K%sB" % (bytes / base, middle)
+    return f"{bytes / base:.1f} K{middle}B"
   elif bytes < base * base * base:
-    return "%.1f M%sB" % (bytes / (base * base), middle)
-  return "%.1f G%sB" % (bytes / (base * base * base), middle)
+    return f"{bytes / (base * base):.1f} M{middle}B"
+  return f"{bytes / (base * base * base):.1f} G{middle}B"
 
 
 def do_pprint(value, verbose=False):

--- a/ambari-common/src/main/python/ambari_jinja2/ambari_jinja2/lexer.py
+++ b/ambari-common/src/main/python/ambari_jinja2/ambari_jinja2/lexer.py
@@ -133,7 +133,7 @@ operators = {
 reverse_operators = dict([(v, k) for k, v in operators.items()])
 assert len(operators) == len(reverse_operators), "operators dropped"
 operator_re = re.compile(
-  "(%s)" % "|".join(re.escape(x) for x in sorted(operators, key=lambda x: -len(x)))
+  f"({'|'.join(re.escape(x) for x in sorted(operators, key=lambda x: -len(x)))})"
 )
 
 ignored_tokens = frozenset(
@@ -284,7 +284,7 @@ class Token(tuple):
     return False
 
   def __repr__(self):
-    return "Token(%r, %r, %r)" % (self.lineno, self.type, self.value)
+    return f"Token({self.lineno!r}, {self.type!r}, {self.value!r})"
 
 
 class TokenStreamIterator(object):
@@ -384,13 +384,13 @@ class TokenStream(object):
       expr = describe_token_expr(expr)
       if self.current.type is TOKEN_EOF:
         raise TemplateSyntaxError(
-          "unexpected end of template, " "expected %r." % expr,
+          f"unexpected end of template, expected {expr!r}.",
           self.current.lineno,
           self.name,
           self.filename,
         )
       raise TemplateSyntaxError(
-        "expected token %r, got %r" % (expr, describe_token(self.current)),
+        f"expected token {expr!r}, got {describe_token(self.current)!r}",
         self.current.lineno,
         self.name,
         self.filename,
@@ -690,12 +690,12 @@ class Lexer(object):
             elif data in ("}", ")", "]"):
               if not balancing_stack:
                 raise TemplateSyntaxError(
-                  "unexpected '%s'" % data, lineno, name, filename
+                  f"unexpected '{data}'", lineno, name, filename
                 )
               expected_op = balancing_stack.pop()
               if expected_op != data:
                 raise TemplateSyntaxError(
-                  "unexpected '%s', " "expected '%s'" % (data, expected_op),
+                  f"unexpected '{data}', expected '{expected_op}'",
                   lineno,
                   name,
                   filename,
@@ -735,7 +735,7 @@ class Lexer(object):
         # this means a loop without break condition, avoid that and
         # raise error
         elif pos2 == pos:
-          raise RuntimeError("%r yielded empty string without " "stack change" % regex)
+          raise RuntimeError(f"{regex!r} yielded empty string without stack change")
         # publish new function and start again
         pos = pos2
         break

--- a/ambari-common/src/main/python/ambari_jinja2/ambari_jinja2/loaders.py
+++ b/ambari-common/src/main/python/ambari_jinja2/ambari_jinja2/loaders.py
@@ -94,7 +94,7 @@ class BaseLoader(object):
     """
     if not self.has_source_access:
       raise RuntimeError(
-        "%s cannot provide access to the source" % self.__class__.__name__
+        f"{self.__class__.__name__} cannot provide access to the source"
       )
     raise TemplateNotFound(template)
 
@@ -413,7 +413,7 @@ class ModuleLoader(BaseLoader):
   has_source_access = False
 
   def __init__(self, path):
-    package_name = "_ambari_jinja2_module_templates_%x" % id(self)
+    package_name = f"_ambari_jinja2_module_templates_{id(self):x}"
 
     # create a fake module that looks for the templates in the
     # path given.
@@ -445,7 +445,7 @@ class ModuleLoader(BaseLoader):
   @internalcode
   def load(self, environment, name, globals=None):
     key = self.get_template_key(name)
-    module = "%s.%s" % (self.package_name, key)
+    module = f"{self.package_name}.{key}"
     mod = getattr(self.module, module, None)
     if mod is None:
       try:

--- a/ambari-common/src/main/python/ambari_jinja2/ambari_jinja2/nodes.py
+++ b/ambari-common/src/main/python/ambari_jinja2/ambari_jinja2/nodes.py
@@ -128,7 +128,7 @@ class Node(object, metaclass=NodeType):
     if fields:
       if len(fields) != len(self.fields):
         if not self.fields:
-          raise TypeError("%r takes 0 arguments" % self.__class__.__name__)
+          raise TypeError(f"{self.__class__.__name__!r} takes 0 arguments")
         raise TypeError(
           "%r takes 0 or %d argument%s"
           % (
@@ -142,7 +142,7 @@ class Node(object, metaclass=NodeType):
     for attr in self.attributes:
       setattr(self, attr, attributes.pop(attr, None))
     if attributes:
-      raise TypeError("unknown attribute %r" % next(iter(attributes)))
+      raise TypeError(f"unknown attribute {next(iter(attributes))!r}")
 
   def iter_fields(self, exclude=None, only=None):
     """This method iterates over all fields that are defined and yields
@@ -751,7 +751,7 @@ class Operand(Helper):
 if __debug__:
   Operand.__doc__ += "\nThe following operators are available: " + ", ".join(
     sorted(
-      "``%s``" % x
+      f"``{x}``"
       for x in set(_binop_to_func) | set(_uaop_to_func) | set(_cmpop_to_func)
     )
   )

--- a/ambari-common/src/main/python/ambari_jinja2/ambari_jinja2/parser.py
+++ b/ambari-common/src/main/python/ambari_jinja2/ambari_jinja2/parser.py
@@ -68,7 +68,7 @@ class Parser(object):
       expected.extend(map(describe_token_expr, exprs))
     if end_token_stack:
       currently_looking = " or ".join(
-        "'%s'" % describe_token_expr(expr) for expr in end_token_stack[-1]
+        f"'{describe_token_expr(expr)}'" for expr in end_token_stack[-1]
       )
     else:
       currently_looking = None
@@ -76,7 +76,7 @@ class Parser(object):
     if name is None:
       message = ["Unexpected end of template."]
     else:
-      message = ["Encountered unknown tag '%s'." % name]
+      message = [f"Encountered unknown tag '{name}'."]
 
     if currently_looking:
       if name is not None and name in expected:
@@ -87,12 +87,12 @@ class Parser(object):
         )
       else:
         message.append(
-          "Jinja was looking for the following tags: " "%s." % currently_looking
+          f"Jinja was looking for the following tags: {currently_looking}."
         )
 
     if self._tag_stack:
       message.append(
-        "The innermost block that needs to be " "closed is '%s'." % self._tag_stack[-1]
+        f"The innermost block that needs to be closed is '{self._tag_stack[-1]}'."
       )
 
     self.fail(" ".join(message), lineno)
@@ -388,7 +388,7 @@ class Parser(object):
         target = self.parse_primary()
       target.set_ctx("store")
     if not target.can_assign():
-      self.fail("can't assign to %r" % target.__class__.__name__.lower(), target.lineno)
+      self.fail(f"can't assign to {target.__class__.__name__.lower()!r}", target.lineno)
     return target
 
   def parse_expression(self, with_condexpr=True):
@@ -584,7 +584,7 @@ class Parser(object):
     elif token.type == "lbrace":
       node = self.parse_dict()
     else:
-      self.fail("unexpected '%s'" % describe_token(token), token.lineno)
+      self.fail(f"unexpected '{describe_token(token)}'", token.lineno)
     return node
 
   def parse_tuple(
@@ -643,7 +643,7 @@ class Parser(object):
       # tuple.
       if not explicit_parentheses:
         self.fail(
-          "Expected an expression, got '%s'" % describe_token(self.stream.current)
+          f"Expected an expression, got '{describe_token(self.stream.current)}'"
         )
 
     return nodes.Tuple(args, "load", lineno=lineno)

--- a/ambari-common/src/main/python/ambari_jinja2/ambari_jinja2/runtime.py
+++ b/ambari-common/src/main/python/ambari_jinja2/ambari_jinja2/runtime.py
@@ -106,7 +106,7 @@ class TemplateReference(object):
     return BlockReference(name, self.__context, blocks, 0)
 
   def __repr__(self):
-    return "<%s %r>" % (self.__class__.__name__, self.__context.name)
+    return f"<{self.__class__.__name__} {self.__context.name!r}>"
 
 
 class Context(object):
@@ -161,7 +161,7 @@ class Context(object):
       blocks[index]
     except LookupError:
       return self.environment.undefined(
-        "there is no parent block " "called %r." % name, name="super"
+        f"there is no parent block called {name!r}.", name="super"
       )
     return BlockReference(name, self, blocks, index)
 
@@ -256,7 +256,7 @@ class Context(object):
     return item
 
   def __repr__(self):
-    return "<%s %s of %r>" % (self.__class__.__name__, repr(self.get_all()), self.name)
+    return f"<{self.__class__.__name__} {repr(self.get_all())} of {self.name!r}>"
 
 
 # register the context as mapping if possible
@@ -282,7 +282,7 @@ class BlockReference(object):
     """Super the block."""
     if self._depth + 1 >= len(self._stack):
       return self._context.environment.undefined(
-        "there is no parent block called %r." % self.name, name="super"
+        f"there is no parent block called {self.name!r}.", name="super"
       )
     return BlockReference(self.name, self._context, self._stack, self._depth + 1)
 
@@ -356,7 +356,7 @@ class LoopContext(object):
     return self._length
 
   def __repr__(self):
-    return "<%s %r/%r>" % (self.__class__.__name__, self.index, self.length)
+    return f"<{self.__class__.__name__} {self.index!r}/{self.length!r}>"
 
 
 class LoopContextIterator(object):
@@ -418,7 +418,7 @@ class Macro(object):
             value = self.defaults[idx - self._argument_count + off]
           except IndexError:
             value = self._environment.undefined(
-              "parameter %r was not provided" % name, name=name
+              f"parameter {name!r} was not provided", name=name
             )
         arguments.append(value)
 
@@ -434,13 +434,13 @@ class Macro(object):
       arguments.append(kwargs)
     elif kwargs:
       raise TypeError(
-        "macro %r takes no keyword argument %r" % (self.name, next(iter(kwargs)))
+        f"macro {self.name!r} takes no keyword argument {next(iter(kwargs))!r}"
       )
     if self.catch_varargs:
       arguments.append(args[self._argument_count :])
     elif len(args) > self._argument_count:
       raise TypeError(
-        "macro %r takes not more than %d argument(s)" % (self.name, len(self.arguments))
+        f"macro {self.name!r} takes not more than {len(self.arguments)} argument(s)"
       )
     return self._func(*arguments)
 
@@ -486,7 +486,7 @@ class Undefined(object):
     """
     if self._undefined_hint is None:
       if self._undefined_obj is missing:
-        hint = "%r is undefined" % self._undefined_name
+        hint = f"{self._undefined_name!r} is undefined"
       elif not isinstance(self._undefined_name, str):
         hint = "%s has no element %r" % (
           object_type_repr(self._undefined_obj),

--- a/ambari-common/src/main/python/ambari_jinja2/ambari_jinja2/sandbox.py
+++ b/ambari-common/src/main/python/ambari_jinja2/ambari_jinja2/sandbox.py
@@ -295,7 +295,7 @@ class SandboxedEnvironment(Environment):
     # the double prefixes are to avoid double keyword argument
     # errors when proxying the call.
     if not __self.is_safe_callable(__obj):
-      raise SecurityError("%r is not safely callable" % (__obj,))
+      raise SecurityError(f"{__obj!r} is not safely callable")
     return __context.call(__obj, *args, **kwargs)
 
 

--- a/ambari-common/src/main/python/ambari_jinja2/ambari_jinja2/testsuite/__init__.py
+++ b/ambari-common/src/main/python/ambari_jinja2/ambari_jinja2/testsuite/__init__.py
@@ -59,7 +59,7 @@ class JinjaTestCase(unittest.TestCase):
       tb = format_exception(*sys.exc_info())
       if re.search(expected_tb.strip(), "".join(tb)) is None:
         raise self.fail(
-          "Traceback did not match:\n\n%s\nexpected:\n%s" % ("".join(tb), expected_tb)
+          f"Traceback did not match:\n\n{''.join(tb)}\nexpected:\n{expected_tb}"
         )
     else:
       self.fail("Expected exception")

--- a/ambari-common/src/main/python/ambari_jinja2/ambari_jinja2/testsuite/ext.py
+++ b/ambari-common/src/main/python/ambari_jinja2/ambari_jinja2/testsuite/ext.py
@@ -122,7 +122,7 @@ class TestExtension(Extension):
     ).set_lineno(next(parser.stream).lineno)
 
   def _dump(self, sandboxed, ext_attr, imported_object, context):
-    return "%s|%s|%s|%s" % (sandboxed, ext_attr, imported_object, context.blocks)
+    return f"{sandboxed}|{ext_attr}|{imported_object}|{context.blocks}"
 
 
 class PreprocessorExtension(Extension):

--- a/ambari-common/src/main/python/ambari_jinja2/ambari_jinja2/testsuite/lexnparse.py
+++ b/ambari-common/src/main/python/ambari_jinja2/ambari_jinja2/testsuite/lexnparse.py
@@ -313,7 +313,7 @@ class SyntaxTestCase(JinjaTestCase):
       if should_fail:
         self.assert_raises(TemplateSyntaxError, env.from_string, "{{ foo(%s) }}" % sig)
       else:
-        env.from_string("foo(%s)" % sig)
+        env.from_string(f"foo({sig})")
 
   def test_tuple_expr(self):
     for tmpl in [
@@ -344,7 +344,7 @@ class SyntaxTestCase(JinjaTestCase):
         "{{ %s }}|{{ %s }}|{{ %s }}"
         % (str(const), str(const).lower(), str(const).upper())
       )
-      assert tmpl.render() == "%s|%s|" % (const, const)
+      assert tmpl.render() == f"{const}|{const}|"
 
   def test_test_chaining(self):
     self.assert_raises(

--- a/ambari-common/src/main/python/ambari_jinja2/ambari_jinja2/utils.py
+++ b/ambari-common/src/main/python/ambari_jinja2/ambari_jinja2/utils.py
@@ -257,7 +257,7 @@ def object_type_repr(obj):
     name = obj.__class__.__name__
   else:
     name = obj.__class__.__module__ + "." + obj.__class__.__name__
-  return "%s object" % name
+  return f"{name} object"
 
 
 def pformat(obj, verbose=False):
@@ -306,20 +306,16 @@ def urlize(text, trim_url_limit=None, nofollow=False):
           middle.endswith(".org") or middle.endswith(".net") or middle.endswith(".com")
         )
       ):
-        middle = '<a href="http://%s"%s>%s</a>' % (
-          middle,
-          nofollow_attr,
-          trim_url(middle),
-        )
+        middle = f'<a href="http://{middle}"{nofollow_attr}>{trim_url(middle)}</a>'
       if middle.startswith("http://") or middle.startswith("https://"):
-        middle = '<a href="%s"%s>%s</a>' % (middle, nofollow_attr, trim_url(middle))
+        middle = f'<a href="{middle}"{nofollow_attr}>{trim_url(middle)}</a>'
       if (
         "@" in middle
         and not middle.startswith("www.")
         and not ":" in middle
         and _simple_email_re.match(middle)
       ):
-        middle = '<a href="mailto:%s">%s</a>' % (middle, middle)
+        middle = f'<a href="mailto:{middle}">{middle}</a>'
       if lead + middle + trail != word:
         words[i] = lead + middle + trail
   return "".join(words)
@@ -372,7 +368,7 @@ def generate_lorem_ipsum(n=5, html=True, min=20, max=100):
 
   if not html:
     return "\n\n".join(result)
-  return Markup("\n".join("<p>%s</p>" % escape(x) for x in result))
+  return Markup("\n".join(f"<p>{escape(x)}</p>" for x in result))
 
 
 class LRUCache(object):
@@ -456,7 +452,7 @@ class LRUCache(object):
     return len(self._mapping)
 
   def __repr__(self):
-    return "<%s %r>" % (self.__class__.__name__, self._mapping)
+    return f"<{self.__class__.__name__} {self._mapping!r}>"
 
   def __getitem__(self, key):
     """Get an item from the cache. Moves the item up so that it has the

--- a/ambari-common/src/main/python/ambari_jinja2/docs/jinjaext.py
+++ b/ambari-common/src/main/python/ambari_jinja2/docs/jinjaext.py
@@ -98,7 +98,7 @@ def format_function(name, aliases, func):
             signature = inspect.formatargspec(*argspec)
         except:
             pass
-    result = ['.. function:: %s%s' % (name, signature), '']
+    result = [f'.. function:: {name}{signature}', '']
     result.extend('    ' + line for line in lines)
     if aliases:
         result.extend(('', '    :aliases: %s' % ', '.join(
@@ -142,7 +142,7 @@ def jinja_nodes(dirname, arguments, options, content, lineno,
     def walk(node, indent):
         p = ' ' * indent
         sig = ', '.join(node.fields)
-        doc.append(p + '.. autoclass:: %s(%s)' % (node.__name__, sig), '')
+        doc.append(p + f'.. autoclass:: {node.__name__}({sig})', '')
         if node.abstract:
             members = []
             for key, name in node.__dict__.items():
@@ -151,11 +151,10 @@ def jinja_nodes(dirname, arguments, options, content, lineno,
                     members.append(key)
             if members:
                 members.sort()
-                doc.append('%s :members: %s' % (p, ', '.join(members)), '')
+                doc.append(f"{p} :members: {', '.join(members)}", '')
         if node.__base__ != object:
             doc.append('', '')
-            doc.append('%s :Node type: :class:`%s`' %
-                       (p, node.__base__.__name__), '')
+            doc.append(f'{p} :Node type: :class:`{node.__base__.__name__}`', '')
         doc.append('', '')
         children = node.__subclasses__()
         children.sort(key=lambda x: x.__name__.lower())

--- a/ambari-common/src/main/python/ambari_jinja2/examples/bench.py
+++ b/ambari-common/src/main/python/ambari_jinja2/examples/bench.py
@@ -464,7 +464,7 @@ for test in (
   if locals()["test_" + test] is None:
     sys.stdout.write("    %-20s*not installed*\n" % test)
     continue
-  t = Timer(setup="from __main__ import test_%s as bench" % test, stmt="bench()")
+  t = Timer(setup=f"from __main__ import test_{test} as bench", stmt="bench()")
   sys.stdout.write(" >> %-20s<running>" % test)
   sys.stdout.flush()
   sys.stdout.write("\r    %-20s%.4f seconds\n" % (test, t.timeit(number=50) / 50))

--- a/ambari-common/src/main/python/ambari_jinja2/examples/rwbench/rwbench.py
+++ b/ambari-common/src/main/python/ambari_jinja2/examples/rwbench/rwbench.py
@@ -55,7 +55,7 @@ class Article(object):
 
 class User(object):
   def __init__(self, username):
-    self.href = "/user/%s" % username
+    self.href = f"/user/{username}"
     self.username = username
 
 
@@ -103,7 +103,7 @@ def test_genshi():
 if __name__ == "__main__":
   sys.stdout.write("Realworldish Benchmark:\n")
   for test in "jinja", "mako", "django", "genshi":
-    t = Timer(setup="from __main__ import test_%s as bench" % test, stmt="bench()")
+    t = Timer(setup=f"from __main__ import test_{test} as bench", stmt="bench()")
     sys.stdout.write(" >> %-20s<running>" % test)
     sys.stdout.flush()
     sys.stdout.write("\r    %-20s%.4f seconds\n" % (test, t.timeit(number=200) / 200))

--- a/ambari-common/src/main/python/ambari_jinja2/ext/django2jinja/django2jinja.py
+++ b/ambari-common/src/main/python/ambari_jinja2/ext/django2jinja/django2jinja.py
@@ -286,11 +286,11 @@ class Writer(object):
     for filter, args in filters:
       name = self.get_filter_name(filter)
       if name is None:
-        self.warn("Could not find filter %s" % name)
+        self.warn(f"Could not find filter {name}")
         continue
       if name not in DEFAULT_FILTERS and name not in self._filters_warned:
         self._filters_warned.add(name)
-        self.warn("Filter %s probably doesn't exist in Jinja" % name)
+        self.warn(f"Filter {name} probably doesn't exist in Jinja")
       if not want_pipe:
         want_pipe = True
       else:
@@ -357,7 +357,7 @@ class Writer(object):
         break
     else:
       self.warn(
-        "Untranslatable node %s.%s found" % (node.__module__, node.__class__.__name__),
+        f"Untranslatable node {node.__module__}.{node.__class__.__name__} found",
         node,
       )
 
@@ -450,7 +450,7 @@ def if_condition(writer, node):
 
   for idx, (ifnot, expr) in enumerate(node.bool_exprs):
     if idx:
-      writer.write(" %s " % join_with)
+      writer.write(f" {join_with} ")
     if ifnot:
       writer.write("not ")
     writer.node(expr)
@@ -521,7 +521,7 @@ def cycle(writer, node):
     return
   if node.variable_name is not None:
     writer.start_block()
-    writer.write("set %s = " % node.variable_name)
+    writer.write(f"set {node.variable_name} = ")
   else:
     writer.start_variable()
   writer.write("loop.cycle(")
@@ -593,7 +593,7 @@ def url_tag(writer, node):
   writer.warn("url node used.  make sure to provide a proper url() " "function", node)
   if node.asvar:
     writer.start_block()
-    writer.write("set %s = " % node.asvar)
+    writer.write(f"set {node.asvar} = ")
   else:
     writer.start_variable()
   autoescape = writer.autoescape
@@ -603,7 +603,7 @@ def url_tag(writer, node):
     writer.write(", ")
     writer.node(arg)
   for key, arg in node.kwargs.items():
-    writer.write(", %s=" % key)
+    writer.write(f", {key}=")
     writer.node(arg)
   writer.write(")")
   if node.asvar:
@@ -638,7 +638,7 @@ def with_block(writer, node):
     node,
   )
   writer.start_block()
-  writer.write("set %s = " % node.name)
+  writer.write(f"set {node.name} = ")
   writer.node(node.var)
   writer.end_block()
   writer.body(node.nodelist)
@@ -661,7 +661,7 @@ def regroup(writer, node):
       node,
     )
   writer.start_block()
-  writer.write("set %s = " % node.var_name)
+  writer.write(f"set {node.var_name} = ")
   writer.node(node.target)
   writer.write("|groupby(")
   writer.literal(node.expression.var.var)
@@ -678,7 +678,7 @@ def warn_load(writer, node):
 def get_available_languages(writer, node):
   writer.warn("make sure to provide a get_available_languages function", node)
   writer.tag(
-    "set %s = get_available_languages()" % writer.translate_variable_name(node.variable)
+    f"set {writer.translate_variable_name(node.variable)} = get_available_languages()"
   )
 
 
@@ -686,7 +686,7 @@ def get_available_languages(writer, node):
 def get_current_language(writer, node):
   writer.warn("make sure to provide a get_current_language function", node)
   writer.tag(
-    "set %s = get_current_language()" % writer.translate_variable_name(node.variable)
+    f"set {writer.translate_variable_name(node.variable)} = get_current_language()"
   )
 
 
@@ -734,7 +734,7 @@ def translate_block(writer, node):
   for idx, (key, var) in enumerate(node.extra_context.items()):
     if idx:
       writer.write(",")
-    writer.write(" %s=" % key)
+    writer.write(f" {key}=")
     touch_var(key)
     writer.node(var.filter_expression)
 
@@ -747,7 +747,7 @@ def translate_block(writer, node):
       if idx > -1:
         writer.write(",")
       touch_var(plural_var)
-      writer.write(" %s=" % plural_var)
+      writer.write(f" {plural_var}=")
       writer.node(node.counter)
 
   writer.end_block()
@@ -770,7 +770,7 @@ def simple_tag(writer, node):
     writer.env and name not in writer.env.filters and name not in writer._filters_warned
   ):
     writer._filters_warned.add(name)
-    writer.warn("Filter %s probably doesn't exist in Jinja" % name)
+    writer.warn(f"Filter {name} probably doesn't exist in Jinja")
 
   if not node.vars_to_resolve:
     # No argument, pass the request

--- a/ambari-common/src/main/python/ambari_pbkdf2/pbkdf2.py
+++ b/ambari-common/src/main/python/ambari_pbkdf2/pbkdf2.py
@@ -284,7 +284,7 @@ def crypt(word, salt=None, iterations=None):
       iterations = 400
     else:
       converted = int(iterations, 16)
-      if iterations != "%x" % converted:  # lowercase hex, minimum digits
+      if iterations != f"{converted:x}":  # lowercase hex, minimum digits
         raise ValueError("Invalid salt")
       iterations = converted
       if not (iterations >= 1):
@@ -294,13 +294,13 @@ def crypt(word, salt=None, iterations=None):
   allowed = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789./"
   for ch in salt:
     if ch not in allowed:
-      raise ValueError("Illegal character %r in salt" % (ch,))
+      raise ValueError(f"Illegal character {ch!r} in salt")
 
   if iterations is None or iterations == 400:
     iterations = 400
     salt = "$p5k2$$" + salt
   else:
-    salt = "$p5k2$%x$%s" % (iterations, salt)
+    salt = f"$p5k2${iterations:x}${salt}"
   rawhash = PBKDF2(word, salt, iterations).read(24)
   return salt + "$" + b64encode(rawhash, "./")
 

--- a/ambari-common/src/main/python/ambari_simplejson/encoder.py
+++ b/ambari-common/src/main/python/ambari_simplejson/encoder.py
@@ -49,7 +49,7 @@ ESCAPE_DCT = {
 }
 for i in range(0x20):
   # ESCAPE_DCT.setdefault(chr(i), '\\u{0:04x}'.format(i))
-  ESCAPE_DCT.setdefault(chr(i), "\\u%04x" % (i,))
+  ESCAPE_DCT.setdefault(chr(i), f"\\u{i:04x}")
 
 FLOAT_REPR = repr
 
@@ -110,14 +110,14 @@ def py_encode_basestring_ascii(s, _PY3=PY3):
       n = ord(s)
       if n < 0x10000:
         # return '\\u{0:04x}'.format(n)
-        return "\\u%04x" % (n,)
+        return f"\\u{n:04x}"
       else:
         # surrogate pair
         n -= 0x10000
         s1 = 0xD800 | ((n >> 10) & 0x3FF)
         s2 = 0xDC00 | (n & 0x3FF)
         # return '\\u{0:04x}\\u{1:04x}'.format(s1, s2)
-        return "\\u%04x\\u%04x" % (s1, s2)
+        return f"\\u{s1:04x}\\u{s2:04x}"
 
   return '"' + str(ESCAPE_ASCII.sub(replace, s)) + '"'
 
@@ -303,7 +303,7 @@ class JSONEncoder(object):
             return JSONEncoder.default(self, o)
 
     """
-    raise TypeError("Object of type %s is not JSON serializable" % o.__class__.__name__)
+    raise TypeError(f"Object of type {o.__class__.__name__} is not JSON serializable")
 
   def encode(self, o):
     """Return a JSON string representation of a Python data structure.
@@ -630,7 +630,7 @@ def _make_iterencode(
       key = None
     else:
       raise TypeError(
-        "keys must be str, int, float, bool or None, " "not %s" % key.__class__.__name__
+        f"keys must be str, int, float, bool or None, not {key.__class__.__name__}"
       )
     return key
 

--- a/ambari-common/src/main/python/ambari_simplejson/ordered_dict.py
+++ b/ambari-common/src/main/python/ambari_simplejson/ordered_dict.py
@@ -11,7 +11,7 @@ from UserDict import DictMixin
 class OrderedDict(dict, DictMixin):
   def __init__(self, *args, **kwds):
     if len(args) > 1:
-      raise TypeError("expected at most 1 arguments, got %d" % len(args))
+      raise TypeError(f"expected at most 1 arguments, got {len(args)}")
     try:
       self.__end
     except AttributeError:
@@ -82,8 +82,8 @@ class OrderedDict(dict, DictMixin):
 
   def __repr__(self):
     if not self:
-      return "%s()" % (self.__class__.__name__,)
-    return "%s(%r)" % (self.__class__.__name__, self.items())
+      return f"{self.__class__.__name__}()"
+    return f"{self.__class__.__name__}({self.items()!r})"
 
   def copy(self):
     return self.__class__(self)

--- a/ambari-common/src/main/python/ambari_stomp/adapter/multicast.py
+++ b/ambari-common/src/main/python/ambari_stomp/adapter/multicast.py
@@ -179,13 +179,13 @@ class MulticastConnection(BaseConnection, Protocol12):
     if cmd == CMD_BEGIN:
       trans = headers[HDR_TRANSACTION]
       if trans in self.transactions:
-        self.notify("error", {}, "Transaction %s already started" % trans)
+        self.notify("error", {}, f"Transaction {trans} already started")
       else:
         self.transactions[trans] = []
     elif cmd == CMD_COMMIT:
       trans = headers[HDR_TRANSACTION]
       if trans not in self.transactions:
-        self.notify("error", {}, "Transaction %s not started" % trans)
+        self.notify("error", {}, f"Transaction {trans} not started")
       else:
         for f in self.transactions[trans]:
           self.transport.transmit(f)
@@ -197,7 +197,7 @@ class MulticastConnection(BaseConnection, Protocol12):
       if "transaction" in headers:
         trans = headers["transaction"]
         if trans not in self.transactions:
-          self.transport.notify("error", {}, "Transaction %s not started" % trans)
+          self.transport.notify("error", {}, f"Transaction {trans} not started")
           return
         else:
           self.transactions[trans].append(frame)

--- a/ambari-common/src/main/python/ambari_stomp/listener.py
+++ b/ambari-common/src/main/python/ambari_stomp/listener.py
@@ -418,17 +418,11 @@ class StatsListener(ConnectionListener):
     Return a string containing the current statistics (messages sent and received,
     errors, etc)
     """
-    return """Connections: %s
-Messages sent: %s
-Messages received: %s
-Heartbeats received: %s
-Errors: %s""" % (
-      self.connections,
-      self.messages_sent,
-      self.messages,
-      self.heartbeat_count,
-      self.errors,
-    )
+    return f"""Connections: {self.connections}
+Messages sent: {self.messages_sent}
+Messages received: {self.messages}
+Heartbeats received: {self.heartbeat_count}
+Errors: {self.errors}"""
 
 
 class PrintingListener(ConnectionListener):
@@ -443,7 +437,7 @@ class PrintingListener(ConnectionListener):
     :param dict headers:
     :param body:
     """
-    print("on_connected %s %s" % (headers, body))
+    print(f"on_connected {headers} {body}")
 
   def on_disconnected(self):
     print("on_disconnected")
@@ -456,7 +450,7 @@ class PrintingListener(ConnectionListener):
     :param dict headers:
     :param body:
     """
-    print("on_before_message %s %s" % (headers, body))
+    print(f"on_before_message {headers} {body}")
     return headers, body
 
   def on_message(self, headers, body):
@@ -464,27 +458,27 @@ class PrintingListener(ConnectionListener):
     :param dict headers:
     :param body:
     """
-    print("on_message %s %s" % (headers, body))
+    print(f"on_message {headers} {body}")
 
   def on_receipt(self, headers, body):
     """
     :param dict headers:
     :param body:
     """
-    print("on_receipt %s %s" % (headers, body))
+    print(f"on_receipt {headers} {body}")
 
   def on_error(self, headers, body):
     """
     :param dict headers:
     :param body:
     """
-    print("on_error %s %s" % (headers, body))
+    print(f"on_error {headers} {body}")
 
   def on_send(self, frame):
     """
     :param Frame frame:
     """
-    print("on_send %s %s %s" % (frame.cmd, frame.headers, frame.body))
+    print(f"on_send {frame.cmd} {frame.headers} {frame.body}")
 
   def on_heartbeat(self):
     print("on_heartbeat")

--- a/ambari-common/src/main/python/ambari_stomp/transport.py
+++ b/ambari-common/src/main/python/ambari_stomp/transport.py
@@ -242,7 +242,7 @@ class BaseTransport(ambari_stomp.listener.Publisher):
       if not listener:
         continue
 
-      notify_func = getattr(listener, "on_%s" % frame_type, None)
+      notify_func = getattr(listener, f"on_{frame_type}", None)
       if not notify_func:
         log.debug("listener %s has no method on_%s", listener, frame_type)
         continue

--- a/ambari-common/src/main/python/ambari_stomp/utils.py
+++ b/ambari-common/src/main/python/ambari_stomp/utils.py
@@ -210,7 +210,7 @@ def convert_frame_to_lines(frame):
     if type(vals) != tuple:
       vals = (vals,)
     for val in vals:
-      lines.append("%s:%s\n" % (key, val))
+      lines.append(f"{key}:{val}\n")
   lines.append("\n")
   if frame.body:
     lines.append(frame.body)

--- a/ambari-common/src/main/python/ambari_ws4py/__init__.py
+++ b/ambari-common/src/main/python/ambari_ws4py/__init__.py
@@ -68,4 +68,4 @@ def format_addresses(ws):
     peer_ip, peer_port = ws.peer_address
     return "[Local => %s:%d | Remote => %s:%d]" % (me_ip, me_port, peer_ip, peer_port)
 
-  return "[Bound to '%s']" % me
+  return f"[Bound to '{me}']"

--- a/ambari-common/src/main/python/ambari_ws4py/client/__init__.py
+++ b/ambari-common/src/main/python/ambari_ws4py/client/__init__.py
@@ -191,7 +191,7 @@ class WebSocketBaseClient(WebSocket):
     elif scheme in ("ws+unix", "wss+unix"):
       pass
     else:
-      raise ValueError("Invalid scheme: %s" % scheme)
+      raise ValueError(f"Invalid scheme: {scheme}")
 
     if parsed.path:
       resource = parsed.path
@@ -275,7 +275,7 @@ class WebSocketBaseClient(WebSocket):
     handshake.
     """
     headers = [
-      ("Host", "%s:%s" % (self.host, self.port)),
+      ("Host", f"{self.host}:{self.port}"),
       ("Connection", "Upgrade"),
       ("Upgrade", "websocket"),
       ("Sec-WebSocket-Key", self.key.decode("utf-8")),
@@ -313,9 +313,9 @@ class WebSocketBaseClient(WebSocket):
     Prepare the request to be sent for the upgrade handshake.
     """
     headers = self.handshake_headers
-    request = [("GET %s HTTP/1.1" % self.resource).encode("utf-8")]
+    request = [f"GET {self.resource} HTTP/1.1".encode("utf-8")]
     for header, value in headers:
-      request.append(("%s: %s" % (header, value)).encode("utf-8"))
+      request.append(f"{header}: {value}".encode("utf-8"))
     request.append(b"\r\n")
 
     return b"\r\n".join(request)
@@ -327,7 +327,7 @@ class WebSocketBaseClient(WebSocket):
     """
     protocol, code, status = response_line.split(b" ", 2)
     if code != b"101":
-      raise HandshakeError("Invalid response status: %s %s" % (code, status))
+      raise HandshakeError(f"Invalid response status: {code} {status}")
 
   def process_handshake_header(self, headers):
     """
@@ -345,15 +345,15 @@ class WebSocketBaseClient(WebSocket):
       value = value.strip().lower()
 
       if header == b"upgrade" and value != b"websocket":
-        raise HandshakeError("Invalid Upgrade header: %s" % value)
+        raise HandshakeError(f"Invalid Upgrade header: {value}")
 
       elif header == b"connection" and value != b"upgrade":
-        raise HandshakeError("Invalid Connection header: %s" % value)
+        raise HandshakeError(f"Invalid Connection header: {value}")
 
       elif header == b"sec-websocket-accept":
         match = b64encode(sha1(self.key + WS_KEY).digest())
         if value != match.lower():
-          raise HandshakeError("Invalid challenge response: %s" % value)
+          raise HandshakeError(f"Invalid challenge response: {value}")
 
       elif header == b"sec-websocket-protocol":
         protocols.extend([x.strip() for x in value.split(b",")])

--- a/ambari-common/src/main/python/ambari_ws4py/client/threadedclient.py
+++ b/ambari-common/src/main/python/ambari_ws4py/client/threadedclient.py
@@ -104,7 +104,7 @@ if __name__ == "__main__":
       print(("Closed down", code, reason))
 
     def received_message(self, m):
-      print("#%d" % len(m))
+      print(f"#{len(m)}")
       if len(m) == 175:
         self.close(reason="bye bye")
 

--- a/ambari-common/src/main/python/ambari_ws4py/client/tornadoclient.py
+++ b/ambari-common/src/main/python/ambari_ws4py/client/tornadoclient.py
@@ -160,7 +160,7 @@ if __name__ == "__main__":
         self.send("*" * i)
 
     def received_message(self, m):
-      print("#%d" % len(m))
+      print(f"#{len(m)}")
       if len(m) == 175:
         self.close()
 

--- a/ambari-common/src/main/python/ambari_ws4py/manager.py
+++ b/ambari-common/src/main/python/ambari_ws4py/manager.py
@@ -255,7 +255,7 @@ class WebSocketManager(threading.Thread):
     if websocket in self:
       return
 
-    logger.info("Managing websocket %s" % format_addresses(websocket))
+    logger.info(f"Managing websocket {format_addresses(websocket)}")
     websocket.opened()
     with self.lock:
       fd = websocket.sock.fileno()
@@ -273,7 +273,7 @@ class WebSocketManager(threading.Thread):
     if websocket not in self:
       return
 
-    logger.info("Removing websocket %s" % format_addresses(websocket))
+    logger.info(f"Removing websocket {format_addresses(websocket)}")
     with self.lock:
       fd = websocket.sock.fileno()
       self.websockets.pop(fd, None)
@@ -337,7 +337,7 @@ class WebSocketManager(threading.Thread):
               self.poller.unregister(fd)
 
             if not ws.terminated:
-              logger.info("Terminating websocket %s" % format_addresses(ws))
+              logger.info(f"Terminating websocket {format_addresses(ws)}")
               ws.terminate()
 
   def close_all(self, code=1001, message="Server is shutting down"):

--- a/ambari-common/src/main/python/ambari_ws4py/messaging.py
+++ b/ambari-common/src/main/python/ambari_ws4py/messaging.py
@@ -54,7 +54,7 @@ class Message(object):
     elif isinstance(data, bytearray):
       data = bytes(data)
     elif not isinstance(data, bytes):
-      raise TypeError("%s is not a supported data type" % type(data))
+      raise TypeError(f"{type(data)} is not a supported data type")
 
     self.data = data
 
@@ -110,7 +110,7 @@ class Message(object):
     elif isinstance(data, unicode):
       self.data += data.encode(self.encoding)
     else:
-      raise TypeError("%s is not a supported data type" % type(data))
+      raise TypeError(f"{type(data)} is not a supported data type")
 
   def __len__(self):
     return len(self.__unicode__())

--- a/ambari-common/src/main/python/ambari_ws4py/server/cherrypyserver.py
+++ b/ambari-common/src/main/python/ambari_ws4py/server/cherrypyserver.py
@@ -134,9 +134,9 @@ class WebSocketTool(Tool):
     for key, expected_value in [("Upgrade", "websocket"), ("Connection", "upgrade")]:
       actual_value = request.headers.get(key, "").lower()
       if not actual_value:
-        raise HandshakeError("Header %s is not defined" % key)
+        raise HandshakeError(f"Header {key} is not defined")
       if expected_value not in actual_value:
-        raise HandshakeError("Illegal value for header %s: %s" % (key, actual_value))
+        raise HandshakeError(f"Illegal value for header {key}: {actual_value}")
 
     version = request.headers.get("Sec-WebSocket-Version")
     supported_versions = ", ".join([str(v) for v in ws_version])
@@ -189,7 +189,7 @@ class WebSocketTool(Tool):
       location.append(":%d" % request.local.port)
     location.append(request.path_info)
     if request.query_string != "":
-      location.append("?%s" % request.query_string)
+      location.append(f"?{request.query_string}")
     ws_location = "".join(location)
 
     response = cherrypy.serving.response
@@ -392,7 +392,7 @@ if __name__ == "__main__":
 
     @cherrypy.expose
     def index(self):
-      cherrypy.log("Handler created: %s" % repr(cherrypy.request.ws_handler))
+      cherrypy.log(f"Handler created: {repr(cherrypy.request.ws_handler)}")
 
   cherrypy.quickstart(
     Root(),

--- a/ambari-common/src/main/python/ambari_ws4py/server/geventserver.py
+++ b/ambari-common/src/main/python/ambari_ws4py/server/geventserver.py
@@ -75,7 +75,7 @@ class GEventWebSocketPool(Pool):
   """
 
   def track(self, websocket):
-    logger.info("Managing websocket %s" % format_addresses(websocket))
+    logger.info(f"Managing websocket {format_addresses(websocket)}")
     return self.spawn(websocket.run)
 
   def clear(self):

--- a/ambari-common/src/main/python/ambari_ws4py/server/wsgiutils.py
+++ b/ambari-common/src/main/python/ambari_ws4py/server/wsgiutils.py
@@ -101,9 +101,9 @@ class WebSocketWSGIApplication(object):
     ]:
       actual_value = environ.get(key, "").lower()
       if not actual_value:
-        raise HandshakeError("Header %s is not defined" % key)
+        raise HandshakeError(f"Header {key} is not defined")
       if expected_value not in actual_value:
-        raise HandshakeError("Illegal value for header %s: %s" % (key, actual_value))
+        raise HandshakeError(f"Illegal value for header {key}: {actual_value}")
 
     key = environ.get("HTTP_SEC_WEBSOCKET_KEY")
     if key:
@@ -150,7 +150,7 @@ class WebSocketWSGIApplication(object):
     upgrade_headers = [
       ("Upgrade", "websocket"),
       ("Connection", "Upgrade"),
-      ("Sec-WebSocket-Version", "%s" % version),
+      ("Sec-WebSocket-Version", f"{version}"),
       ("Sec-WebSocket-Accept", accept_value),
     ]
     if ws_protocols:

--- a/ambari-common/src/main/python/ambari_ws4py/websocket.py
+++ b/ambari-common/src/main/python/ambari_ws4py/websocket.py
@@ -350,7 +350,7 @@ class WebSocket(object):
         )
 
     else:
-      raise ValueError("Unsupported type '%s' passed to send()" % type(payload))
+      raise ValueError(f"Unsupported type '{type(payload)}' passed to send()")
 
   def _get_from_pending(self):
     """

--- a/ambari-common/src/main/python/resource_management/core/base.py
+++ b/ambari-common/src/main/python/resource_management/core/base.py
@@ -39,7 +39,7 @@ class ResourceArgument(object):
 
   def validate(self, value):
     if self.required and value is None:
-      raise InvalidArgument("Required argument %s missing" % self.name)
+      raise InvalidArgument(f"Required argument {self.name} missing")
     return value
 
 
@@ -56,7 +56,7 @@ class BooleanArgument(ResourceArgument):
     value = super(BooleanArgument, self).validate(value)
     if not value in (True, False):
       raise InvalidArgument(
-        "Expected a boolean for %s received %r" % (self.name, value)
+        f"Expected a boolean for {self.name} received {value!r}"
       )
     return value
 
@@ -69,7 +69,7 @@ class IntegerArgument(ResourceArgument):
     value = super(IntegerArgument, self).validate(value)
     if not isinstance(value, int):
       raise InvalidArgument(
-        "Expected an integer for %s received %r" % (self.name, value)
+        f"Expected an integer for {self.name} received {value!r}"
       )
     return value
 
@@ -157,12 +157,12 @@ class Resource(object, metaclass=ResourceMetaclass):
       try:
         arg = self._arguments[key]
       except KeyError:
-        raise Fail("%s received unsupported argument %s" % (self, key))
+        raise Fail(f"{self} received unsupported argument {key}")
       else:
         try:
           self.arguments[key] = arg.validate(value)
         except InvalidArgument as exc:
-          raise InvalidArgument("%s %s" % (self, exc))
+          raise InvalidArgument(f"{self} {exc}")
 
     if not self.env.test_mode:
       self.env.run()
@@ -174,10 +174,7 @@ class Resource(object, metaclass=ResourceMetaclass):
     return str(self)
 
   def __str__(self):
-    return "%s[%s]" % (
-      self.__class__.__name__,
-      Logger._get_resource_name_repr(self.name),
-    )
+    return f"{self.__class__.__name__}[{Logger._get_resource_name_repr(self.name)}]"
 
   def __getstate__(self):
     return dict(

--- a/ambari-common/src/main/python/resource_management/core/environment.py
+++ b/ambari-common/src/main/python/resource_management/core/environment.py
@@ -92,7 +92,7 @@ class Environment(object):
         os.makedirs(self.config.backup.path, 0o700)
       new_name = self.config.backup.prefix + path.replace("/", "-")
       backup_path = os.path.join(self.config.backup.path, new_name)
-      Logger.info("backing up %s to %s" % (path, backup_path))
+      Logger.info(f"backing up {path} to {backup_path}")
       shutil.copy(path, backup_path)
 
   def update_config(self, attributes, overwrite=True):
@@ -131,9 +131,9 @@ class Environment(object):
     provider_class = find_provider(self, resource.__class__.__name__, resource.provider)
     provider = provider_class(resource)
     try:
-      provider_action = getattr(provider, "action_%s" % action)
+      provider_action = getattr(provider, f"action_{action}")
     except AttributeError:
-      raise Fail("%r does not implement action %s" % (provider, action))
+      raise Fail(f"{provider!r} does not implement action {action}")
     provider_action()
 
   def _check_condition(self, cond):
@@ -147,7 +147,7 @@ class Environment(object):
       ret, out = shell.call(cond)
       return ret == 0
 
-    raise Exception("Unknown condition type %r" % cond)
+    raise Exception(f"Unknown condition type {cond!r}")
 
   def run(self):
     # Run resource actions

--- a/ambari-common/src/main/python/resource_management/core/providers/__init__.py
+++ b/ambari-common/src/main/python/resource_management/core/providers/__init__.py
@@ -38,7 +38,7 @@ class Provider(object):
     return self.__str__()
 
   def __str__(self):
-    return "%s[%s]" % (self.__class__.__name__, self.resource)
+    return f"{self.__class__.__name__}[{self.resource}]"
 
 
 PROVIDERS = dict(
@@ -90,6 +90,6 @@ def find_provider(env, resource, class_path=None):
   try:
     mod_path, class_name = class_path.rsplit(".", 1)
   except ValueError:
-    raise Fail("Unable to find provider for %s as %s" % (resource, class_path))
+    raise Fail(f"Unable to find provider for {resource} as {class_path}")
   mod = __import__(mod_path, {}, {}, [class_name])
   return getattr(mod, class_name)

--- a/ambari-common/src/main/python/resource_management/core/providers/accounts.py
+++ b/ambari-common/src/main/python/resource_management/core/providers/accounts.py
@@ -46,7 +46,7 @@ class UserProvider(Provider):
     if not self.user:
       creating_user = True
       command = ["useradd", "-m"]
-      Logger.info("Adding user %s" % self.resource)
+      Logger.info(f"Adding user {self.resource}")
     else:
       creating_user = False
       command = ["usermod"]
@@ -64,7 +64,7 @@ class UserProvider(Provider):
       else:
         return
 
-      Logger.info("Modifying user %s" % (self.resource.username))
+      Logger.info(f"Modifying user {self.resource.username}")
 
     if self.resource.system and not self.user:
       command.append("--system")
@@ -110,7 +110,7 @@ class UserProvider(Provider):
     if self.user:
       command = ["userdel", self.resource.username]
       shell.checked_call(command, sudo=True)
-      Logger.info("Removed user %s" % self.resource)
+      Logger.info(f"Removed user {self.resource}")
 
   @property
   def user(self):
@@ -154,7 +154,7 @@ class GroupProvider(Provider):
     group = self.group
     if not group:
       command = ["groupadd"]
-      Logger.info("Adding group %s" % self.resource)
+      Logger.info(f"Adding group {self.resource}")
     else:
       command = ["groupmod"]
 
@@ -166,7 +166,7 @@ class GroupProvider(Provider):
       else:
         return
 
-      Logger.info("Modifying group %s" % (self.resource.group_name))
+      Logger.info(f"Modifying group {self.resource.group_name}")
 
     for option_name, attributes in self.options.items():
       option_value = getattr(self.resource, option_name)
@@ -185,7 +185,7 @@ class GroupProvider(Provider):
     if self.group:
       command = ["groupdel", self.resource.group_name]
       shell.checked_call(command, sudo=True)
-      Logger.info("Removed group %s" % self.resource)
+      Logger.info(f"Removed group {self.resource}")
 
   @property
   def group(self):

--- a/ambari-common/src/main/python/resource_management/core/providers/mount.py
+++ b/ambari-common/src/main/python/resource_management/core/providers/mount.py
@@ -86,7 +86,7 @@ class MountProvider(Provider):
       os.makedirs(self.resource.mount_point)
 
     if self.is_mounted():
-      Logger.debug("%s already mounted" % self)
+      Logger.debug(f"{self} already mounted")
     else:
       args = ["mount"]
       if self.resource.fstype:
@@ -99,24 +99,24 @@ class MountProvider(Provider):
 
       check_call(args)
 
-      Logger.info("%s mounted" % self)
+      Logger.info(f"{self} mounted")
 
   def action_umount(self):
     if self.is_mounted():
       check_call(["umount", self.resource.mount_point])
 
-      Logger.info("%s unmounted" % self)
+      Logger.info(f"{self} unmounted")
     else:
-      Logger.debug("%s is not mounted" % self)
+      Logger.debug(f"{self} is not mounted")
 
   def action_enable(self):
     if self.is_enabled():
-      Logger.debug("%s already enabled" % self)
+      Logger.debug(f"{self} already enabled")
     else:
       if not self.resource.device:
-        raise Fail("[%s] device not set but required for enable action" % self)
+        raise Fail(f"[{self}] device not set but required for enable action")
       if not self.resource.fstype:
-        raise Fail("[%s] fstype not set but required for enable action" % self)
+        raise Fail(f"[{self}] fstype not set but required for enable action")
 
       with open("/etc/fstab", "a") as fp:
         fp.write(
@@ -131,7 +131,7 @@ class MountProvider(Provider):
           )
         )
 
-      Logger.info("%s enabled" % self)
+      Logger.info(f"{self} enabled")
 
   def action_disable(self):
     pass  # TODO
@@ -141,7 +141,7 @@ class MountProvider(Provider):
       return False
 
     if self.resource.device and not os.path.exists(self.resource.device):
-      raise Fail("%s Device %s does not exist" % (self, self.resource.device))
+      raise Fail(f"{self} Device {self.resource.device} does not exist")
 
     mounts = get_mounted()
     for m in mounts:

--- a/ambari-common/src/main/python/resource_management/core/providers/service.py
+++ b/ambari-common/src/main/python/resource_management/core/providers/service.py
@@ -54,11 +54,11 @@ class ServiceProvider(Provider):
 
   def _exec_cmd(self, command, expect=None):
     if command != "status":
-      Logger.info("%s command '%s'" % (self.resource, command))
+      Logger.info(f"{self.resource} command '{command}'")
 
-    custom_cmd = getattr(self.resource, "%s_command" % command, None)
+    custom_cmd = getattr(self.resource, f"{command}_command", None)
     if custom_cmd:
-      Logger.debug("%s executing '%s'" % (self.resource, custom_cmd))
+      Logger.debug(f"{self.resource} executing '{custom_cmd}'")
       if hasattr(custom_cmd, "__call__"):
         if custom_cmd():
           ret = 0
@@ -85,7 +85,7 @@ class ServiceProvider(Provider):
       else:
         ret, out = shell.call(["/sbin/" + command, self.resource.service_name])
     else:
-      ret, out = shell.call(["/etc/init.d/%s" % self.resource.service_name, command])
+      ret, out = shell.call([f"/etc/init.d/{self.resource.service_name}", command])
     return ret, out
 
   @property
@@ -94,7 +94,7 @@ class ServiceProvider(Provider):
       return self.__upstart
     except AttributeError:
       self.__upstart = os.path.exists("/sbin/start") and os.path.exists(
-        "/etc/init/%s.conf" % self.resource.service_name
+        f"/etc/init/{self.resource.service_name}.conf"
       )
     return self.__upstart
 

--- a/ambari-common/src/main/python/resource_management/core/providers/windows/system.py
+++ b/ambari-common/src/main/python/resource_management/core/providers/windows/system.py
@@ -174,7 +174,7 @@ def _call_command(
   user=None,
 ):
   # TODO implement timeout, wait_for_finish
-  Logger.info("Executing %s" % (command))
+  Logger.info(f"Executing {command}")
   if user:
     domain, username = UserHelper.parse_user_name(user, ".")
 
@@ -297,14 +297,13 @@ class FileProvider(Provider):
 
     if os.path.isdir(path):
       raise Fail(
-        "Applying %s failed, directory with name %s exists" % (self.resource, path)
+        f"Applying {self.resource} failed, directory with name {path} exists"
       )
 
     dirname = os.path.dirname(path)
     if not os.path.isdir(dirname):
       raise Fail(
-        "Applying %s failed, parent directory %s doesn't exist"
-        % (self.resource, dirname)
+        f"Applying {self.resource} failed, parent directory {dirname} doesn't exist"
       )
 
     write = False
@@ -323,7 +322,7 @@ class FileProvider(Provider):
             self.resource.env.backup_file(path)
 
     if write:
-      Logger.info("Writing %s because %s" % (self.resource, reason))
+      Logger.info(f"Writing {self.resource} because {reason}")
       with open(path, "wb") as fp:
         if content:
           fp.write(content)
@@ -336,11 +335,11 @@ class FileProvider(Provider):
 
     if os.path.isdir(path):
       raise Fail(
-        "Applying %s failed, %s is directory not file!" % (self.resource, path)
+        f"Applying {self.resource} failed, {path} is directory not file!"
       )
 
     if os.path.exists(path):
-      Logger.info("Deleting %s" % self.resource)
+      Logger.info(f"Deleting {self.resource}")
       os.unlink(path)
 
   def _get_content(self):
@@ -351,7 +350,7 @@ class FileProvider(Provider):
       return content
     elif hasattr(content, "__call__"):
       return content()
-    raise Fail("Unknown source type for %s: %r" % (self, content))
+    raise Fail(f"Unknown source type for {self}: {content!r}")
 
 
 class ExecuteProvider(Provider):
@@ -360,7 +359,7 @@ class ExecuteProvider(Provider):
       if os.path.exists(self.resource.creates):
         return
 
-    Logger.debug("Executing %s" % self.resource)
+    Logger.debug(f"Executing {self.resource}")
 
     if self.resource.path != []:
       if not self.resource.environment:
@@ -398,7 +397,7 @@ class ExecuteProvider(Provider):
 
         if self.resource.on_timeout:
           Logger.info(
-            "Executing '%s'. Reason: %s" % (self.resource.on_timeout, err_msg)
+            f"Executing '{self.resource.on_timeout}'. Reason: {err_msg}"
           )
           _call_command(self.resource.on_timeout)
         else:
@@ -409,7 +408,7 @@ class DirectoryProvider(Provider):
   def action_create(self):
     path = DirectoryProvider._trim_uri(self.resource.path)
     if not os.path.exists(path):
-      Logger.info("Creating directory %s" % self.resource)
+      Logger.info(f"Creating directory {self.resource}")
       if self.resource.recursive:
         os.makedirs(path)
       else:
@@ -423,7 +422,7 @@ class DirectoryProvider(Provider):
         os.mkdir(path)
 
     if not os.path.isdir(path):
-      raise Fail("Applying %s failed, file %s already exists" % (self.resource, path))
+      raise Fail(f"Applying {self.resource} failed, file {path} already exists")
 
     if self.resource.owner and self.resource.mode:
       _set_file_acl(path, self.resource.owner, self.resource.mode)
@@ -432,9 +431,9 @@ class DirectoryProvider(Provider):
     path = self.resource.path
     if os.path.exists(path):
       if not os.path.isdir(path):
-        raise Fail("Applying %s failed, %s is not a directory" % (self.resource, path))
+        raise Fail(f"Applying {self.resource} failed, {path} is not a directory")
 
-      Logger.info("Removing directory %s and all its content" % self.resource)
+      Logger.info(f"Removing directory {self.resource} and all its content")
       shutil.rmtree(path)
 
   @staticmethod

--- a/ambari-common/src/main/python/resource_management/core/source.py
+++ b/ambari-common/src/main/python/resource_management/core/source.py
@@ -121,7 +121,7 @@ else:
         path = os.path.join(basedir, "templates", template_name)
 
       if not os.path.exists(path):
-        raise TemplateNotFound("%s at %s" % (template_name, path))
+        raise TemplateNotFound(f"{template_name} at {path}")
       mtime = os.path.getmtime(path)
       with open(path, "rt") as fp:
         source = fp.read()

--- a/ambari-common/src/main/python/resource_management/core/utils.py
+++ b/ambari-common/src/main/python/resource_management/core/utils.py
@@ -58,7 +58,7 @@ class AttributeDictionary(object):
       return self[name]
     except KeyError:
       raise AttributeError(
-        "'%s' object has no attribute '%s'" % (self.__class__.__name__, name)
+        f"'{self.__class__.__name__}' object has no attribute '{name}'"
       )
 
   def __setitem__(self, name, value):

--- a/ambari-common/src/main/python/resource_management/libraries/functions/dynamic_variable_interpretation.py
+++ b/ambari-common/src/main/python/resource_management/libraries/functions/dynamic_variable_interpretation.py
@@ -57,7 +57,7 @@ def _get_tar_source_and_dest_folder(tarball_prefix):
   :return: Returns a tuple of (x, y) after verifying the properties
   """
   component_tar_source_file = default(
-    "/configurations/cluster-env/%s%s" % (tarball_prefix.lower(), TAR_SOURCE_SUFFIX),
+    f"/configurations/cluster-env/{tarball_prefix.lower()}{TAR_SOURCE_SUFFIX}",
     None,
   )
   # E.g., <stack-root>/current/hadoop-client/tez-{{ stack_version_formatted }}.tar.gz
@@ -77,7 +77,7 @@ def _get_tar_source_and_dest_folder(tarball_prefix):
     return None, None
 
   if component_tar_source_file.find("/") == -1:
-    Logger.warning("The tar file path %s is not valid" % str(component_tar_source_file))
+    Logger.warning(f"The tar file path {str(component_tar_source_file)} is not valid")
     return None, None
 
   if not component_tar_destination_folder.endswith("/"):
@@ -203,12 +203,12 @@ def copy_tarballs_to_hdfs(
   )
   if not component_tar_source_file or not component_tar_destination_folder:
     Logger.warning(
-      "Could not retrieve properties for tarball with prefix: %s" % str(tarball_prefix)
+      f"Could not retrieve properties for tarball with prefix: {str(tarball_prefix)}"
     )
     return 1
 
   if not os.path.exists(component_tar_source_file):
-    Logger.warning("Could not find file: %s" % str(component_tar_source_file))
+    Logger.warning(f"Could not find file: {str(component_tar_source_file)}")
     return 1
 
   # Ubuntu returns: "stdin: is not a tty", as subprocess output.
@@ -238,8 +238,7 @@ def copy_tarballs_to_hdfs(
 
   if not stack_version:
     Logger.error(
-      "Could not parse stack version from output of %s: %s"
-      % (stack_selector_name, str(out))
+      f"Could not parse stack version from output of {stack_selector_name}: {str(out)}"
     )
     return 1
 
@@ -249,7 +248,7 @@ def copy_tarballs_to_hdfs(
     "{{ stack_version_formatted }}", stack_version
   )
 
-  does_hdfs_file_exist_cmd = "fs -ls %s" % destination_file
+  does_hdfs_file_exist_cmd = f"fs -ls {destination_file}"
 
   kinit_if_needed = ""
   if params.security_enabled:

--- a/ambari-common/src/main/python/resource_management/libraries/functions/file_system.py
+++ b/ambari-common/src/main/python/resource_management/libraries/functions/file_system.py
@@ -44,7 +44,7 @@ def get_and_cache_mount_points(refresh=False):
     for m in mounts:
       if m["mount_point"] is not None:
         m["mount_point"] = m["mount_point"].rstrip()
-    Logger.info("Host contains mounts: %s." % str([m["mount_point"] for m in mounts]))
+    Logger.info(f"Host contains mounts: {str([m['mount_point'] for m in mounts])}.")
     return mounts
 
 
@@ -78,5 +78,5 @@ def get_mount_point_for_dir(dir, mount_points=None):
         ).count(os.path.sep):
           best_mount_found = m
 
-  Logger.info("Mount point for directory %s is %s" % (str(dir), str(best_mount_found)))
+  Logger.info(f"Mount point for directory {str(dir)} is {str(best_mount_found)}")
   return best_mount_found

--- a/ambari-common/src/main/python/resource_management/libraries/functions/mounted_dirs_helper.py
+++ b/ambari-common/src/main/python/resource_management/libraries/functions/mounted_dirs_helper.py
@@ -117,7 +117,7 @@ def handle_mounted_dirs(func, dirs_string, history_filename, update_cache=True):
     if not os.path.exists(history_filename):
       history_file_exists = False
       Logger.warning(
-        "History_file property has file %s and it does not exist." % history_filename
+        f"History_file property has file {history_filename} and it does not exist."
       )
 
   valid_dirs = []  # dirs that have been normalized

--- a/ambari-common/src/main/python/resource_management/libraries/functions/security_commons.py
+++ b/ambari-common/src/main/python/resource_management/libraries/functions/security_commons.py
@@ -120,7 +120,7 @@ def validate_security_config_properties(params, configuration_rules):
           actual_value = get_value(actual_values, property_name, "")
           if not actual_value:
             issues[config_file] = (
-              "Property %s must exist and must not be empty" % property_name
+              f"Property {property_name} must exist and must not be empty"
             )
 
       # Process Read Checks
@@ -131,7 +131,7 @@ def validate_security_config_properties(params, configuration_rules):
         for property_name in rules:
           actual_value = get_value(actual_values, property_name, None)
           if not actual_value:
-            issues[config_file] = "Property %s does not exist" % property_name
+            issues[config_file] = f"Property {property_name} does not exist"
           elif not os.path.isfile(actual_value):
             issues[config_file] = "Property %s points to an inaccessible file - %s" % (
               property_name,
@@ -139,7 +139,7 @@ def validate_security_config_properties(params, configuration_rules):
             )
     except Exception as e:
       issues[config_file] = (
-        "Exception occurred while validating the config file\nCauses: %s" % str(e)
+        f"Exception occurred while validating the config file\nCauses: {str(e)}"
       )
   return issues
 
@@ -238,7 +238,7 @@ def cached_kinit_executor(
   Main cached kinit executor - Uses a temporary file on the FS to cache executions. Each command
   will have its own file and only one entry (last successful execution) will be stored
   """
-  key = str(hash("%s|%s" % (principal, keytab_file)))
+  key = str(hash(f"{principal}|{keytab_file}"))
   filename = key + "_tmp.txt"
   file_path = temp_dir + os.sep + "kinit_executor_cache"
   output = None

--- a/ambari-common/src/main/python/resource_management/libraries/functions/solr_cloud_util.py
+++ b/ambari-common/src/main/python/resource_management/libraries/functions/solr_cloud_util.py
@@ -73,7 +73,7 @@ def __create_solr_cloud_cli_prefix(
 def __append_flags_if_exists(command, flagsDict):
   for key, value in flagsDict.items():
     if value is not None:
-      command += " %s %s" % (key, value)
+      command += f" {key} {value}"
   return command
 
 

--- a/ambari-common/src/main/python/resource_management/libraries/functions/tar_archive.py
+++ b/ambari-common/src/main/python/resource_management/libraries/functions/tar_archive.py
@@ -97,5 +97,5 @@ def mode(archive):
     return "r:bz2"
   else:
     raise ValueError(
-      "Could not extract `%s` as no appropriate extractor is found" % archive
+      f"Could not extract `{archive}` as no appropriate extractor is found"
     )

--- a/ambari-common/src/main/python/resource_management/libraries/functions/version_select_util.py
+++ b/ambari-common/src/main/python/resource_management/libraries/functions/version_select_util.py
@@ -71,21 +71,21 @@ def get_component_version_from_symlink(stack_name, component_name):
       if code != 0 or out is None:
         raise ValueError("Code is nonzero or output is empty")
 
-      Logger.debug("Command: %s\nOutput: %s" % (get_stack_comp_version_cmd, str(out)))
+      Logger.debug(f"Command: {get_stack_comp_version_cmd}\nOutput: {str(out)}")
       matches = re.findall(r"( [\d\.]+(\-\d+)?)", out)
       version = (
         matches[0][0].strip()
         if matches and len(matches) > 0 and len(matches[0]) > 0
         else None
       )
-      Logger.debug("Version for component %s: %s" % (component_name, str(version)))
+      Logger.debug(f"Version for component {component_name}: {str(version)}")
     except Exception as e:
       Logger.error(
         "Could not determine stack version for component %s by calling '%s'. Return Code: %s, Output: %s."
         % (component_name, get_stack_comp_version_cmd, str(code), str(out))
       )
   else:
-    Logger.error("Could not find stack selector for stack: %s" % str(stack_name))
+    Logger.error(f"Could not find stack selector for stack: {str(stack_name)}")
 
   return version
 
@@ -125,7 +125,7 @@ def get_component_version_with_stack_selector(stack_selector_path, component_nam
       if code != 0 or out is None:
         raise Exception("Code is nonzero or output is empty")
 
-      Logger.debug("Command: %s\nOutput: %s" % (get_stack_comp_version_cmd, str(out)))
+      Logger.debug(f"Command: {get_stack_comp_version_cmd}\nOutput: {str(out)}")
       matches = re.findall(r"([\d\.]+\-\d+)", out)
       version = matches[0] if matches and len(matches) > 0 else None
     except Exception as e:

--- a/ambari-common/src/main/python/resource_management/libraries/providers/repository.py
+++ b/ambari-common/src/main/python/resource_management/libraries/providers/repository.py
@@ -188,7 +188,7 @@ class UbuntuRepositoryProvider(RepositoryProvider):
 
   def update(self, repo_file_path):
     repo_file_name = os.path.basename(repo_file_path)
-    self.update_cmd[4] = "Dir::Etc::sourcelist=sources.list.d/%s" % repo_file_name
+    self.update_cmd[4] = f"Dir::Etc::sourcelist=sources.list.d/{repo_file_name}"
     update_cmd_formatted = [format(x) for x in self.update_cmd]
     update_failed_exception = None
 

--- a/ambari-common/src/main/python/resource_management/libraries/script/dummy.py
+++ b/ambari-common/src/main/python/resource_management/libraries/script/dummy.py
@@ -64,14 +64,14 @@ class Dummy(Script):
     if "role" in self.config:
       self.component_name = self.config["role"]
 
-    self.pid_file = "/var/run/%s/%s.pid" % (self.host_name, self.component_name)
+    self.pid_file = f"/var/run/{self.host_name}/{self.component_name}.pid"
     self.user = "root"
     self.user_group = "root"
     self.sudo = AMBARI_SUDO_BINARY
 
-    print("Host: %s" % self.host_name)
-    print("Component: %s" % self.component_name)
-    print("Pid File: %s" % self.pid_file)
+    print(f"Host: {self.host_name}")
+    print(f"Component: {self.component_name}")
+    print(f"Pid File: {self.pid_file}")
 
   def install(self, env):
     print("Install")
@@ -112,12 +112,12 @@ class Dummy(Script):
         self.keytab_name
       ].replace("_HOST", self.host_name)
       Execute(
-        "%s -kt %s %s" % (kinit_path_local, keytab_path_replaced, principal_replaced),
+        f"{kinit_path_local} -kt {keytab_path_replaced} {principal_replaced}",
         user="root",
       )
 
     if not os.path.isfile(self.pid_file):
-      print("Creating pid file: %s" % self.pid_file)
+      print(f"Creating pid file: {self.pid_file}")
 
       Directory(
         os.path.dirname(self.pid_file),
@@ -134,8 +134,8 @@ class Dummy(Script):
     self.prepare()
 
     if os.path.isfile(self.pid_file):
-      print("Deleting pid file: %s" % self.pid_file)
-      Execute("%s rm -rf %s" % (self.sudo, self.pid_file))
+      print(f"Deleting pid file: {self.pid_file}")
+      Execute(f"{self.sudo} rm -rf {self.pid_file}")
 
   def status(self, env):
     print("Status")

--- a/ambari-common/src/main/python/resource_management/libraries/script/script.py
+++ b/ambari-common/src/main/python/resource_management/libraries/script/script.py
@@ -1252,7 +1252,7 @@ class Script(object):
       and config["commandParams"]["reconfigureAction"] is not None
     ):
       reconfigure_action = config["commandParams"]["reconfigureAction"]
-      Logger.info("Call %s" % reconfigure_action)
+      Logger.info(f"Call {reconfigure_action}")
       method = self.choose_method_to_execute(reconfigure_action)
       method(env)
 

--- a/ambari-common/src/test/python/coilmq/auth/simple.py
+++ b/ambari-common/src/test/python/coilmq/auth/simple.py
@@ -87,7 +87,7 @@ class SimpleAuthenticator(Authenticator):
     else:
       filesread = cfg.read(configfile)
       if not filesread:
-        raise ValueError("Could not parse auth file: %s" % configfile)
+        raise ValueError(f"Could not parse auth file: {configfile}")
 
     if not cfg.has_section("auth"):
       raise ValueError("Config file contains no [auth] section.")

--- a/ambari-common/src/test/python/coilmq/config/__init__.py
+++ b/ambari-common/src/test/python/coilmq/config/__init__.py
@@ -65,7 +65,7 @@ def init_config(config_file=None):
   if config_file and os.path.exists(config_file):
     read = config.read([config_file])
     if not read:
-      raise ValueError("Could not read configuration from file: %s" % config_file)
+      raise ValueError(f"Could not read configuration from file: {config_file}")
 
 
 def init_logging(logfile=None, loglevel=logging.INFO, configfile=None):

--- a/ambari-common/src/test/python/coilmq/engine.py
+++ b/ambari-common/src/test/python/coilmq/engine.py
@@ -72,7 +72,7 @@ class StompEngine(object):
     @type connection: L{coilmq.server.StompConnection}
     """
     self.log = logging.getLogger(
-      "%s.%s" % (self.__class__.__module__, self.__class__.__name__)
+      f"{self.__class__.__module__}.{self.__class__.__name__}"
     )
     self.connection = connection
     self.authenticator = authenticator

--- a/ambari-common/src/test/python/coilmq/protocol/__init__.py
+++ b/ambari-common/src/test/python/coilmq/protocol/__init__.py
@@ -112,15 +112,15 @@ class STOMP10(STOMP):
         method(frame)
       else:
         if not transaction in self.engine.transactions:
-          raise ProtocolError("Invalid transaction specified: %s" % transaction)
+          raise ProtocolError(f"Invalid transaction specified: {transaction}")
         self.engine.transactions[transaction].append(frame)
     except Exception as e:
-      self.engine.log.error("Error processing STOMP frame: %s" % e)
+      self.engine.log.error(f"Error processing STOMP frame: {e}")
       self.engine.log.exception(e)
       try:
         self.engine.connection.send_frame(ErrorFrame(str(e), str(e)))
       except Exception as e:  # pragma: no cover
-        self.engine.log.error("Could not send error frame: %s" % e)
+        self.engine.log.error(f"Could not send error frame: {e}")
         self.engine.log.exception(e)
     else:
       # The protocol is not especially clear here (not sure why I'm surprised)
@@ -144,7 +144,7 @@ class STOMP10(STOMP):
       login = frame.headers.get("login")
       passcode = frame.headers.get("passcode")
       if not self.engine.authenticator.authenticate(login, passcode):
-        raise AuthError("Authentication failed for %s" % login)
+        raise AuthError(f"Authentication failed for {login}")
 
     self.engine.connected = True
 
@@ -216,7 +216,7 @@ class STOMP10(STOMP):
       raise ProtocolError("Missing transaction for COMMIT command.")
 
     if not frame.transaction in self.engine.transactions:
-      raise ProtocolError("Invalid transaction: %s" % frame.transaction)
+      raise ProtocolError(f"Invalid transaction: {frame.transaction}")
 
     for tframe in self.engine.transactions[frame.transaction]:
       del tframe.headers["transaction"]
@@ -235,7 +235,7 @@ class STOMP10(STOMP):
       raise ProtocolError("Missing transaction for ABORT command.")
 
     if not frame.transaction in self.engine.transactions:
-      raise ProtocolError("Invalid transaction: %s" % frame.transaction)
+      raise ProtocolError(f"Invalid transaction: {frame.transaction}")
 
     self.engine.queue_manager.resend_transaction_frames(
       self.engine.connection, frame.transaction

--- a/ambari-common/src/test/python/coilmq/server/socket_server.py
+++ b/ambari-common/src/test/python/coilmq/server/socket_server.py
@@ -59,7 +59,7 @@ class StompRequestHandler(BaseRequestHandler, StompConnection):
     if self.server.timeout is not None:
       self.request.settimeout(self.server.timeout)
     self.debug = False
-    self.log = logging.getLogger("%s.%s" % (self.__module__, self.__class__.__name__))
+    self.log = logging.getLogger(f"{self.__module__}.{self.__class__.__name__}")
     self.buffer = FrameBuffer()
     self.engine = StompEngine(
       connection=self,
@@ -81,12 +81,12 @@ class StompRequestHandler(BaseRequestHandler, StompConnection):
           if not data:
             break
           if self.debug:
-            self.log.debug("RECV: %r" % data)
+            self.log.debug(f"RECV: {data!r}")
           self.buffer.append(data)
 
           for frame in self.buffer:
             self.server.frames_queue.put(frame)
-            self.log.debug("Processing frame: %s" % frame)
+            self.log.debug(f"Processing frame: {frame}")
             self.engine.process_frame(frame)
             if not self.engine.connected:
               raise ClientDisconnected()
@@ -95,7 +95,7 @@ class StompRequestHandler(BaseRequestHandler, StompConnection):
     except ClientDisconnected:
       self.log.debug("Client disconnected, discontinuing read loop.")
     except Exception as e:  # pragma: no cover
-      self.log.error("Error receiving data (unbinding): %s" % e)
+      self.log.error(f"Error receiving data (unbinding): {e}")
       self.engine.unbind()
       raise
 
@@ -116,7 +116,7 @@ class StompRequestHandler(BaseRequestHandler, StompConnection):
     """
     packed = frame.pack()
     if self.debug:  # pragma: no cover
-      self.log.debug("SEND: %r" % packed)
+      self.log.debug(f"SEND: {packed!r}")
     self.request.sendall(packed)
 
 
@@ -160,7 +160,7 @@ class StompServer(TCPServer):
     @keyword queue_manager: The configured L{coilmq.queue.QueueManager} object to use.
     @keyword topic_manager: The configured L{coilmq.topic.TopicManager} object to use.
     """
-    self.log = logging.getLogger("%s.%s" % (self.__module__, self.__class__.__name__))
+    self.log = logging.getLogger(f"{self.__module__}.{self.__class__.__name__}")
     if not RequestHandlerClass:
       RequestHandlerClass = StompRequestHandler
     self.timeout = timeout

--- a/ambari-common/src/test/python/coilmq/start.py
+++ b/ambari-common/src/test/python/coilmq/start.py
@@ -99,7 +99,7 @@ def server_from_config(config=None, server_class=None, additional_kwargs=None):
     authenticator=authenticator,
     protocol=STOMP11,
   )
-  logger.info("Created server:%r" % server)
+  logger.info(f"Created server:{server!r}")
   return server
 
 
@@ -184,7 +184,7 @@ def context_serve(
     logger.info("Stomp server stopped by user interrupt.")
     raise SystemExit()
   except Exception as e:
-    logger.error("Stomp server stopped due to error: %s" % e)
+    logger.error(f"Stomp server stopped due to error: {e}")
     logger.exception(e)
     raise SystemExit()
   finally:
@@ -313,5 +313,5 @@ if __name__ == "__main__":
   except (KeyboardInterrupt, SystemExit):
     pass
   except Exception as e:
-    logger.error("Server terminated due to error: %s" % e)
+    logger.error(f"Server terminated due to error: {e}")
     logger.exception(e)

--- a/ambari-common/src/test/python/coilmq/store/__init__.py
+++ b/ambari-common/src/test/python/coilmq/store/__init__.py
@@ -43,7 +43,7 @@ class QueueStore(object, metaclass=abc.ABCMeta):
     If you extend this class, you should either call this method or at minimum make sure these values
     get set.
     """
-    self.log = logging.getLogger("%s.%s" % (self.__module__, self.__class__.__name__))
+    self.log = logging.getLogger(f"{self.__module__}.{self.__class__.__name__}")
 
   @abc.abstractmethod
   @synchronized(lock)

--- a/ambari-common/src/test/python/coilmq/store/dbm.py
+++ b/ambari-common/src/test/python/coilmq/store/dbm.py
@@ -55,13 +55,13 @@ def make_dbm():
     cp_ops = config.getint("coilmq", "qstore.dbm.checkpoint_operations")
     cp_timeout = config.getint("coilmq", "qstore.dbm.checkpoint_timeout")
   except ConfigParser.NoOptionError as e:
-    raise ConfigError("Missing configuration parameter: %s" % e)
+    raise ConfigError(f"Missing configuration parameter: {e}")
 
   if not os.path.exists(data_dir):
-    raise ConfigError("DBM directory does not exist: %s" % data_dir)
+    raise ConfigError(f"DBM directory does not exist: {data_dir}")
   # FIXME: how do these get applied? Is OR appropriate?
   if not os.access(data_dir, os.W_OK | os.R_OK):
-    raise ConfigError("Cannot read and write DBM directory: %s" % data_dir)
+    raise ConfigError(f"Cannot read and write DBM directory: {data_dir}")
 
   store = DbmQueue(
     data_dir, checkpoint_operations=cp_ops, checkpoint_timeout=cp_timeout

--- a/ambari-common/src/test/python/coilmq/topic.py
+++ b/ambari-common/src/test/python/coilmq/topic.py
@@ -46,7 +46,7 @@ class TopicManager(object):
   """
 
   def __init__(self):
-    self.log = logging.getLogger("%s.%s" % (__name__, self.__class__.__name__))
+    self.log = logging.getLogger(f"{__name__}.{self.__class__.__name__}")
 
     # Lock var is required for L{synchornized} decorator.
     self._lock = threading.RLock()
@@ -75,7 +75,7 @@ class TopicManager(object):
     @param destination: The topic destination (e.g. '/topic/foo')
     @type destination: C{str}
     """
-    self.log.debug("Subscribing %s to %s" % (connection, destination))
+    self.log.debug(f"Subscribing {connection} to {destination}")
     self._topics[destination].add(connection)
 
   @synchronized(lock)
@@ -89,7 +89,7 @@ class TopicManager(object):
     @param destination: The topic destination (e.g. '/topic/foo')
     @type destination: C{str}
     """
-    self.log.debug("Unsubscribing %s from %s" % (connection, destination))
+    self.log.debug(f"Unsubscribing {connection} from {destination}")
     if connection in self._topics[destination]:
       self._topics[destination].remove(connection)
 
@@ -104,7 +104,7 @@ class TopicManager(object):
     @param connection: The client connection to unsubscribe.
     @type connection: L{coilmq.server.StompConnection}
     """
-    self.log.debug("Disconnecting %s" % connection)
+    self.log.debug(f"Disconnecting {connection}")
     for dest in list(self._topics.keys()):
       if connection in self._topics[dest]:
         self._topics[dest].remove(connection)
@@ -123,7 +123,7 @@ class TopicManager(object):
     """
     dest = message.headers.get("destination")
     if not dest:
-      raise ValueError("Cannot send frame with no destination: %s" % message)
+      raise ValueError(f"Cannot send frame with no destination: {message}")
 
     message.cmd = "message"
 

--- a/ambari-common/src/test/python/coilmq/util/frames.py
+++ b/ambari-common/src/test/python/coilmq/util/frames.py
@@ -190,7 +190,7 @@ class HeaderValue(object):
     @type calculator: C{callable}
     """
     if not callable(calculator):
-      raise ValueError("Non-callable param: %s" % calculator)
+      raise ValueError(f"Non-callable param: {calculator}")
     self.calc = calculator
 
   def __get__(self, obj, objtype):
@@ -203,7 +203,7 @@ class HeaderValue(object):
     self.calc = value
 
   def __repr__(self):
-    return "<%s calculator=%s>" % (self.__class__.__name__, self.calc)
+    return f"<{self.__class__.__name__} calculator={self.calc}>"
 
 
 class ErrorFrame(Frame):
@@ -221,7 +221,7 @@ class ErrorFrame(Frame):
     self.headers["content-length"] = HeaderValue(calculator=lambda: len(self.body))
 
   def __repr__(self):
-    return "<%s message=%r>" % (self.__class__.__name__, self.headers["message"])
+    return f"<{self.__class__.__name__} message={self.headers['message']!r}>"
 
 
 class ReceiptFrame(Frame):
@@ -273,7 +273,7 @@ class FrameBuffer(object):
     self._buffer = io.BytesIO()
     self._pointer = 0
     self.debug = False
-    self.log = logging.getLogger("%s.%s" % (self.__module__, self.__class__.__name__))
+    self.log = logging.getLogger(f"{self.__module__}.{self.__class__.__name__}")
 
   def clear(self):
     """

--- a/ambari-common/src/test/python/mock/tests/_testwith.py
+++ b/ambari-common/src/test/python/mock/tests/_testwith.py
@@ -121,7 +121,7 @@ class WithTest(unittest2.TestCase):
 class TestMockOpen(unittest2.TestCase):
   def test_mock_open(self):
     mock = mock_open()
-    with patch("%s.open" % __name__, mock, create=True) as patched:
+    with patch(f"{__name__}.open", mock, create=True) as patched:
       self.assertIs(patched, mock)
       open("foo")
 
@@ -130,7 +130,7 @@ class TestMockOpen(unittest2.TestCase):
   def test_mock_open_context_manager(self):
     mock = mock_open()
     handle = mock.return_value
-    with patch("%s.open" % __name__, mock, create=True):
+    with patch(f"{__name__}.open", mock, create=True):
       with open("foo") as f:
         f.read()
 
@@ -147,7 +147,7 @@ class TestMockOpen(unittest2.TestCase):
     mock = MagicMock()
     mock_open(mock)
 
-    with patch("%s.open" % __name__, mock, create=True) as patched:
+    with patch(f"{__name__}.open", mock, create=True) as patched:
       self.assertIs(patched, mock)
       open("foo")
 
@@ -155,7 +155,7 @@ class TestMockOpen(unittest2.TestCase):
 
   def test_read_data(self):
     mock = mock_open(read_data="foo")
-    with patch("%s.open" % __name__, mock, create=True):
+    with patch(f"{__name__}.open", mock, create=True):
       h = open("bar")
       result = h.read()
 

--- a/ambari-common/src/test/python/mock/tests/support_with.py
+++ b/ambari-common/src/test/python/mock/tests/support_with.py
@@ -51,11 +51,11 @@ except ImportError:
       if self._record:
         args.append("record=True")
       name = type(self).__name__
-      return "%s(%s)" % (name, ", ".join(args))
+      return f"{name}({', '.join(args)})"
 
     def __enter__(self):
       if self._entered:
-        raise RuntimeError("Cannot enter %r twice" % self)
+        raise RuntimeError(f"Cannot enter {self!r} twice")
       self._entered = True
       self._filters = self._module.filters
       self._module.filters = self._filters[:]
@@ -73,7 +73,7 @@ except ImportError:
 
     def __exit__(self, *exc_info):
       if not self._entered:
-        raise RuntimeError("Cannot exit %r without entering first" % self)
+        raise RuntimeError(f"Cannot exit {self!r} without entering first")
       self._module.filters = self._filters
       self._module.showwarning = self._showwarning
 

--- a/ambari-common/src/test/python/mock/tests/testcallable.py
+++ b/ambari-common/src/test/python/mock/tests/testcallable.py
@@ -52,7 +52,7 @@ class TestCallable(unittest2.TestCase):
     self.assertTrue(issubclass(type(two.two), MagicSub))
 
   def test_patch_spec(self):
-    patcher = patch("%s.X" % __name__, spec=True)
+    patcher = patch(f"{__name__}.X", spec=True)
     mock = patcher.start()
     self.addCleanup(patcher.stop)
 
@@ -63,7 +63,7 @@ class TestCallable(unittest2.TestCase):
     self.assertRaises(TypeError, instance)
 
   def test_patch_spec_set(self):
-    patcher = patch("%s.X" % __name__, spec_set=True)
+    patcher = patch(f"{__name__}.X", spec_set=True)
     mock = patcher.start()
     self.addCleanup(patcher.stop)
 
@@ -74,7 +74,7 @@ class TestCallable(unittest2.TestCase):
     self.assertRaises(TypeError, instance)
 
   def test_patch_spec_instance(self):
-    patcher = patch("%s.X" % __name__, spec=X())
+    patcher = patch(f"{__name__}.X", spec=X())
     mock = patcher.start()
     self.addCleanup(patcher.stop)
 
@@ -82,7 +82,7 @@ class TestCallable(unittest2.TestCase):
     self.assertRaises(TypeError, mock)
 
   def test_patch_spec_set_instance(self):
-    patcher = patch("%s.X" % __name__, spec_set=X())
+    patcher = patch(f"{__name__}.X", spec_set=X())
     mock = patcher.start()
     self.addCleanup(patcher.stop)
 
@@ -109,7 +109,7 @@ class TestCallable(unittest2.TestCase):
 
     for arg in "spec", "spec_set":
       for Klass in CallableX, Sub, Multi, OldStyle, OldStyleSub:
-        patcher = patch("%s.X" % __name__, **{arg: Klass})
+        patcher = patch(f"{__name__}.X", **{arg: Klass})
         mock = patcher.start()
 
         try:

--- a/ambari-common/src/test/python/mock/tests/testhelpers.py
+++ b/ambari-common/src/test/python/mock/tests/testhelpers.py
@@ -868,7 +868,7 @@ class TestCallList(unittest2.TestCase):
     self.assertEqual(str(mock.mock_calls), expected)
 
   def test_propertymock(self):
-    p = patch("%s.SomeClass.one" % __name__, new_callable=PropertyMock)
+    p = patch(f"{__name__}.SomeClass.one", new_callable=PropertyMock)
     mock = p.start()
     try:
       SomeClass.one

--- a/ambari-common/src/test/python/mock/tests/testmagicmethods.py
+++ b/ambari-common/src/test/python/mock/tests/testmagicmethods.py
@@ -64,7 +64,7 @@ class TestMockingMagicMethods(unittest2.TestCase):
 
   def test_repr(self):
     mock = Mock()
-    self.assertEqual(repr(mock), "<Mock id='%s'>" % id(mock))
+    self.assertEqual(repr(mock), f"<Mock id='{id(mock)}'>")
     mock.__repr__ = lambda s: "foo"
     self.assertEqual(repr(mock), "foo")
 

--- a/ambari-common/src/test/python/mock/tests/testmock.py
+++ b/ambari-common/src/test/python/mock/tests/testmock.py
@@ -94,17 +94,17 @@ class MockTest(unittest2.TestCase):
   def test_repr(self):
     mock = Mock(name="foo")
     self.assertIn("foo", repr(mock))
-    self.assertIn("'%s'" % id(mock), repr(mock))
+    self.assertIn(f"'{id(mock)}'", repr(mock))
 
     mocks = [(Mock(), "mock"), (Mock(name="bar"), "bar")]
     for mock, name in mocks:
-      self.assertIn("%s.bar" % name, repr(mock.bar))
-      self.assertIn("%s.foo()" % name, repr(mock.foo()))
-      self.assertIn("%s.foo().bing" % name, repr(mock.foo().bing))
-      self.assertIn("%s()" % name, repr(mock()))
-      self.assertIn("%s()()" % name, repr(mock()()))
+      self.assertIn(f"{name}.bar", repr(mock.bar))
+      self.assertIn(f"{name}.foo()", repr(mock.foo()))
+      self.assertIn(f"{name}.foo().bing", repr(mock.foo().bing))
+      self.assertIn(f"{name}()", repr(mock()))
+      self.assertIn(f"{name}()()", repr(mock()()))
       self.assertIn(
-        "%s()().foo.bar.baz().bing" % name, repr(mock()().foo.bar.baz().bing)
+        f"{name}()().foo.bar.baz().bing", repr(mock()().foo.bar.baz().bing)
       )
 
   def test_repr_with_spec(self):
@@ -207,7 +207,7 @@ class MockTest(unittest2.TestCase):
     self.assertEqual(
       mock.method_calls,
       [],
-      "method_calls not initialised correctly: %r != %r" % (mock.method_calls, []),
+      f"method_calls not initialised correctly: {mock.method_calls!r} != {[]!r}",
     )
     self.assertEqual(mock.mock_calls, [])
 
@@ -689,7 +689,7 @@ class MockTest(unittest2.TestCase):
       instance = sys.exc_info()[1]
       self.assertIsInstance(instance, exception)
     else:
-      self.fail("Exception %r not raised" % (exception,))
+      self.fail(f"Exception {exception!r} not raised")
 
     msg = str(instance)
     self.assertEqual(msg, message)

--- a/ambari-common/src/test/python/mock/tests/testpatch.py
+++ b/ambari-common/src/test/python/mock/tests/testpatch.py
@@ -30,7 +30,7 @@ if inPy3k:
   unicode = str
 
 PTModule = sys.modules[__name__]
-MODNAME = "%s.PTModule" % __name__
+MODNAME = f"{__name__}.PTModule"
 
 
 def _get_proxy(obj, get_only=True):
@@ -73,7 +73,7 @@ class Foo(object):
       pass
 
 
-foo_name = "%s.Foo" % __name__
+foo_name = f"{__name__}.Foo"
 
 
 def function(a, b=Foo):
@@ -148,7 +148,7 @@ class PatchTest(unittest2.TestCase):
     global something
     original = something
 
-    @patch("%s.something" % __name__, sentinel.Something2)
+    @patch(f"{__name__}.something", sentinel.Something2)
     def test():
       pass
 
@@ -160,15 +160,15 @@ class PatchTest(unittest2.TestCase):
       something = original
 
   def test_patch(self):
-    @patch("%s.something" % __name__, sentinel.Something2)
+    @patch(f"{__name__}.something", sentinel.Something2)
     def test():
       self.assertEqual(PTModule.something, sentinel.Something2, "unpatched")
 
     test()
     self.assertEqual(PTModule.something, sentinel.Something, "patch not restored")
 
-    @patch("%s.something" % __name__, sentinel.Something2)
-    @patch("%s.something_else" % __name__, sentinel.SomethingElse)
+    @patch(f"{__name__}.something", sentinel.Something2)
+    @patch(f"{__name__}.something_else", sentinel.SomethingElse)
     def test():
       self.assertEqual(PTModule.something, sentinel.Something2, "unpatched")
       self.assertEqual(PTModule.something_else, sentinel.SomethingElse, "unpatched")
@@ -189,7 +189,7 @@ class PatchTest(unittest2.TestCase):
     mock = Mock()
     mock.return_value = sentinel.Handle
 
-    @patch("%s.open" % builtin_string, mock)
+    @patch(f"{builtin_string}.open", mock)
     def test():
       self.assertEqual(open("filename", "r"), sentinel.Handle, "open not patched")
 
@@ -199,7 +199,7 @@ class PatchTest(unittest2.TestCase):
     self.assertNotEqual(open, mock, "patch not restored")
 
   def test_patch_class_attribute(self):
-    @patch("%s.SomeClass.class_attribute" % __name__, sentinel.ClassAttribute)
+    @patch(f"{__name__}.SomeClass.class_attribute", sentinel.ClassAttribute)
     def test():
       self.assertEqual(
         PTModule.SomeClass.class_attribute, sentinel.ClassAttribute, "unpatched"
@@ -255,7 +255,7 @@ class PatchTest(unittest2.TestCase):
     test(sentinel.this1, sentinel.this2)
 
   def test_patch_with_spec(self):
-    @patch("%s.SomeClass" % __name__, spec=SomeClass)
+    @patch(f"{__name__}.SomeClass", spec=SomeClass)
     def test(MockSomeClass):
       self.assertEqual(SomeClass, MockSomeClass)
       self.assertTrue(is_instance(SomeClass.wibble, MagicMock))
@@ -273,7 +273,7 @@ class PatchTest(unittest2.TestCase):
     test()
 
   def test_patch_with_spec_as_list(self):
-    @patch("%s.SomeClass" % __name__, spec=["wibble"])
+    @patch(f"{__name__}.SomeClass", spec=["wibble"])
     def test(MockSomeClass):
       self.assertEqual(SomeClass, MockSomeClass)
       self.assertTrue(is_instance(SomeClass.wibble, MagicMock))
@@ -292,8 +292,8 @@ class PatchTest(unittest2.TestCase):
 
   def test_nested_patch_with_spec_as_list(self):
     # regression test for nested decorators
-    @patch("%s.open" % builtin_string)
-    @patch("%s.SomeClass" % __name__, spec=["wibble"])
+    @patch(f"{builtin_string}.open")
+    @patch(f"{__name__}.SomeClass", spec=["wibble"])
     def test(MockSomeClass, MockOpen):
       self.assertEqual(SomeClass, MockSomeClass)
       self.assertTrue(is_instance(SomeClass.wibble, MagicMock))
@@ -302,7 +302,7 @@ class PatchTest(unittest2.TestCase):
     test()
 
   def test_patch_with_spec_as_boolean(self):
-    @patch("%s.SomeClass" % __name__, spec=True)
+    @patch(f"{__name__}.SomeClass", spec=True)
     def test(MockSomeClass):
       self.assertEqual(SomeClass, MockSomeClass)
       # Should not raise attribute error
@@ -324,7 +324,7 @@ class PatchTest(unittest2.TestCase):
     test()
 
   def test_patch_class_acts_with_spec_is_inherited(self):
-    @patch("%s.SomeClass" % __name__, spec=True)
+    @patch(f"{__name__}.SomeClass", spec=True)
     def test(MockSomeClass):
       self.assertTrue(is_instance(MockSomeClass, MagicMock))
       instance = MockSomeClass()
@@ -337,7 +337,7 @@ class PatchTest(unittest2.TestCase):
     test()
 
   def test_patch_with_create_mocks_non_existent_attributes(self):
-    @patch("%s.frooble" % builtin_string, sentinel.Frooble, create=True)
+    @patch(f"{builtin_string}.frooble", sentinel.Frooble, create=True)
     def test():
       self.assertEqual(frooble, sentinel.Frooble)
 
@@ -355,7 +355,7 @@ class PatchTest(unittest2.TestCase):
   def test_patch_wont_create_by_default(self):
     try:
 
-      @patch("%s.frooble" % builtin_string, sentinel.Frooble)
+      @patch(f"{builtin_string}.frooble", sentinel.Frooble)
       def test():
         self.assertEqual(frooble, sentinel.Frooble)
 
@@ -455,7 +455,7 @@ class PatchTest(unittest2.TestCase):
           PTModule.something, sentinel.Something, "non-test method patched"
         )
 
-    Foo = patch("%s.something" % __name__)(Foo)
+    Foo = patch(f"{__name__}.something")(Foo)
 
     f = Foo()
     f.test_method()
@@ -594,8 +594,8 @@ class PatchTest(unittest2.TestCase):
   def test_name_preserved(self):
     foo = {}
 
-    @patch("%s.SomeClass" % __name__, object())
-    @patch("%s.SomeClass" % __name__, object(), autospec=True)
+    @patch(f"{__name__}.SomeClass", object())
+    @patch(f"{__name__}.SomeClass", object(), autospec=True)
     @patch.object(SomeClass, object())
     @patch.dict(foo)
     def some_name():
@@ -669,7 +669,7 @@ class PatchTest(unittest2.TestCase):
     something.klass_dict()
 
   def test_patch_spec_set(self):
-    @patch("%s.SomeClass" % __name__, spec_set=SomeClass)
+    @patch(f"{__name__}.SomeClass", spec_set=SomeClass)
     def test(MockClass):
       MockClass.z = "foo"
 
@@ -681,7 +681,7 @@ class PatchTest(unittest2.TestCase):
 
     self.assertRaises(AttributeError, test)
 
-    @patch("%s.SomeClass" % __name__, spec_set=True)
+    @patch(f"{__name__}.SomeClass", spec_set=True)
     def test(MockClass):
       MockClass.z = "foo"
 
@@ -694,7 +694,7 @@ class PatchTest(unittest2.TestCase):
     self.assertRaises(AttributeError, test)
 
   def test_spec_set_inherit(self):
-    @patch("%s.SomeClass" % __name__, spec_set=True)
+    @patch(f"{__name__}.SomeClass", spec_set=True)
     def test(MockClass):
       instance = MockClass()
       instance.z = "foo"
@@ -703,7 +703,7 @@ class PatchTest(unittest2.TestCase):
 
   def test_patch_start_stop(self):
     original = something
-    patcher = patch("%s.something" % __name__)
+    patcher = patch(f"{__name__}.something")
     self.assertIs(something, original)
     mock = patcher.start()
     try:
@@ -923,7 +923,7 @@ class PatchTest(unittest2.TestCase):
     test()
 
   def test_autospec_function(self):
-    @patch("%s.function" % __name__, autospec=True)
+    @patch(f"{__name__}.function", autospec=True)
     def test(mock):
       function(1)
       function.assert_called_with(1)
@@ -936,7 +936,7 @@ class PatchTest(unittest2.TestCase):
     test()
 
   def test_autospec_keywords(self):
-    @patch("%s.function" % __name__, autospec=True, return_value=3)
+    @patch(f"{__name__}.function", autospec=True, return_value=3)
     def test(mock_function):
       # self.assertEqual(function.abc, 'foo')
       return function(1, 2)
@@ -945,7 +945,7 @@ class PatchTest(unittest2.TestCase):
     self.assertEqual(result, 3)
 
   def test_autospec_with_new(self):
-    patcher = patch("%s.function" % __name__, new=3, autospec=True)
+    patcher = patch(f"{__name__}.function", new=3, autospec=True)
     self.assertRaises(TypeError, patcher.start)
 
     module = sys.modules[__name__]
@@ -1061,7 +1061,7 @@ class PatchTest(unittest2.TestCase):
       patcher.stop()
 
   def test_new_callable_create(self):
-    non_existent_attr = "%s.weeeee" % foo_name
+    non_existent_attr = f"{foo_name}.weeeee"
     p = patch(non_existent_attr, new_callable=NonCallableMock)
     self.assertRaises(AttributeError, p.start)
 
@@ -1524,7 +1524,7 @@ class PatchTest(unittest2.TestCase):
 
   def test_patch_with_spec_mock_repr(self):
     for arg in ("spec", "autospec", "spec_set"):
-      p = patch("%s.SomeClass" % __name__, **{arg: True})
+      p = patch(f"{__name__}.SomeClass", **{arg: True})
       m = p.start()
       try:
         self.assertIn(" name='SomeClass'", repr(m))
@@ -1547,7 +1547,7 @@ class PatchTest(unittest2.TestCase):
 
   def test_mock_calls_with_patch(self):
     for arg in ("spec", "autospec", "spec_set"):
-      p = patch("%s.SomeClass" % __name__, **{arg: True})
+      p = patch(f"{__name__}.SomeClass", **{arg: True})
       m = p.start()
       try:
         m.wibble()
@@ -1612,7 +1612,7 @@ class PatchTest(unittest2.TestCase):
 
   def test_create_and_specs(self):
     for kwarg in ("spec", "spec_set", "autospec"):
-      p = patch("%s.doesnotexist" % __name__, create=True, **{kwarg: True})
+      p = patch(f"{__name__}.doesnotexist", create=True, **{kwarg: True})
       self.assertRaises(TypeError, p.start)
       self.assertRaises(NameError, lambda: doesnotexist)
 

--- a/ambari-server/src/main/python/ambari_server/resourceFilesKeeper.py
+++ b/ambari-server/src/main/python/ambari_server/resourceFilesKeeper.py
@@ -280,9 +280,7 @@ class ResourceFilesKeeper:
       os.chmod(zip_file_path, 0o755)
     except Exception as err:
       raise KeeperException(
-        "Can not create zip archive of " "directory {0} : {1}".format(
-          directory, str(err)
-        )
+        f"Can not create zip archive of directory {directory} : {str(err)}"
       )
 
   def is_ignored(self, filename):

--- a/ambari-server/src/main/python/ambari_server/serverConfiguration.py
+++ b/ambari-server/src/main/python/ambari_server/serverConfiguration.py
@@ -959,7 +959,7 @@ def backup_file_in_temp(filePath):
       )
     except Exception as e:
       print_error_msg(
-        'Could not backup file in temp "%s": %s' % (back_up_file_count, str(e))
+        f'Could not backup file in temp "{back_up_file_count}": {str(e)}'
       )
   return 0
 

--- a/ambari-server/src/main/python/ambari_server/serverSetup.py
+++ b/ambari-server/src/main/python/ambari_server/serverSetup.py
@@ -431,9 +431,7 @@ class AmbariUserChecksLinux(AmbariUserChecks):
 
     elif retcode != 0:  # fail
       print_warning_msg(
-        "Can't create user {0}. Command {1} " "finished with {2}: \n{3}".format(
-          user, command, retcode, err
-        )
+        f"Can't create user {user}. Command {command} finished with {retcode}: \n{err}"
       )
       return retcode
 
@@ -1529,7 +1527,7 @@ def check_ambari_java_version_is_valid(java_home, java_bin, min_version, propert
   print("Check JDK version for Ambari Server...")
   try:
     command = JDK_VERSION_CHECK_CMD.format(os.path.join(java_home, "bin", java_bin))
-    print("Running java version check command: {0}".format(command))
+    print(f"Running java version check command: {command}")
     process = subprocess.Popen(
       command,
       stdout=subprocess.PIPE,

--- a/ambari-server/src/main/python/bootstrap.py
+++ b/ambari-server/src/main/python/bootstrap.py
@@ -1140,9 +1140,7 @@ class PBootstrap:
           if elapsedtime > HOST_BOOTSTRAP_TIMEOUT:
             # bootstrap timed out
             logging.warn(
-              "Bootstrap at host {0} timed out and will be " "interrupted".format(
-                bootstrap.host
-              )
+              f"Bootstrap at host {bootstrap.host} timed out and will be interrupted"
             )
             bootstrap.interruptBootstrap()
             finished_list.append(bootstrap)

--- a/ambari-server/src/main/resources/common-services/AMBARI_METRICS/3.0.0/package/scripts/service_check.py
+++ b/ambari-server/src/main/resources/common-services/AMBARI_METRICS/3.0.0/package/scripts/service_check.py
@@ -323,8 +323,7 @@ def call_curl_krb_request(
       if i < tries - 1:  # range/xrange returns items from start to end-1
         time.sleep(connection_timeout)
         Logger.info(
-          "Connection failed for %s. Next retry in %s seconds."
-          % (uri, connection_timeout)
+          f"Connection failed for {uri}. Next retry in {connection_timeout} seconds."
         )
         continue
       else:

--- a/ambari-server/src/main/resources/scripts/cluster_blueprint.py
+++ b/ambari-server/src/main/resources/scripts/cluster_blueprint.py
@@ -217,8 +217,7 @@ class AmbariBlueprint:
       logger.info("Blueprint created successfully.")
     elif retCode == "409":
       logger.info(
-        "Blueprint %s already exists, proceeding with host "
-        "assignments." % blueprint_name
+        f"Blueprint {blueprint_name} already exists, proceeding with host assignments."
       )
     else:
       logger.error(f"Unable to create blueprint from location {blueprintLocation}")

--- a/ambari-server/src/main/resources/stacks/BIGTOP/3.2.0/services/HBASE/service_advisor.py
+++ b/ambari-server/src/main/resources/stacks/BIGTOP/3.2.0/services/HBASE/service_advisor.py
@@ -1144,9 +1144,7 @@ class HBASEValidator(service_advisor.ServiceAdvisor):
         {
           "config-name": prop_name,
           "item": self.getWarnItem(
-            "Recommended values of " " {0} is empty or '{1}'".format(
-              prop_name, prop_val
-            )
+            f"Recommended values of  {prop_name} is empty or '{prop_val}'"
           ),
         }
       )

--- a/ambari-server/src/test/python/unitTests.py
+++ b/ambari-server/src/test/python/unitTests.py
@@ -339,9 +339,7 @@ def main():
   for variant in test_variants:
     executor_result = multiprocessing.Queue()
     sys.stderr.write(
-      "Running tests for stack:{0} service:{1}\n".format(
-        variant["stack"], variant["service"]
-      )
+      f"Running tests for stack:{variant['stack']} service:{variant['service']}\n"
     )
     process = multiprocessing.Process(
       target=stack_test_executor,

--- a/dev-support/config-utils/diff_stack_properties.py
+++ b/dev-support/config-utils/diff_stack_properties.py
@@ -63,7 +63,7 @@ def do_work(args):
 
 
 def compare_stacks(new_stacks, old_stacks):
-  print("#############[{}]#############".format(STACKS))
+  print(f"#############[{STACKS}]#############")
   for stack in [
     stack
     for stack in os.listdir(os.path.join(new_stacks, STACKS))
@@ -76,10 +76,10 @@ def compare_stacks(new_stacks, old_stacks):
           os.path.join(old_stacks, STACKS, stack, version, CONFIG_DIR),
         )
         if diff != "":
-          print("#############{}.{}#############".format(stack, version))
+          print(f"#############{stack}.{version}#############")
           print(diff)
       if os.path.exists(os.path.join(new_stacks, STACKS, stack, version, SERVICES_DIR)):
-        print("#############{}.{}#############".format(stack, version))
+        print(f"#############{stack}.{version}#############")
         for service_name in os.listdir(
           os.path.join(new_stacks, STACKS, stack, version, SERVICES_DIR)
         ):
@@ -91,12 +91,12 @@ def compare_stacks(new_stacks, old_stacks):
           )
           diff = compare_config_dirs(new_configs_dir, old_configs_dir)
           if diff != "":
-            print("=========={}==========".format(service_name))
+            print(f"=========={service_name}==========")
             print(diff)
 
 
 def compare_common(new_stacks, old_stacks):
-  print("#############[{}]#############".format(COMMON))
+  print(f"#############[{COMMON}]#############")
   for service_name in os.listdir(os.path.join(new_stacks, COMMON)):
     for version in os.listdir(os.path.join(new_stacks, COMMON, service_name)):
       new_configs_dir = os.path.join(
@@ -107,7 +107,7 @@ def compare_common(new_stacks, old_stacks):
       )
       diff = compare_config_dirs(new_configs_dir, old_configs_dir)
       if diff != "":
-        print("=========={}.{}==========".format(service_name, version))
+        print(f"=========={service_name}.{version}==========")
         print(diff)
 
 
@@ -123,11 +123,11 @@ def compare_config_dirs(new_configs_dir, old_configs_dir):
           file_name,
         )
       else:
-        result += "new file {}\n".format(file_name)
+        result += f"new file {file_name}\n"
   else:
     if os.path.exists(old_configs_dir) or os.path.exists(new_configs_dir):
       if not os.path.exists(new_configs_dir):
-        result += "deleted configuration dir {}\n".format(new_configs_dir)
+        result += f"deleted configuration dir {new_configs_dir}\n"
       if not os.path.exists(old_configs_dir):
         result += "new configuration dir {} with files {} \n".format(
           new_configs_dir, os.listdir(new_configs_dir)
@@ -153,21 +153,19 @@ def compare_config_files(new_configs, old_configs, file_name):
       old_deleted = None
       if new_property.find("deleted") is not None:
         deleted = new_property.find("deleted").text
-      old_property = old_configs_tree.find("property[name='{}']".format(name))
+      old_property = old_configs_tree.find(f"property[name='{name}']")
 
       if on_amb_upgrade == "true" and old_property is None:
-        result += "add {}\n".format(name)
+        result += f"add {name}\n"
       else:
         if old_property is not None and old_property.find("deleted") is not None:
           old_deleted = old_property.find("deleted").text
         if deleted == "true" and old_deleted != "true":
-          result += "deleted {}\n".format(name)
+          result += f"deleted {name}\n"
     if result != "":
-      result = "------{}------\n".format(file_name) + result
+      result = f"------{file_name}------\n" + result
   else:
-    result += "{} not exists\n".format(
-      old_configs,
-    )
+    result += f"{old_configs} not exists\n"
   return result
 
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

- Replace legacy `.format()` syntax with modern f-strings throughout the codebase
- Update string formatting to improve code readability

## Examples

Before:
message = "Hello, {}".format(name)
After:
message = f"Hello, {name}"

## How was this patch tested?

All existing tests pass
No functionality changes, only syntax improvements