### PR TITLE
AMBARI-26279: ambari-agent prints logs that netstat command not found

### DIFF
--- a/ambari-agent/src/main/package/dependencies.properties
+++ b/ambari-agent/src/main/package/dependencies.properties
@@ -28,5 +28,5 @@
 # Such a format is respected by install_ambari_tarball.py by default, 
 # however should be encouraged manually in pom.xml.
 
-rpm.dependency.list=openssl,\nRequires: python3-rpm,\nRequires: zlib,\nRequires: python3-distro
-deb.dependency.list=openssl, python (>= 2.6)
+rpm.dependency.list=openssl,\nRequires: python3-rpm,\nRequires: zlib,\nRequires: net-tools,\nRequires: python3-distro
+deb.dependency.list=openssl, net-tools, python (>= 2.6)


### PR DESCRIPTION
## What changes were proposed in this pull request?

Details see: [AMBARI-26279](https://issues.apache.org/jira/browse/AMBARI-26279)

## How was this patch tested?

Compiling ambari, and installing ambari-agent on centos, we will get the following message.
We will find that net-tools would be automatically installed when it's not installed.
```shell
Dependencies Resolved

============================================================================================================================================================================
 Package                                  Arch                             Version                                              Repository                             Size
============================================================================================================================================================================
Installing:
 ambari-agent                             x86_64                           3.0.0.0-SNAPSHOT                                     ambari-repo                            30 M
Installing for dependencies:
 net-tools                                x86_64                           2.0-0.25.20131004git.el7                             base                                  306 k
 python36-rpm                             x86_64                           4.11.3-10.el7                                        epel                                  768 k
Updating for dependencies:
 rpm                                      x86_64                           4.11.3-48.el7_9                                      updates                               1.2 M
 rpm-build                                x86_64                           4.11.3-48.el7_9                                      updates                               150 k
 rpm-build-libs                           x86_64                           4.11.3-48.el7_9                                      updates                               108 k
 rpm-libs                                 x86_64                           4.11.3-48.el7_9                                      updates                               279 k
 rpm-python                               x86_64                           4.11.3-48.el7_9                                      updates                                84 k
 rpm-sign                                 x86_64                           4.11.3-48.el7_9                                      updates                                49 k

Transaction Summary
============================================================================================================================================================================
Install  1 Package  (+2 Dependent packages)
Upgrade             ( 6 Dependent packages)
```

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.