### PR TITLE
AMBARI-26304 : User authentication fails for previously sync'd LDAP /AD based users.

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/orm/entities/UserAuthenticationEntity.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/orm/entities/UserAuthenticationEntity.java
@@ -105,9 +105,11 @@ public class UserAuthenticationEntity {
   }
 
   public String getAuthenticationKey() {
-    int firstCommaIndex = authenticationKey.indexOf(",");
-    if (firstCommaIndex != -1) {
-      return authenticationKey.substring(0, firstCommaIndex);
+    if (getAuthenticationType().equals(UserAuthenticationType.LOCAL)) {
+      int firstCommaIndex = authenticationKey.indexOf(",");
+      if (firstCommaIndex != -1) {
+        return authenticationKey.substring(0, firstCommaIndex);
+      }
     }
     return authenticationKey;
   }

--- a/ambari-server/src/main/java/org/apache/ambari/server/security/authorization/Users.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/security/authorization/Users.java
@@ -1266,7 +1266,7 @@ public class Users {
         userAuthenticationEntity.updateAuthenticationKey(passwordEncoder.encode(newKey), configuration.getPasswordPolicyHistoryCount());
       } else {
         // If we get here the authenticated user is authorized to change the key for the subject.
-        userAuthenticationEntity.updateAuthenticationKey(newKey, configuration.getPasswordPolicyHistoryCount());
+        userAuthenticationEntity.setAuthenticationKey(newKey);
       }
 
       userAuthenticationDAO.merge(userAuthenticationEntity);


### PR DESCRIPTION
Team, apologies for pushing the commit directly without having a PR, it was accidentally done due to a missed check for push to a right branch instead got pushed to the tracking branch. Will take care about this in future contributions.

## What changes were proposed in this pull request?
Issue: User authentication fails for previously sync'd LDAP / AD based users.

Cause: the authentication-key was being split before checking if the authentication type required is local or remote based, hence it fails with a NullPointerException.

(Please fill in changes proposed in this fix)
Changes made: Updated the implementation to add a check for auth type before adding split for authentication-key

## How was this patch tested?
validated changes on a local cluster with AD setup

(Please explain how this patch was tested. Ex: unit tests, manual tests)
(If this patch involves UI changes, please attach a screen-shot; otherwise, remove this)

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.