### PR TITLE
AMBARI-26305: Setting up Hive's xms config

### DIFF
--- a/ambari-server/src/main/resources/stacks/BIGTOP/3.2.0/services/HIVE/configuration/hive-env.xml
+++ b/ambari-server/src/main/resources/stacks/BIGTOP/3.2.0/services/HIVE/configuration/hive-env.xml
@@ -388,7 +388,7 @@ fi
 export HADOOP_OPTS="$HADOOP_OPTS -Dzookeeper.sasl.client.username={{zk_principal_user}}"
 {% endif %}
 
-export HADOOP_CLIENT_OPTS="$HADOOP_CLIENT_OPTS  -Xmx${HADOOP_HEAPSIZE}m"
+export HADOOP_CLIENT_OPTS="$HADOOP_CLIENT_OPTS  -Xms${HADOOP_HEAPSIZE}m -Xmx${HADOOP_HEAPSIZE}m"
 export HADOOP_CLIENT_OPTS="$HADOOP_CLIENT_OPTS{{heap_dump_opts}}"
 
 # Larger heap size may be required when running queries over large number of files or partitions.


### PR DESCRIPTION
## What changes were proposed in this pull request?

Suggesting to append the xms value for Hive serivces.

## How was this patch tested?

Tested on local lab cluster by adding xms value to hive services during the scenario of failure, by adding this, able to make serivice up and running. 
Details are added at [AMBARI-26305](https://issues.apache.org/jira/browse/AMBARI-26305)

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.