### PR TITLE
AMBARI-26306: Bumpup logback to 1.5.16(latest) due to CVE's

### DIFF
--- a/ambari-project/pom.xml
+++ b/ambari-project/pom.xml
@@ -38,7 +38,7 @@
     <swagger.maven.plugin.version>3.1.5</swagger.maven.plugin.version>
     <slf4j.version>2.0.0</slf4j.version>
     <reload4j.version>1.2.22</reload4j.version>
-    <logback.version>1.2.13</logback.version>
+    <logback.version>1.5.16</logback.version>
     <guice.version>5.1.0</guice.version>
     <spring.version>5.3.22</spring.version>
     <spring.security.version>5.7.8</spring.security.version>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Upgrade the logback version to fix the CVE's
Details are added at [AMBARI-26306](https://issues.apache.org/jira/browse/AMBARI-26306)
