### PR TITLE
AMBARI-26307: Knox SSO fails to login into Ambari

### DIFF
--- a/ambari-web/app/router.js
+++ b/ambari-web/app/router.js
@@ -285,7 +285,7 @@ App.Router = Em.Router.extend({
     var self = this;
     var auth = App.db.getAuthenticated();
     this.getClusterDataRequest().always(function (xhr, textStatus, jqXHRorErrorThrown) {
-      if (xhr) {
+      if (xhr && textStatus == 'success') {
         // if server knows the user and user authenticated by UI
         if (auth) {
           dfd.resolve(self.get('loggedIn'));

--- a/ambari-web/app/router.js
+++ b/ambari-web/app/router.js
@@ -284,15 +284,15 @@ App.Router = Em.Router.extend({
     var dfd = $.Deferred();
     var self = this;
     var auth = App.db.getAuthenticated();
-    this.getClusterDataRequest().always(function (xhr) {
+    this.getClusterDataRequest().always(function (xhr, textStatus, jqXHRorErrorThrown) {
       if (xhr) {
         // if server knows the user and user authenticated by UI
         if (auth) {
           dfd.resolve(self.get('loggedIn'));
           // if server knows the user but UI don't, check the response header
           // and try to authorize
-        } else if (xhr.getResponseHeader('User')) {
-          var user = xhr.getResponseHeader('User');
+        } else if (jqXHRorErrorThrown.getResponseHeader('User')) {
+          var user = jqXHRorErrorThrown.getResponseHeader('User');
           App.ajax.send({
             name: 'router.afterLogin',
             sender: self,


### PR DESCRIPTION
## What changes were proposed in this pull request?
Fix getAuthenticated method when Knox SSO is enabled.
I believe this started happening after the jQuery upgrade.


## How was this patch tested?
Have installed Knox in one of the hosts, then setup Knox SSO for Ambari (ambari-server setup-sso).
Once everything is configured/restarted check if we are able to login using knox-sso (hadoop-jwt) or not.

And without this patch UI errors out with
```
Uncaught TypeError: xhr.getResponseHeader is not a function
    at Class.<anonymous> (app.js:92484:24)
    at c (vendor.js:1717:25)
    at Object.fireWith [as resolveWith] (vendor.js:1772:20)
    at l (vendor.js:4936:19)
    at XMLHttpRequest.<anonymous> (vendor.js:5085:23)
```