### PR TITLE
AMBARI-26295: ambari-server start error: Caused by: java.lang.AbstractMethodError

### DIFF
--- a/ambari-agent/pom.xml
+++ b/ambari-agent/pom.xml
@@ -52,7 +52,6 @@
     <resourcesFolder>${ambari.server.module}/src/main/resources</resourcesFolder>
     <customActionsLocation>${target.cache.dir}/custom_actions</customActionsLocation>
     <empty.dir>src/packages/tarball</empty.dir> <!-- any directory in project with not very big amount of files (not to waste-load them) -->
-    <hadoop.version>3.3.4</hadoop.version>
     <python.test.mask>[Tt]est*.py</python.test.mask>
     
     <commons-cli.version>1.5.0</commons-cli.version>

--- a/ambari-agent/pom.xml
+++ b/ambari-agent/pom.xml
@@ -52,6 +52,7 @@
     <resourcesFolder>${ambari.server.module}/src/main/resources</resourcesFolder>
     <customActionsLocation>${target.cache.dir}/custom_actions</customActionsLocation>
     <empty.dir>src/packages/tarball</empty.dir> <!-- any directory in project with not very big amount of files (not to waste-load them) -->
+    <hadoop.version>3.3.4</hadoop.version>
     <python.test.mask>[Tt]est*.py</python.test.mask>
     
     <commons-cli.version>1.5.0</commons-cli.version>
@@ -175,6 +176,22 @@
         <exclusion>
           <groupId>org.slf4j</groupId>
           <artifactId>slf4j-log4j12</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.sun.jersey</groupId>
+          <artifactId>jersey-core</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.sun.jersey</groupId>
+          <artifactId>jersey-servlet</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.sun.jersey</groupId>
+          <artifactId>jersey-json</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.sun.jersey</groupId>
+          <artifactId>jersey-server</artifactId>
         </exclusion>
       </exclusions>
     </dependency>

--- a/ambari-server/pom.xml
+++ b/ambari-server/pom.xml
@@ -1650,7 +1650,11 @@
     <dependency>
       <groupId>org.codehaus.jettison</groupId>
       <artifactId>jettison</artifactId>
-      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId> org.codehaus.jackson</groupId>
+      <artifactId>jackson-jaxrs</artifactId>
+      <version>1.9.2</version>
     </dependency>
     <dependency>
       <groupId>junit</groupId>
@@ -1802,6 +1806,11 @@
       <version>${FastInfoset.version}</version>
     </dependency>
     <dependency>
+      <groupId>com.sun.xml.bind</groupId>
+      <artifactId>jaxb-impl</artifactId>
+      <version>2.2.3-1</version>
+    </dependency>
+    <dependency>
       <groupId>org.ehcache</groupId>
       <artifactId>ehcache</artifactId>
       <version>${ehcache.version}</version>
@@ -1939,6 +1948,22 @@
         <exclusion>
           <groupId>org.slf4j</groupId>
           <artifactId>slf4j-log4j12</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.sun.jersey</groupId>
+          <artifactId>jersey-core</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.sun.jersey</groupId>
+          <artifactId>jersey-servlet</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.sun.jersey</groupId>
+          <artifactId>jersey-json</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.sun.jersey</groupId>
+          <artifactId>jersey-server</artifactId>
         </exclusion>
       </exclusions>
     </dependency>

--- a/ambari-server/pom.xml
+++ b/ambari-server/pom.xml
@@ -1652,11 +1652,6 @@
       <artifactId>jettison</artifactId>
     </dependency>
     <dependency>
-      <groupId> org.codehaus.jackson</groupId>
-      <artifactId>jackson-jaxrs</artifactId>
-      <version>1.9.2</version>
-    </dependency>
-    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <scope>test</scope>

--- a/ambari-utility/pom.xml
+++ b/ambari-utility/pom.xml
@@ -64,6 +64,18 @@
           <groupId>log4j</groupId>
           <artifactId>log4j</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>com.sun.jersey</groupId>
+          <artifactId>jersey-server</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.sun.jersey</groupId>
+          <artifactId>jersey-core</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.sun.jersey.contribs</groupId>
+          <artifactId>jersey-multipart</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>


### PR DESCRIPTION
## What changes were proposed in this pull request?
Fix: [AMBARI-26295](https://issues.apache.org/jira/browse/AMBARI-26295)

## How was this patch tested?
Build ambari, deploy ambari, and start it.

Or view dependency relationships through Maven command `mvn dependency:tree`
Before applying this changes.
```
[INFO] +- org.apache.hadoop:hadoop-common:jar:3.3.4:compile
[INFO] |  +- org.apache.hadoop.thirdparty:hadoop-shaded-protobuf_3_7:jar:1.1.1:compile
[INFO] |  +- jakarta.activation:jakarta.activation-api:jar:1.2.1:compile
[INFO] |  +- javax.servlet.jsp:jsp-api:jar:2.1:runtime
[INFO] |  +- com.sun.jersey:jersey-core:jar:1.19:compile
[INFO] |  |  \- javax.ws.rs:jsr311-api:jar:1.1.1:compile
[INFO] |  +- com.sun.jersey:jersey-servlet:jar:1.19:compile
[INFO] |  +- com.sun.jersey:jersey-json:jar:1.19:compile
[INFO] |  |  +- com.sun.xml.bind:jaxb-impl:jar:2.2.3-1:compile
[INFO] |  |  \- org.codehaus.jackson:jackson-jaxrs:jar:1.9.2:compile
[INFO] |  +- com.sun.jersey:jersey-server:jar:1.19:compile
[INFO] |  +- org.apache.commons:commons-configuration2:jar:2.1.1:compile
[INFO] |  +- org.apache.avro:avro:jar:1.7.7:compile
[INFO] |  |  \- com.thoughtworks.paranamer:paranamer:jar:2.3:compile
[INFO] |  +- com.google.re2j:re2j:jar:1.1:compile
[INFO] |  +- com.google.protobuf:protobuf-java:jar:2.5.0:compile
[INFO] |  +- org.apache.curator:curator-client:jar:4.2.0:compile
[INFO] |  +- org.apache.curator:curator-recipes:jar:4.2.0:compile
[INFO] |  +- org.apache.kerby:kerb-core:jar:1.0.1:compile
[INFO] |  |  \- org.apache.kerby:kerby-pkix:jar:1.0.1:compile
[INFO] |  |     +- org.apache.kerby:kerby-asn1:jar:1.0.1:compile
[INFO] |  |     \- org.apache.kerby:kerby-util:jar:1.0.1:compile
[INFO] |  +- org.codehaus.woodstox:stax2-api:jar:4.2.1:compile
[INFO] |  +- com.fasterxml.woodstox:woodstox-core:jar:5.3.0:compile
[INFO] |  +- dnsjava:dnsjava:jar:2.1.7:compile
[INFO] |  \- org.xerial.snappy:snappy-java:jar:1.1.8.2:compile
```

After applying this changes.
```
[INFO] +- org.apache.hadoop:hadoop-common:jar:3.3.4:compile
[INFO] |  +- org.apache.hadoop.thirdparty:hadoop-shaded-protobuf_3_7:jar:1.1.1:compile
[INFO] |  +- jakarta.activation:jakarta.activation-api:jar:1.2.1:compile
[INFO] |  +- javax.servlet.jsp:jsp-api:jar:2.1:runtime
[INFO] |  +- org.apache.commons:commons-configuration2:jar:2.1.1:compile
[INFO] |  +- org.apache.avro:avro:jar:1.7.7:compile
[INFO] |  |  \- com.thoughtworks.paranamer:paranamer:jar:2.3:compile
[INFO] |  +- com.google.re2j:re2j:jar:1.1:compile
[INFO] |  +- com.google.protobuf:protobuf-java:jar:2.5.0:compile
[INFO] |  +- org.apache.curator:curator-client:jar:4.2.0:compile
[INFO] |  +- org.apache.curator:curator-recipes:jar:4.2.0:compile
[INFO] |  +- org.apache.kerby:kerb-core:jar:1.0.1:compile
[INFO] |  |  \- org.apache.kerby:kerby-pkix:jar:1.0.1:compile
[INFO] |  |     +- org.apache.kerby:kerby-asn1:jar:1.0.1:compile
[INFO] |  |     \- org.apache.kerby:kerby-util:jar:1.0.1:compile
[INFO] |  +- org.codehaus.woodstox:stax2-api:jar:4.2.1:compile
[INFO] |  +- com.fasterxml.woodstox:woodstox-core:jar:5.3.0:compile
[INFO] |  +- dnsjava:dnsjava:jar:2.1.7:compile
[INFO] |  \- org.xerial.snappy:snappy-java:jar:1.1.8.2:compile
```


Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.