### PR TITLE
AMBARI-26311: postgresql-server should be installed even though ambari-server is configured with mysql

### DIFF
--- a/ambari-server/src/main/python/ambari_server/dbCleanup.py
+++ b/ambari-server/src/main/python/ambari_server/dbCleanup.py
@@ -20,13 +20,18 @@ limitations under the License.
 
 from ambari_commons.logging_utils import print_info_msg, print_error_msg
 from ambari_commons.os_utils import run_os_command
-from ambari_server.dbConfiguration import ensure_jdbc_driver_is_installed
+from ambari_server.dbConfiguration import (
+  ensure_jdbc_driver_is_installed,
+  LINUX_DBMS_KEYS_LIST,
+)
 from ambari_server.serverConfiguration import (
   configDefaults,
   get_ambari_properties,
   get_java_exe_path,
   read_ambari_user,
   get_db_type,
+  parse_properties_file,
+  JDBC_DATABASE_PROPERTY,
 )
 from ambari_server.setupSecurity import (
   generate_env,
@@ -106,6 +111,9 @@ def run_db_purge(options):
     )
     return 1
 
+  properties = get_ambari_properties()
+  parse_properties_file(options)
+  options.database_index = LINUX_DBMS_KEYS_LIST.index(properties[JDBC_DATABASE_PROPERTY])
   ensure_jdbc_driver_is_installed(options, get_ambari_properties())
 
   server_class_path = ServerClassPath(get_ambari_properties(), options)

--- a/ambari-server/src/main/python/ambari_server/dbConfiguration_linux.py
+++ b/ambari-server/src/main/python/ambari_server/dbConfiguration_linux.py
@@ -524,6 +524,7 @@ class PGConfig(LinuxDBMSConfig):
   PG_STATUS_STOPPED = "stopped"
   PG_SERVICE_NAME = "postgresql"
   PG_HBA_DIR = None
+  PG_INITDB_CMD = None
 
   if (
     OSCheck.is_redhat_family()
@@ -541,8 +542,6 @@ class PGConfig(LinuxDBMSConfig):
         if psql_service_file:
           psql_service_file_name = os.path.basename(psql_service_file[0])
           PG_SERVICE_NAME = psql_service_file_name[:-8]  # remove .service
-      else:
-        raise FatalException(1, "Cannot find postgresql-setup script.")
 
     SERVICE_CMD = "/usr/bin/env systemctl"
     PG_ST_CMD = f"{SERVICE_CMD} status {PG_SERVICE_NAME}"
@@ -598,6 +597,8 @@ class PGConfig(LinuxDBMSConfig):
   )
 
   def __init__(self, options, properties, storage_type):
+    if PGConfig.PG_INITDB_CMD is None:
+      raise FatalException(1, "Cannot find postgresql-setup script.")
     super(PGConfig, self).__init__(options, properties, storage_type)
 
     # Init the database configuration data here, if any


### PR DESCRIPTION
## What changes were proposed in this pull request?

(Please fill in changes proposed in this fix)
Allow ambari-server can be installed or executed with db-purge-history script without postgresql-server package on centos7 if ambari-server is not configured with postgresql.


## How was this patch tested?

manual tests on our company's cluster.