### PR TITLE
[WIP] AMBARI-26314: Ambari's ldap-sync issue for db's

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/orm/entities/GroupEntity.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/orm/entities/GroupEntity.java
@@ -41,7 +41,7 @@ import javax.persistence.UniqueConstraint;
 import org.apache.ambari.server.security.authorization.GroupType;
 
 @Entity
-@Table(name = "\"groups\"", uniqueConstraints = {@UniqueConstraint(columnNames = {"group_name", "ldap_group"})})
+@Table(name = "groups_info", uniqueConstraints = {@UniqueConstraint(columnNames = {"group_name", "ldap_group"})})
 @TableGenerator(name = "group_id_generator",
     table = "ambari_sequences",
     pkColumnName = "sequence_name",

--- a/ambari-server/src/main/resources/Ambari-DDL-Derby-CREATE.sql
+++ b/ambari-server/src/main/resources/Ambari-DDL-Derby-CREATE.sql
@@ -337,7 +337,7 @@ CREATE TABLE user_authentication (
   CONSTRAINT PK_user_authentication PRIMARY KEY (user_authentication_id),
   CONSTRAINT FK_user_authentication_users FOREIGN KEY (user_id) REFERENCES users (user_id));
 
-CREATE TABLE groups (
+CREATE TABLE groups_info (
   group_id INTEGER,
   principal_id BIGINT NOT NULL,
   group_name VARCHAR(255) NOT NULL,
@@ -353,7 +353,7 @@ CREATE TABLE members (
   user_id INTEGER NOT NULL,
   CONSTRAINT PK_members PRIMARY KEY (member_id),
   UNIQUE(group_id, user_id),
-  CONSTRAINT FK_members_group_id FOREIGN KEY (group_id) REFERENCES groups (group_id),
+  CONSTRAINT FK_members_group_id FOREIGN KEY (group_id) REFERENCES groups_info (group_id),
   CONSTRAINT FK_members_user_id FOREIGN KEY (user_id) REFERENCES users (user_id));
 
 CREATE TABLE requestschedule (

--- a/ambari-server/src/main/resources/Ambari-DDL-MySQL-CREATE.sql
+++ b/ambari-server/src/main/resources/Ambari-DDL-MySQL-CREATE.sql
@@ -357,7 +357,7 @@ CREATE TABLE user_authentication (
   CONSTRAINT FK_user_authentication_users FOREIGN KEY (user_id) REFERENCES users (user_id)
 );
 
-CREATE TABLE `groups` (
+CREATE TABLE groups_info (
   group_id INTEGER,
   principal_id BIGINT NOT NULL,
   group_name VARCHAR(255) NOT NULL,
@@ -372,7 +372,7 @@ CREATE TABLE members (
   group_id INTEGER NOT NULL,
   user_id INTEGER NOT NULL,
   CONSTRAINT PK_members PRIMARY KEY (member_id),
-  CONSTRAINT FK_members_group_id FOREIGN KEY (group_id) REFERENCES `groups` (group_id),
+  CONSTRAINT FK_members_group_id FOREIGN KEY (group_id) REFERENCES groups_info (group_id),
   CONSTRAINT FK_members_user_id FOREIGN KEY (user_id) REFERENCES users (user_id),
   CONSTRAINT UNQ_members_0 UNIQUE (group_id, user_id));
 

--- a/ambari-server/src/main/resources/Ambari-DDL-Oracle-CREATE.sql
+++ b/ambari-server/src/main/resources/Ambari-DDL-Oracle-CREATE.sql
@@ -338,7 +338,7 @@ CREATE TABLE user_authentication (
   CONSTRAINT FK_user_authentication_users FOREIGN KEY (user_id) REFERENCES users (user_id)
 );
 
-CREATE TABLE groups (
+CREATE TABLE groups_info (
   group_id NUMBER(10) NOT NULL,
   principal_id NUMBER(19) NOT NULL,
   group_name VARCHAR2(255) NOT NULL,
@@ -353,7 +353,7 @@ CREATE TABLE members (
   group_id NUMBER(10) NOT NULL,
   user_id NUMBER(10) NOT NULL,
   CONSTRAINT PK_members PRIMARY KEY (member_id),
-  CONSTRAINT FK_members_group_id FOREIGN KEY (group_id) REFERENCES groups (group_id),
+  CONSTRAINT FK_members_group_id FOREIGN KEY (group_id) REFERENCES groups_info (group_id),
   CONSTRAINT FK_members_user_id FOREIGN KEY (user_id) REFERENCES users (user_id),
   CONSTRAINT UNQ_members_0 UNIQUE (group_id, user_id));
 

--- a/ambari-server/src/main/resources/Ambari-DDL-Postgres-CREATE.sql
+++ b/ambari-server/src/main/resources/Ambari-DDL-Postgres-CREATE.sql
@@ -339,7 +339,7 @@ CREATE TABLE user_authentication (
   CONSTRAINT PK_user_authentication PRIMARY KEY (user_authentication_id),
   CONSTRAINT FK_user_authentication_users FOREIGN KEY (user_id) REFERENCES users (user_id));
 
-CREATE TABLE groups (
+CREATE TABLE groups_info (
   group_id INTEGER,
   principal_id BIGINT NOT NULL,
   group_name VARCHAR(255) NOT NULL,
@@ -355,7 +355,7 @@ CREATE TABLE members (
   user_id INTEGER NOT NULL,
   CONSTRAINT PK_members PRIMARY KEY (member_id),
   UNIQUE(group_id, user_id),
-  CONSTRAINT FK_members_group_id FOREIGN KEY (group_id) REFERENCES groups (group_id),
+  CONSTRAINT FK_members_group_id FOREIGN KEY (group_id) REFERENCES groups_info (group_id),
   CONSTRAINT FK_members_user_id FOREIGN KEY (user_id) REFERENCES users (user_id));
 
 CREATE TABLE requestschedule (

--- a/ambari-server/src/main/resources/Ambari-DDL-SQLAnywhere-CREATE.sql
+++ b/ambari-server/src/main/resources/Ambari-DDL-SQLAnywhere-CREATE.sql
@@ -336,7 +336,7 @@ CREATE TABLE user_authentication (
   CONSTRAINT FK_user_authentication_users FOREIGN KEY (user_id) REFERENCES users (user_id)
 );
 
-CREATE TABLE groups (
+CREATE TABLE groups_info (
   group_id INTEGER,
   principal_id NUMERIC(19) NOT NULL,
   group_name VARCHAR(255) NOT NULL,
@@ -351,7 +351,7 @@ CREATE TABLE members (
   group_id INTEGER NOT NULL,
   user_id INTEGER NOT NULL,
   CONSTRAINT PK_members PRIMARY KEY (member_id),
-  CONSTRAINT FK_members_group_id FOREIGN KEY (group_id) REFERENCES groups (group_id),
+  CONSTRAINT FK_members_group_id FOREIGN KEY (group_id) REFERENCES groups_info (group_id),
   CONSTRAINT FK_members_user_id FOREIGN KEY (user_id) REFERENCES users (user_id),
   CONSTRAINT UNQ_members_0 UNIQUE (group_id, user_id));
 

--- a/ambari-server/src/main/resources/Ambari-DDL-SQLServer-CREATE.sql
+++ b/ambari-server/src/main/resources/Ambari-DDL-SQLServer-CREATE.sql
@@ -342,7 +342,7 @@ CREATE TABLE user_authentication (
   CONSTRAINT FK_user_authentication_users FOREIGN KEY (user_id) REFERENCES users (user_id)
 );
 
-CREATE TABLE groups (
+CREATE TABLE groups_info (
   group_id INTEGER,
   principal_id BIGINT NOT NULL,
   group_name VARCHAR(255) NOT NULL,
@@ -357,7 +357,7 @@ CREATE TABLE members (
   group_id INTEGER NOT NULL,
   user_id INTEGER NOT NULL,
   CONSTRAINT PK_members PRIMARY KEY CLUSTERED (member_id),
-  CONSTRAINT FK_members_group_id FOREIGN KEY (group_id) REFERENCES groups (group_id),
+  CONSTRAINT FK_members_group_id FOREIGN KEY (group_id) REFERENCES groups_info (group_id),
   CONSTRAINT FK_members_user_id FOREIGN KEY (user_id) REFERENCES users (user_id),
   CONSTRAINT UNQ_members_0 UNIQUE (group_id, user_id));
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

The suggested changes are to make compatible for both MySQL-8.x and Oracle-19.x daatabases for ldap-sync.

## How was this patch tested?

The changes are tested on local rhel-8 and rhel-9 env clussters by convering both MySQL and oracle databases, followed by syncing the ldap .


Results are added at [AMBARI-26314](https://issues.apache.org/jira/browse/AMBARI-26314)