### PR TITLE
AMBARI-26296: Fix security related issues after spring upgrade

### DIFF
--- a/ambari-agent/pom.xml
+++ b/ambari-agent/pom.xml
@@ -108,6 +108,18 @@
       <version>2.7.3</version>
       <exclusions>
         <exclusion>
+          <groupId>com.sun.jersey</groupId>
+          <artifactId>jersey-core</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.sun.jersey</groupId>
+          <artifactId>jersey-servlet</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.sun.jersey</groupId>
+          <artifactId>jersey-server</artifactId>
+        </exclusion>
+        <exclusion>
             <groupId>com.jcraft</groupId>
             <artifactId>jsch</artifactId>
         </exclusion>

--- a/ambari-project/pom.xml
+++ b/ambari-project/pom.xml
@@ -31,7 +31,7 @@
     <solr.version>5.5.2</solr.version>
     <ambari.dir>${project.parent.basedir}</ambari.dir>
     <powermock.version>2.0.9</powermock.version>
-    <jetty.version>11.0.15</jetty.version>
+    <jetty.version>11.0.24</jetty.version>
     <ldap-api.version>1.0.0</ldap-api.version>
     <checkstyle.version>8.9</checkstyle.version>
     <swagger.version>1.6.8</swagger.version>
@@ -434,11 +434,6 @@
         <groupId>commons-lang</groupId>
         <artifactId>commons-lang</artifactId>
         <version>2.6</version>
-      </dependency>
-      <dependency>
-        <groupId>javax.servlet</groupId>
-        <artifactId>javax.servlet-api</artifactId>
-        <version>3.1.0</version>
       </dependency>
       <dependency>
         <groupId>org.glassfish.jersey.core</groupId>

--- a/ambari-server/pom.xml
+++ b/ambari-server/pom.xml
@@ -1391,10 +1391,10 @@
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-server</artifactId>
     </dependency>
-    <dependency>
-      <groupId>org.eclipse.jetty.websocket</groupId>
-      <artifactId>websocket-servlet</artifactId>
-    </dependency>
+<!--    <dependency>-->
+<!--      <groupId>org.eclipse.jetty.websocket</groupId>-->
+<!--      <artifactId>websocket-servlet</artifactId>-->
+<!--    </dependency>-->
     <dependency>
       <groupId>org.eclipse.jetty.websocket</groupId>
       <artifactId>websocket-jetty-server</artifactId>
@@ -1402,7 +1402,7 @@
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty.websocket</groupId>
-      <artifactId>websocket-jetty-server</artifactId>
+      <artifactId>websocket-jetty-api</artifactId>
       <version>${jetty.version}</version>
     </dependency>
     <dependency>
@@ -1460,6 +1460,7 @@
     <dependency>
       <groupId>org.glassfish.jersey.core</groupId>
       <artifactId>jersey-server</artifactId>
+      <version>${jersey.version}</version>
     </dependency>
     <dependency>
       <groupId>org.glassfish.jersey.media</groupId>
@@ -1519,6 +1520,14 @@
         <exclusion>
           <groupId>org.yaml</groupId>
           <artifactId>snakeyaml</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.sun.jersey</groupId>
+          <artifactId>jersey-core</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.sun.jersey</groupId>
+          <artifactId>jersey-server</artifactId>
         </exclusion>
       </exclusions>
     </dependency>
@@ -1639,7 +1648,7 @@
     <dependency>
       <groupId>cglib</groupId>
       <artifactId>cglib</artifactId>
-      <version>3.2.4</version>
+      <version>3.3.0</version>
     </dependency>
     <dependency>
       <groupId>com.google.code.gson</groupId>
@@ -1818,6 +1827,18 @@
       <artifactId>hadoop-common</artifactId>
       <version>${hadoop.version}</version>
       <exclusions>
+        <exclusion>
+          <groupId>com.sun.jersey</groupId>
+          <artifactId>jersey-core</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.sun.jersey</groupId>
+          <artifactId>jersey-servlet</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.sun.jersey</groupId>
+          <artifactId>jersey-server</artifactId>
+        </exclusion>
         <exclusion>
           <groupId>javax.servlet</groupId>
           <artifactId>javax.servlet-api</artifactId>

--- a/ambari-server/pom.xml
+++ b/ambari-server/pom.xml
@@ -1169,14 +1169,8 @@
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-jndi</artifactId>
-      <version>11.0.15</version>
+      <version>${jetty.version}</version>
     </dependency>
-    <dependency>
-      <groupId>org.eclipse.jetty</groupId>
-      <artifactId>jetty-plus</artifactId>
-      <version>11.0.15</version>
-    </dependency>
-
     <dependency>
       <groupId>jakarta.servlet</groupId>
       <artifactId>jakarta.servlet-api</artifactId>
@@ -1406,10 +1400,6 @@
       <artifactId>websocket-jetty-server</artifactId>
       <version>${jetty.version}</version>
     </dependency>
-<!--    <dependency>-->
-<!--      <groupId>org.eclipse.jetty.websocket</groupId>-->
-<!--      <artifactId>websocket-server</artifactId>-->
-<!--    </dependency>-->
     <dependency>
       <groupId>org.eclipse.jetty.websocket</groupId>
       <artifactId>websocket-jetty-server</artifactId>
@@ -1828,6 +1818,14 @@
       <artifactId>hadoop-common</artifactId>
       <version>${hadoop.version}</version>
       <exclusions>
+        <exclusion>
+          <groupId>javax.servlet</groupId>
+          <artifactId>javax.servlet-api</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>javax.servlet.jsp</groupId>
+          <artifactId>jsp-api</artifactId>
+        </exclusion>
         <exclusion>
           <groupId>commons-collections</groupId>
           <artifactId>commons-collections</artifactId>

--- a/ambari-server/src/main/java/org/apache/ambari/server/configuration/spring/AgentStompConfig.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/configuration/spring/AgentStompConfig.java
@@ -50,6 +50,8 @@ public class AgentStompConfig implements WebSocketMessageBrokerConfigurer {
   @Autowired
   private AgentRegisteringQueueChecker agentRegisteringQueueChecker;
 
+
+
   public AgentStompConfig(ServletContext servletContext, Injector injector) {
     this.servletContext = servletContext;
     configuration = injector.getInstance(org.apache.ambari.server.configuration.Configuration.class);
@@ -79,7 +81,6 @@ public class AgentStompConfig implements WebSocketMessageBrokerConfigurer {
   @Override
   public void configureClientOutboundChannel(ChannelRegistration registration) {
     registration.taskExecutor().corePoolSize(configuration.getSpringMessagingThreadPoolSize());
-//    registration.setInterceptors(agentRegisteringQueueChecker);
     registration.interceptors(agentRegisteringQueueChecker);
   }
 

--- a/ambari-server/src/main/java/org/apache/ambari/server/configuration/spring/ApiSecurityConfig.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/configuration/spring/ApiSecurityConfig.java
@@ -5,6 +5,7 @@ import java.util.Arrays;
 import org.apache.ambari.server.security.AmbariEntryPoint;
 import org.apache.ambari.server.security.authentication.AmbariDelegatingAuthenticationFilter;
 import org.apache.ambari.server.security.authentication.AmbariLocalAuthenticationProvider;
+import org.apache.ambari.server.security.authentication.RequestBodyCachingFilter;
 import org.apache.ambari.server.security.authentication.jwt.AmbariJwtAuthenticationProvider;
 import org.apache.ambari.server.security.authentication.kerberos.AmbariAuthToLocalUserDetailsService;
 import org.apache.ambari.server.security.authentication.kerberos.AmbariKerberosAuthenticationProvider;
@@ -55,6 +56,7 @@ public class ApiSecurityConfig {
             .exceptionHandling(exceptionHandling -> exceptionHandling.authenticationEntryPoint(ambariEntryPoint))
             .sessionManagement(sessionManagement -> sessionManagement
                     .sessionCreationPolicy(SessionCreationPolicy.IF_REQUIRED))
+            .addFilterBefore(new RequestBodyCachingFilter(), BasicAuthenticationFilter.class)
             .addFilterBefore(guiceBeansConfig.ambariUserAuthorizationFilter(), BasicAuthenticationFilter.class)
             .addFilterAt(delegatingAuthenticationFilter, BasicAuthenticationFilter.class)
             .addFilterBefore(authorizationFilter, FilterSecurityInterceptor.class);
@@ -78,7 +80,7 @@ public class ApiSecurityConfig {
             ambariKerberosAuthenticationProvider
     ));
   }
-
+  
   @Bean
   public AmbariKerberosAuthenticationProvider ambariKerberosAuthenticationProvider(
           AmbariKerberosTicketValidator ambariKerberosTicketValidator,

--- a/ambari-server/src/main/java/org/apache/ambari/server/configuration/spring/ApiSecurityConfig.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/configuration/spring/ApiSecurityConfig.java
@@ -23,6 +23,7 @@ import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.ProviderManager;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.access.intercept.FilterSecurityInterceptor;
 import org.springframework.security.web.authentication.www.BasicAuthenticationFilter;
@@ -42,7 +43,7 @@ public class ApiSecurityConfig {
   @Autowired
   private AmbariAuthorizationFilter authorizationFilter;
 
-  public ApiSecurityConfig(GuiceBeansConfig guiceBeansConfig) {
+  public ApiSecurityConfig(GuiceBeansConfig guiceBeansConfig){
     this.guiceBeansConfig = guiceBeansConfig;
   }
 
@@ -52,6 +53,8 @@ public class ApiSecurityConfig {
             .authorizeHttpRequests(authz -> authz.anyRequest().authenticated())
             .headers(headers -> headers.httpStrictTransportSecurity().disable().frameOptions().disable())
             .exceptionHandling(exceptionHandling -> exceptionHandling.authenticationEntryPoint(ambariEntryPoint))
+            .sessionManagement(sessionManagement -> sessionManagement
+                    .sessionCreationPolicy(SessionCreationPolicy.IF_REQUIRED))
             .addFilterBefore(guiceBeansConfig.ambariUserAuthorizationFilter(), BasicAuthenticationFilter.class)
             .addFilterAt(delegatingAuthenticationFilter, BasicAuthenticationFilter.class)
             .addFilterBefore(authorizationFilter, FilterSecurityInterceptor.class);

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/AmbariHandlerList.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/AmbariHandlerList.java
@@ -44,8 +44,6 @@ import org.apache.ambari.server.view.ViewInstanceHandlerList;
 import org.apache.ambari.server.view.ViewRegistry;
 import org.apache.ambari.view.SystemException;
 import org.apache.ambari.view.ViewContext;
-import org.eclipse.jetty.plus.webapp.EnvConfiguration;
-import org.eclipse.jetty.plus.webapp.PlusConfiguration;
 import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.handler.ErrorHandler;
@@ -263,11 +261,6 @@ public class AmbariHandlerList extends HandlerCollection implements ViewInstance
     webAppContext.addFilter(new FilterHolder(persistFilter), "/*", AmbariServer.DISPATCHER_TYPES);
     webAppContext.addFilter(new FilterHolder(springSecurityFilter), "/*", AmbariServer.DISPATCHER_TYPES);
     webAppContext.setAllowNullPathInfo(true);
-    webAppContext.setConfigurations(new org.eclipse.jetty.webapp.Configuration[] {
-            new EnvConfiguration(),
-            new PlusConfiguration()
-    });
-
 
     if (webAppContext.getErrorHandler() != null) {
       ErrorHandler errorHandlerProxy = createAmbariViewErrorHandlerProxy(webAppContext.getErrorHandler());

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/AmbariServer.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/AmbariServer.java
@@ -84,6 +84,7 @@ import org.apache.ambari.server.controller.utilities.KerberosIdentityCleaner;
 import org.apache.ambari.server.events.AmbariPropertiesChangedEvent;
 import org.apache.ambari.server.events.publishers.AmbariEventPublisher;
 import org.apache.ambari.server.ldap.LdapModule;
+import org.apache.ambari.server.listeners.WebSocketInitializerListener;
 import org.apache.ambari.server.metrics.system.MetricsService;
 import org.apache.ambari.server.orm.GuiceJpaInitializer;
 import org.apache.ambari.server.orm.PersistenceType;
@@ -151,6 +152,7 @@ import org.eclipse.jetty.servlet.ServletContextHandler;
 import org.eclipse.jetty.servlet.ServletHolder;
 import org.eclipse.jetty.util.ssl.SslContextFactory;
 import org.eclipse.jetty.util.thread.QueuedThreadPool;
+import org.eclipse.jetty.websocket.server.config.JettyWebSocketServletContainerInitializer;
 import org.glassfish.jersey.server.ResourceConfig;
 import org.glassfish.jersey.servlet.ServletContainer;
 import org.slf4j.Logger;
@@ -389,7 +391,14 @@ public class AmbariServer {
       if (configs.isAgentApiGzipped()) {
         configureHandlerCompression(agentroot);
       }
+
+      JettyWebSocketServletContainerInitializer initializerForAgentroot = new JettyWebSocketServletContainerInitializer((context, jettyContainer) -> {
+        jettyContainer.setMaxTextMessageSize(configs.getStompMaxIncomingMessageSize());
+        LOG.info("Configured WebSocket container max text message size: {}", configs.getStompMaxIncomingMessageSize());
+      });
+
       agentroot.addEventListener(new ContextLoaderListener(agentApiContext));
+      agentroot.addEventListener(new WebSocketInitializerListener(initializerForAgentroot));
 
       ServletHolder rootServlet = root.addServlet(DefaultServlet.class, "/");
       rootServlet.setInitParameter("dirAllowed", "false");
@@ -423,8 +432,14 @@ public class AmbariServer {
       root.addFilter(new FilterHolder(new MethodOverrideFilter()), "/api/*", DISPATCHER_TYPES);
       root.addFilter(new FilterHolder(new ContentTypeOverrideFilter()), "/api/*", DISPATCHER_TYPES);
 
+      JettyWebSocketServletContainerInitializer initializerForRoot = new JettyWebSocketServletContainerInitializer((context, jettyContainer) -> {
+        jettyContainer.setMaxTextMessageSize(configs.getStompMaxIncomingMessageSize());
+        LOG.info("Configured WebSocket container max text message size: {}", configs.getStompMaxIncomingMessageSize());
+      });
+
       // register listener to capture request context
       root.addEventListener(new RequestContextListener());
+      root.addEventListener(new WebSocketInitializerListener(initializerForRoot));
       root.addFilter(new FilterHolder(springSecurityFilter), "/api/*", DISPATCHER_TYPES);
       root.addFilter(new FilterHolder(new UserNameOverrideFilter()), "/api/v1/users/*", DISPATCHER_TYPES);
 
@@ -623,15 +638,16 @@ public class AmbariServer {
 
       String srvrCrtPass = configsMap.get(Configuration.SRVR_CRT_PASS.getKey());
 
-
+      SecureRequestCustomizer src = new SecureRequestCustomizer();
+      src.setSniHostCheck(false);
+      src.setSniRequired(false);
       HttpConfiguration https_config = new HttpConfiguration();
-      https_config.addCustomizer(new SecureRequestCustomizer());
+      https_config.addCustomizer(src);
       https_config.setRequestHeaderSize(configs.getHttpRequestHeaderSize());
       https_config.setResponseHeaderSize(configs.getHttpResponseHeaderSize());
       https_config.setSendServerVersion(false);
 
       // Secured connector - default constructor sets trustAll = true for certs
-    //  SslContextFactory sslContextFactory = new SslContextFactory(); depricated
       SslContextFactory.Server sslContextFactory = new SslContextFactory.Server();
       disableInsecureProtocols(sslContextFactory);
       sslContextFactory.setKeyStorePath(keystore);
@@ -642,6 +658,8 @@ public class AmbariServer {
       sslContextFactory.setKeyStoreType(configsMap.get(Configuration.KSTR_TYPE.getKey()));
       sslContextFactory.setTrustStoreType(configsMap.get(Configuration.TSTR_TYPE.getKey()));
       sslContextFactory.setNeedClientAuth(needClientAuth);
+      sslContextFactory.setSniRequired(false);
+
       ServerConnector agentSslConnector = new ServerConnector(server, acceptors, -1,
         new SslConnectionFactory(sslContextFactory, HttpVersion.HTTP_1_1.toString()),
         new HttpConnectionFactory(https_config));
@@ -675,7 +693,10 @@ public class AmbariServer {
       String httpsCrtPass = configsMap.get(Configuration.CLIENT_API_SSL_CRT_PASS.getKey());
 
       HttpConfiguration https_config = new HttpConfiguration(http_config);
-      https_config.addCustomizer(new SecureRequestCustomizer());
+      SecureRequestCustomizer src = new SecureRequestCustomizer();
+      src.setSniRequired(false);
+      src.setSniHostCheck(false);
+      https_config.addCustomizer(src);
       https_config.setSecurePort(configs.getClientSSLApiPort());
 
       SslContextFactory.Server contextFactoryApi = new SslContextFactory.Server();
@@ -687,6 +708,7 @@ public class AmbariServer {
       contextFactoryApi.setTrustStorePassword(httpsCrtPass);
       contextFactoryApi.setKeyStoreType(configsMap.get(Configuration.CLIENT_API_SSL_KSTR_TYPE.getKey()));
       contextFactoryApi.setTrustStoreType(configsMap.get(Configuration.CLIENT_API_SSL_KSTR_TYPE.getKey()));
+      contextFactoryApi.setSniRequired(false);
       apiConnector = new ServerConnector(server, acceptors, -1,
         new SslConnectionFactory(contextFactoryApi, HttpVersion.HTTP_1_1.toString()),
         new HttpConnectionFactory(https_config));

--- a/ambari-server/src/main/java/org/apache/ambari/server/listeners/WebSocketInitializerListener.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/listeners/WebSocketInitializerListener.java
@@ -1,0 +1,65 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.ambari.server.listeners;
+
+import java.util.Collections;
+
+import jakarta.servlet.ServletContext;
+import jakarta.servlet.ServletContextEvent;
+import jakarta.servlet.ServletContextListener;
+
+import org.eclipse.jetty.websocket.server.JettyWebSocketServerContainer;
+import org.eclipse.jetty.websocket.server.config.JettyWebSocketServletContainerInitializer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class WebSocketInitializerListener implements ServletContextListener {
+    private static final Logger LOG = LoggerFactory.getLogger(WebSocketInitializerListener.class);
+    private final JettyWebSocketServletContainerInitializer initializer;
+
+    public WebSocketInitializerListener(JettyWebSocketServletContainerInitializer initializer) {
+        this.initializer = initializer;
+    }
+    @Override
+    public void contextInitialized(ServletContextEvent sce) {
+        ServletContext servletContext = sce.getServletContext();
+        try {
+            initializer.onStartup(Collections.emptySet(), servletContext);
+            LOG.info("WebSocket container initialized");
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    @Override
+    public void contextDestroyed(ServletContextEvent sce) {
+        ServletContext servletContext = sce.getServletContext();
+        try {
+            JettyWebSocketServerContainer container = (JettyWebSocketServerContainer) servletContext.getAttribute(JettyWebSocketServerContainer.class.getName());
+
+            if (container != null) {
+                container.stop();
+                LOG.info("WebSocket container stopped.");
+            } else {
+                LOG.info("No WebSocket container found during shutdown.");
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+}

--- a/ambari-server/src/main/java/org/apache/ambari/server/security/authentication/RequestBodyCachingFilter.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/security/authentication/RequestBodyCachingFilter.java
@@ -1,0 +1,87 @@
+package org.apache.ambari.server.security.authentication;
+
+import java.io.BufferedReader;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+
+import jakarta.servlet.Filter;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ReadListener;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletInputStream;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequestWrapper;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+public class RequestBodyCachingFilter implements Filter {
+    private static final Logger LOG = LoggerFactory.getLogger(RequestBodyCachingFilter.class);
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
+            throws IOException, ServletException {
+        if (request instanceof HttpServletRequest) {
+            HttpServletRequest httpRequest = (HttpServletRequest) request;
+            HttpServletRequestWrapper wrappedRequest = new CachedBodyHttpServletRequest(httpRequest);
+            chain.doFilter(wrappedRequest, response);
+        } else {
+            chain.doFilter(request, response);
+        }
+    }
+
+    private static class CachedBodyHttpServletRequest extends HttpServletRequestWrapper {
+
+        private byte[] cachedBody;
+
+        public CachedBodyHttpServletRequest(HttpServletRequest request) throws IOException {
+            super(request);
+            InputStream requestInputStream = request.getInputStream();
+            this.cachedBody = requestInputStream.readAllBytes();
+        }
+
+        @Override
+        public ServletInputStream getInputStream() throws IOException {
+            return new CachedBodyServletInputStream(this.cachedBody);
+        }
+
+        @Override
+        public BufferedReader getReader() throws IOException {
+            ByteArrayInputStream byteArrayInputStream = new ByteArrayInputStream(this.cachedBody);
+            return new BufferedReader(new InputStreamReader(byteArrayInputStream));
+        }
+    }
+
+    private static class CachedBodyServletInputStream extends ServletInputStream {
+
+        private final ByteArrayInputStream byteArrayInputStream;
+
+        public CachedBodyServletInputStream(byte[] cachedBody) {
+            this.byteArrayInputStream = new ByteArrayInputStream(cachedBody);
+        }
+
+        @Override
+        public boolean isFinished() {
+            return byteArrayInputStream.available() == 0;
+        }
+
+        @Override
+        public boolean isReady() {
+            return true;
+        }
+
+        @Override
+        public void setReadListener(ReadListener readListener) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public int read() throws IOException {
+            return byteArrayInputStream.read();
+        }
+    }
+}

--- a/ambari-server/src/main/java/org/apache/ambari/server/view/ViewClassLoader.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/view/ViewClassLoader.java
@@ -93,4 +93,26 @@ public class ViewClassLoader extends WebAppClassLoader {
     }
     return webAppContext;
   }
+
+  @Override
+  public Class<?> loadClass(String name) throws ClassNotFoundException {
+    System.out.println("Attempting to load class: " + name);
+    try {
+      // First, try to load the class using the current class loader
+      Class<?> loadedClass = super.loadClass(name);
+      System.out.println("Class loaded successfully: " + name + " by " + this);
+      return loadedClass;
+    } catch (ClassNotFoundException e) {
+      System.out.println("Class not found in current loader: " + name + ", delegating to parent.");
+      // If not found, delegate to the parent class loader
+      if (getParent() != null) {
+        Class<?> parentLoadedClass = getParent().loadClass(name);
+        System.out.println("Class loaded successfully by parent: " + name);
+        return parentLoadedClass;
+      } else {
+        System.out.println("Class not found: " + name + " in both current and parent class loaders.");
+        throw e;
+      }
+    }
+  }
 }

--- a/ambari-server/src/main/python/ambari_server/serverSetup.py
+++ b/ambari-server/src/main/python/ambari_server/serverSetup.py
@@ -535,7 +535,16 @@ class JDKSetup(object):
       properties.process_pair(AMBARI_JAVA_HOME_PROPERTY, args.ambari_java_home)
       properties.removeOldProp(JDK_NAME_PROPERTY)
       properties.removeOldProp(JCE_NAME_PROPERTY)
-      print("Setting AMBARI_JAVA_HOME for Ambari finished")
+
+      if not ambariOnly:
+        properties.process_pair(STACK_JAVA_HOME_PROPERTY, args.ambari_java_home)
+        properties.removeOldProp(STACK_JDK_NAME_PROPERTY)
+        properties.removeOldProp(STACK_JCE_NAME_PROPERTY)
+
+      self._ensure_java_home_env_var_is_set(args.ambari_java_home)
+      self.jdk_index = self.custom_jdk_number
+      print('Setting AMBARI_JAVA_HOME for Ambari finished')
+
 
     if args.java_home:
       # java_home was specified among the command-line arguments. Use it as custom JDK location.

--- a/ambari-server/src/main/python/ambari_server_main.py
+++ b/ambari-server/src/main/python/ambari_server_main.py
@@ -84,9 +84,8 @@ SUSPEND_START_MODE = False
 ambari_provider_module_option = ""
 ambari_provider_module = os.environ.get("AMBARI_PROVIDER_MODULE")
 if ambari_provider_module is not None:
-  ambari_provider_module_option = (
-    "-Dprovider.module.class=" + ambari_provider_module + " "
-  )
+  ambari_provider_module_option = "-Dprovider.module.class=" + \
+                                  ambari_provider_module + " "
 
 jvm_args = os.getenv("AMBARI_JVM_ARGS", "-Xms512m -Xmx2048m")
 ENV_FOREGROUND_KEY = "AMBARI_SERVER_RUN_IN_FOREGROUND"

--- a/ambari-server/src/main/resources/META-INF/persistence.xml
+++ b/ambari-server/src/main/resources/META-INF/persistence.xml
@@ -9,7 +9,7 @@
   License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS
   OF ANY KIND, either express or implied. See the License for the specific
   language governing permissions and limitations under the License. -->
-<persistence xmlns="http://java.sun.com/xml/ns/persistence" version="2.0">
+<persistence xmlns="https://jakarta.ee/xml/ns/persistence" version="3.0">
 
   <persistence-unit name="ambari-server" transaction-type="RESOURCE_LOCAL">
     <provider>org.eclipse.persistence.jpa.PersistenceProvider</provider>

--- a/ambari-server/src/main/resources/common-services/AMBARI_INFRA_SOLR/3.0.0/package/scripts/infra_solr.py
+++ b/ambari-server/src/main/resources/common-services/AMBARI_INFRA_SOLR/3.0.0/package/scripts/infra_solr.py
@@ -169,17 +169,17 @@ class InfraSolr(Script):
   def disable_security(self, env):
     import params
 
-    if not params.infra_solr_znode:
-      Logger.info("Skipping reverting ACL")
-      return
-    zkmigrator = ZkMigrator(
-      zk_host=params.zk_quorum,
-      java_exec=params.ambari_java_exec,
-      java_home=params.ambari_java_home,
-      jaas_file=params.infra_solr_jaas_file,
-      user=params.infra_solr_user,
-    )
-    zkmigrator.set_acls(params.infra_solr_znode, "world:anyone:crdwa")
+        if not params.infra_solr_znode:
+            Logger.info("Skipping reverting ACL")
+            return
+        zkmigrator = ZkMigrator(
+            zk_host=params.zk_quorum,
+            java_exec=params.ambari_java_home,
+            java_home=params.ambari_java_home,
+            jaas_file=params.infra_solr_jaas_file,
+            user=params.infra_solr_user,
+        )
+        zkmigrator.set_acls(params.infra_solr_znode, "world:anyone:crdwa")
 
   def backup(self, env):
     backup_collection(env)

--- a/ambari-server/src/main/resources/common-services/AMBARI_INFRA_SOLR/3.0.0/package/scripts/params.py
+++ b/ambari-server/src/main/resources/common-services/AMBARI_INFRA_SOLR/3.0.0/package/scripts/params.py
@@ -77,7 +77,7 @@ infra_solr_user_nproc_limit = default(
 # shared configs
 java_home = config["ambariLevelParams"]["java_home"]
 ambari_java_home = default("/ambariLevelParams/ambari_java_home", None)
-ambari_java_exec = f"{ambari_java_home}/bin/java"
+ambari_java_exec =  f"{ambari_java_home}/bin/java"
 java64_home = java_home
 java_exec = format("{java64_home}/bin/java")
 zookeeper_hosts_list = config["clusterHostInfo"]["zookeeper_server_hosts"]

--- a/ambari-server/src/main/resources/stacks/BIGTOP/3.2.0/properties/stack_features.json
+++ b/ambari-server/src/main/resources/stacks/BIGTOP/3.2.0/properties/stack_features.json
@@ -185,6 +185,11 @@
         "name": "ranger_kms_pid_support",
         "description": "Ranger KMS Service support pid generation",
         "min_version": "3.3.0"
+      },
+      {
+        "name": "secure_zookeeper",
+        "description": "Protect ZNodes with SASL acl in secure clusters",
+        "min_version": "3.2.0"
       }
     ]
   }

--- a/ambari-server/src/main/resources/stacks/BIGTOP/3.2.0/services/HDFS/package/scripts/params_linux.py
+++ b/ambari-server/src/main/resources/stacks/BIGTOP/3.2.0/services/HDFS/package/scripts/params_linux.py
@@ -550,6 +550,9 @@ java_home = config["ambariLevelParams"]["java_home"]
 java_version = expect("/ambariLevelParams/java_version", int)
 java_exec = format("{java_home}/bin/java")
 
+ambari_java_home = config['ambariLevelParams']['ambari_java_home']
+ambari_java_exec = format("{ambari_java_home}/bin/java")
+
 hadoop_heapsize = config["configurations"]["hadoop-env"]["hadoop_heapsize"]
 namenode_heapsize = config["configurations"]["hadoop-env"]["namenode_heapsize"]
 namenode_opt_newsize = config["configurations"]["hadoop-env"]["namenode_opt_newsize"]

--- a/ambari-server/src/main/resources/stacks/BIGTOP/3.2.0/services/HDFS/package/scripts/zkfc_slave.py
+++ b/ambari-server/src/main/resources/stacks/BIGTOP/3.2.0/services/HDFS/package/scripts/zkfc_slave.py
@@ -145,8 +145,8 @@ class ZkfcSlaveDefault(ZkfcSlave):
 
     zkmigrator = ZkMigrator(
       params.ha_zookeeper_quorum,
-      params.java_exec,
-      params.java_home,
+      params.ambari_java_exec,
+      params.ambari_java_home,
       params.jaas_file,
       params.hdfs_user,
     )

--- a/ambari-server/src/main/resources/stacks/BIGTOP/3.2.0/services/HIVE/package/scripts/hive_server.py
+++ b/ambari-server/src/main/resources/stacks/BIGTOP/3.2.0/services/HIVE/package/scripts/hive_server.py
@@ -106,8 +106,8 @@ class HiveServer(Script):
 
     zkmigrator = ZkMigrator(
       params.hive_zookeeper_quorum,
-      params.java_exec,
-      params.java64_home,
+      params.ambari_java_exec,
+      params.ambari_java_home,
       params.jaas_file,
       params.hive_user,
     )

--- a/ambari-server/src/main/resources/stacks/BIGTOP/3.2.0/services/SOLR/package/scripts/params.py
+++ b/ambari-server/src/main/resources/stacks/BIGTOP/3.2.0/services/SOLR/package/scripts/params.py
@@ -85,9 +85,12 @@ solr_user_nproc_limit = default(
 
 # shared configs
 java_home = config["ambariLevelParams"]["java_home"]
-ambari_java_home = default("/ambariLevelParams/ambari_java_home", None)
-java64_home = ambari_java_home if ambari_java_home is not None else java_home
+ambari_java_home = config['ambariLevelParams']['ambari_java_home']
+ambari_java_exec = format("{ambari_java_home}/bin/java")
+
+java64_home = java_home
 java_exec = format("{java64_home}/bin/java")
+
 zookeeper_hosts_list = config["clusterHostInfo"]["zookeeper_server_hosts"]
 zookeeper_hosts_list.sort()
 # get comma separated list of zookeeper hosts from clusterHostInfo

--- a/ambari-server/src/main/resources/stacks/BIGTOP/3.2.0/services/SOLR/package/scripts/solr.py
+++ b/ambari-server/src/main/resources/stacks/BIGTOP/3.2.0/services/SOLR/package/scripts/solr.py
@@ -166,8 +166,8 @@ class Solr(Script):
       return
     zkmigrator = ZkMigrator(
       zk_host=params.zk_quorum,
-      java_exec=params.java_exec,
-      java_home=params.java64_home,
+      java_exec=params.ambari_java_exec,
+      java_home=params.ambari_java_home,
       jaas_file=params.solr_jaas_file,
       user=params.solr_user,
     )

--- a/ambari-server/src/main/resources/stacks/BIGTOP/3.2.0/services/YARN/package/scripts/params_linux.py
+++ b/ambari-server/src/main/resources/stacks/BIGTOP/3.2.0/services/YARN/package/scripts/params_linux.py
@@ -282,6 +282,10 @@ rm_nodes_exclude_dir = os.path.dirname(rm_nodes_exclude_path)
 
 java64_home = config["ambariLevelParams"]["java_home"]
 java_exec = format("{java64_home}/bin/java")
+
+ambari_java_home = config['ambariLevelParams']['ambari_java_home']
+ambari_java_exec = format("{ambari_java_home}/bin/java")
+
 hadoop_ssl_enabled = default("/configurations/core-site/hadoop.ssl.enabled", False)
 java_version = expect("/ambariLevelParams/java_version", int)
 

--- a/ambari-server/src/main/resources/stacks/BIGTOP/3.2.0/services/YARN/package/scripts/resourcemanager.py
+++ b/ambari-server/src/main/resources/stacks/BIGTOP/3.2.0/services/YARN/package/scripts/resourcemanager.py
@@ -206,8 +206,8 @@ class ResourcemanagerDefault(Resourcemanager):
       return
     zkmigrator = ZkMigrator(
       params.rm_zk_address,
-      params.java_exec,
-      params.java64_home,
+      params.ambari_java_exec,
+      params.ambari_java_home,
       params.yarn_jaas_file,
       params.yarn_user,
     )

--- a/ambari-utility/pom.xml
+++ b/ambari-utility/pom.xml
@@ -47,6 +47,14 @@
       <scope>provided</scope>
       <exclusions>
         <exclusion>
+          <groupId>com.sun.jersey</groupId>
+          <artifactId>jersey-core</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.sun.jersey</groupId>
+          <artifactId>jersey-server</artifactId>
+        </exclusion>
+        <exclusion>
           <groupId>com.fasterxml.jackson.core</groupId>
           <artifactId>jackson-databind</artifactId>
         </exclusion>

--- a/ambari-views/examples/hello-spring-view/pom.xml
+++ b/ambari-views/examples/hello-spring-view/pom.xml
@@ -49,7 +49,7 @@
     <dependency>
       <groupId>com.sun.jersey</groupId>
       <artifactId>jersey-server</artifactId>
-      <version>1.8</version>
+      <version>${jersey.version}</version>
     </dependency>
     <dependency>
       <groupId>javax.servlet</groupId>

--- a/ambari-views/examples/helloworld-view/pom.xml
+++ b/ambari-views/examples/helloworld-view/pom.xml
@@ -49,7 +49,7 @@
     <dependency>
       <groupId>com.sun.jersey</groupId>
       <artifactId>jersey-server</artifactId>
-      <version>1.8</version>
+      <version>${jersey.version}</version>
     </dependency>
   </dependencies>
 

--- a/ambari-views/examples/phone-list-upgrade-view/pom.xml
+++ b/ambari-views/examples/phone-list-upgrade-view/pom.xml
@@ -54,7 +54,7 @@
     <dependency>
       <groupId>com.sun.jersey</groupId>
       <artifactId>jersey-server</artifactId>
-      <version>1.8</version>
+      <version>${jersey.version}</version>
     </dependency>
     <dependency>
       <groupId>javax.servlet</groupId>

--- a/ambari-views/examples/phone-list-view/pom.xml
+++ b/ambari-views/examples/phone-list-view/pom.xml
@@ -49,7 +49,7 @@
     <dependency>
       <groupId>com.sun.jersey</groupId>
       <artifactId>jersey-server</artifactId>
-      <version>1.8</version>
+      <version>${jersey.version}</version>
     </dependency>
     <dependency>
       <groupId>javax.servlet</groupId>

--- a/ambari-views/examples/property-validator-view/pom.xml
+++ b/ambari-views/examples/property-validator-view/pom.xml
@@ -37,7 +37,7 @@
     <dependency>
       <groupId>com.sun.jersey</groupId>
       <artifactId>jersey-server</artifactId>
-      <version>1.8</version>
+      <version>${jersey.version}</version>
     </dependency>
     <dependency>
       <groupId>javax.inject</groupId>

--- a/ambari-views/examples/property-view/pom.xml
+++ b/ambari-views/examples/property-view/pom.xml
@@ -37,7 +37,7 @@
     <dependency>
       <groupId>com.sun.jersey</groupId>
       <artifactId>jersey-server</artifactId>
-      <version>1.8</version>
+      <version>${jersey.version}</version>
     </dependency>
     <dependency>
       <groupId>javax.inject</groupId>

--- a/ambari-views/examples/restricted-view/pom.xml
+++ b/ambari-views/examples/restricted-view/pom.xml
@@ -49,7 +49,7 @@
     <dependency>
       <groupId>com.sun.jersey</groupId>
       <artifactId>jersey-server</artifactId>
-      <version>1.8</version>
+      <version>${jersey.version}</version>
     </dependency>
     <dependency>
       <groupId>javax.inject</groupId>

--- a/ambari-views/examples/simple-view/pom.xml
+++ b/ambari-views/examples/simple-view/pom.xml
@@ -37,7 +37,7 @@
     <dependency>
       <groupId>com.sun.jersey</groupId>
       <artifactId>jersey-server</artifactId>
-      <version>1.8</version>
+      <version>${jersey.version}</version>
     </dependency>
     <dependency>
       <groupId>javax.inject</groupId>

--- a/ambari-views/pom.xml
+++ b/ambari-views/pom.xml
@@ -32,11 +32,6 @@
     <dependencies>
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
-            <artifactId>jetty-jndi</artifactId>
-            <version>11.0.15</version>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-plus</artifactId>
             <version>11.0.15</version>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -96,7 +96,7 @@
     <distMgmtSnapshotsUrl>https://repository.apache.org/content/repositories/snapshots</distMgmtSnapshotsUrl>
     <assemblyPhase>package</assemblyPhase> <!-- use -DassemblyPhase=none to skip building tarball, useful when you want purely compile jar -->
     <rpm-maven-plugin.version>2.1.4</rpm-maven-plugin.version>
-    <eclipselink.version>2.7.14</eclipselink.version>
+    <eclipselink.version>4.0.2</eclipselink.version>
   </properties>
   <pluginRepositories>
     <pluginRepository>


### PR DESCRIPTION
## What changes were proposed in this pull request?
1. Fix issues caused by API changes in Spring Security after upgrading to 6.0.  
2. Fix issues caused by API changes in Jetty 11 WebSocket.  
3. Fix the "request body consumed by filter" error after upgrading Spring Security to 6.0.  
4. Fix JNDI version compatibility issues.
(Please fill in changes proposed in this fix)

## How was this patch tested?
manual test
(Please explain how this patch was tested. Ex: unit tests, manual tests)
(If this patch involves UI changes, please attach a screen-shot; otherwise, remove this)

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.