### PR TITLE
AMBARI-26319: Fix rpm build failed problem

### DIFF
--- a/ambari-server/pom.xml
+++ b/ambari-server/pom.xml
@@ -530,6 +530,7 @@
           <description>Maven Recipe: RPM Package.</description>
           <defineStatements>
              <defineStatement>__python 3</defineStatement>
+             <defineStatement>__brp_mangle_shebangs %{nil}</defineStatement>
           </defineStatements>
           <autoRequires>no</autoRequires>
           <prefix>/</prefix>


### PR DESCRIPTION
## What changes were proposed in this pull request?

(Please fill in changes proposed in this fix)

## How was this patch tested?
build command
```shell
export JAVA_HOME=/usr/lib/jvm/java-17-openjdk
export PATH=$JAVA_HOME/bin:$PATH
```

```java
mvn -B clean install package rpm:rpm  -Drat.skip=true -DskipTests -Dmaven.test.skip=true -Dfindbugs.skip=true  -Dcheckstyle.skip=true
```
manual test
before this patch
![image](https://github.com/user-attachments/assets/9ce96624-46f0-4be2-b546-98865d3f5517)

after apply this patch
![image](https://github.com/user-attachments/assets/e9d1ce1b-81c0-46a7-8812-f9f597bfb92d)

(Please explain how this patch was tested. Ex: unit tests, manual tests)
(If this patch involves UI changes, please attach a screen-shot; otherwise, remove this)

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.