### PR TITLE
AMBARI-26320: Fix jersey conflict error when ambari server start

### DIFF
--- a/ambari-agent/pom.xml
+++ b/ambari-agent/pom.xml
@@ -109,6 +109,18 @@
       <version>2.7.3</version>
       <exclusions>
         <exclusion>
+          <groupId>com.sun.jersey</groupId>
+          <artifactId>jersey-core</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.sun.jersey</groupId>
+          <artifactId>jersey-servlet</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.sun.jersey</groupId>
+          <artifactId>jersey-server</artifactId>
+        </exclusion>
+        <exclusion>
             <groupId>com.jcraft</groupId>
             <artifactId>jsch</artifactId>
         </exclusion>

--- a/ambari-server/pom.xml
+++ b/ambari-server/pom.xml
@@ -1444,6 +1444,7 @@
     <dependency>
       <groupId>org.glassfish.jersey.core</groupId>
       <artifactId>jersey-server</artifactId>
+      <version>${jersey.version}</version>
     </dependency>
     <dependency>
       <groupId>org.glassfish.jersey.media</groupId>
@@ -1503,6 +1504,14 @@
         <exclusion>
           <groupId>org.yaml</groupId>
           <artifactId>snakeyaml</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.sun.jersey</groupId>
+          <artifactId>jersey-core</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.sun.jersey</groupId>
+          <artifactId>jersey-server</artifactId>
         </exclusion>
       </exclusions>
     </dependency>
@@ -1623,7 +1632,7 @@
     <dependency>
       <groupId>cglib</groupId>
       <artifactId>cglib</artifactId>
-      <version>3.2.4</version>
+      <version>3.3.0</version>
     </dependency>
     <dependency>
       <groupId>com.google.code.gson</groupId>
@@ -1805,6 +1814,30 @@
         <exclusion>
           <groupId>org.apache.commons</groupId>
           <artifactId>commons-collections4</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.sun.jersey</groupId>
+          <artifactId>jersey-core</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.sun.jersey</groupId>
+          <artifactId>jersey-servlet</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.sun.jersey</groupId>
+          <artifactId>jersey-server</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>javax.servlet</groupId>
+          <artifactId>javax.servlet-api</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>javax.servlet.jsp</groupId>
+          <artifactId>jsp-api</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>commons-collections</groupId>
+          <artifactId>commons-collections</artifactId>
         </exclusion>
         <exclusion>
           <groupId>commons-beanutils</groupId>

--- a/ambari-utility/pom.xml
+++ b/ambari-utility/pom.xml
@@ -42,6 +42,14 @@
       <scope>provided</scope>
       <exclusions>
         <exclusion>
+          <groupId>com.sun.jersey</groupId>
+          <artifactId>jersey-core</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.sun.jersey</groupId>
+          <artifactId>jersey-server</artifactId>
+        </exclusion>
+        <exclusion>
           <groupId>com.fasterxml.jackson.core</groupId>
           <artifactId>jackson-databind</artifactId>
         </exclusion>

--- a/ambari-views/examples/hello-spring-view/pom.xml
+++ b/ambari-views/examples/hello-spring-view/pom.xml
@@ -49,7 +49,7 @@
     <dependency>
       <groupId>com.sun.jersey</groupId>
       <artifactId>jersey-server</artifactId>
-      <version>1.8</version>
+      <version>${jersey.version}</version>
     </dependency>
     <dependency>
       <groupId>javax.servlet</groupId>

--- a/ambari-views/examples/helloworld-view/pom.xml
+++ b/ambari-views/examples/helloworld-view/pom.xml
@@ -49,7 +49,7 @@
     <dependency>
       <groupId>com.sun.jersey</groupId>
       <artifactId>jersey-server</artifactId>
-      <version>1.8</version>
+      <version>${jersey.version}</version>
     </dependency>
   </dependencies>
 

--- a/ambari-views/examples/phone-list-upgrade-view/pom.xml
+++ b/ambari-views/examples/phone-list-upgrade-view/pom.xml
@@ -54,7 +54,7 @@
     <dependency>
       <groupId>com.sun.jersey</groupId>
       <artifactId>jersey-server</artifactId>
-      <version>1.8</version>
+      <version>${jersey.version}</version>
     </dependency>
     <dependency>
       <groupId>javax.servlet</groupId>

--- a/ambari-views/examples/phone-list-view/pom.xml
+++ b/ambari-views/examples/phone-list-view/pom.xml
@@ -49,7 +49,7 @@
     <dependency>
       <groupId>com.sun.jersey</groupId>
       <artifactId>jersey-server</artifactId>
-      <version>1.8</version>
+      <version>${jersey.version}</version>
     </dependency>
     <dependency>
       <groupId>javax.servlet</groupId>

--- a/ambari-views/examples/property-validator-view/pom.xml
+++ b/ambari-views/examples/property-validator-view/pom.xml
@@ -37,7 +37,7 @@
     <dependency>
       <groupId>com.sun.jersey</groupId>
       <artifactId>jersey-server</artifactId>
-      <version>1.8</version>
+      <version>${jersey.version}</version>
     </dependency>
     <dependency>
       <groupId>javax.inject</groupId>

--- a/ambari-views/examples/property-view/pom.xml
+++ b/ambari-views/examples/property-view/pom.xml
@@ -37,7 +37,7 @@
     <dependency>
       <groupId>com.sun.jersey</groupId>
       <artifactId>jersey-server</artifactId>
-      <version>1.8</version>
+      <version>${jersey.version}</version>
     </dependency>
     <dependency>
       <groupId>javax.inject</groupId>

--- a/ambari-views/examples/restricted-view/pom.xml
+++ b/ambari-views/examples/restricted-view/pom.xml
@@ -49,7 +49,7 @@
     <dependency>
       <groupId>com.sun.jersey</groupId>
       <artifactId>jersey-server</artifactId>
-      <version>1.8</version>
+      <version>${jersey.version}</version>
     </dependency>
     <dependency>
       <groupId>javax.inject</groupId>

--- a/ambari-views/examples/simple-view/pom.xml
+++ b/ambari-views/examples/simple-view/pom.xml
@@ -37,7 +37,7 @@
     <dependency>
       <groupId>com.sun.jersey</groupId>
       <artifactId>jersey-server</artifactId>
-      <version>1.8</version>
+      <version>${jersey.version}</version>
     </dependency>
     <dependency>
       <groupId>javax.inject</groupId>


### PR DESCRIPTION
## What changes were proposed in this pull request?
Make jersey 1.x exclude.
(Please fill in changes proposed in this fix)

## How was this patch tested?
manual test
before apply
![image](https://github.com/user-attachments/assets/2012943d-fecd-4fe7-9cee-b1245520933d)
![image](https://github.com/user-attachments/assets/610f2acf-63ec-4ab7-bb6e-f02470ab8ded)

after apply
![image](https://github.com/user-attachments/assets/7ab9384d-b603-4d70-9072-8950d7b9ec97)

(Please explain how this patch was tested. Ex: unit tests, manual tests)
(If this patch involves UI changes, please attach a screen-shot; otherwise, remove this)

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.