### PR TITLE
AMBARI-26326: Fix Hive installation failures due to missing dependenc…

### DIFF
--- a/ambari-agent/pom.xml
+++ b/ambari-agent/pom.xml
@@ -58,6 +58,7 @@
     <commons-cli.version>1.5.0</commons-cli.version>
     <commons-collections.version>3.2.2</commons-collections.version>
     <commons-configuration2.version>2.8.0</commons-configuration2.version>
+    <commons-lang.version>2.6</commons-lang.version>
     <commons-lang3.version>3.12.0</commons-lang3.version>
     <commons-io.version>2.8.0</commons-io.version>
     <commons-logging.version>1.1.3</commons-logging.version>
@@ -105,6 +106,11 @@
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
       <version>${commons-lang3.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>commons-lang</groupId>
+      <artifactId>commons-lang</artifactId>
+      <version>${commons-lang.version}</version>
     </dependency>
     <dependency>
       <groupId>commons-io</groupId>

--- a/ambari-agent/src/packages/tarball/all.xml
+++ b/ambari-agent/src/packages/tarball/all.xml
@@ -244,6 +244,7 @@
         <include>org.apache.commons:commons-configuration2</include>
         <include>org.apache.commons:commons-compress</include>
         <include>commons-io:commons-io</include>
+        <include>commons-lang:commons-lang</include>
         <include>org.apache.commons:commons-lang3</include>
         <include>commons-logging:commons-logging</include>
         <include>com.google.guava:guava</include>

--- a/ambari-server/src/main/resources/stacks/BIGTOP/3.2.0/services/HIVE/package/scripts/params.py
+++ b/ambari-server/src/main/resources/stacks/BIGTOP/3.2.0/services/HIVE/package/scripts/params.py
@@ -163,6 +163,10 @@ hive_lib_dir = format("{hive_home}/lib")
 hive_server2_hive_dir = None
 hive_server2_hive_lib = None
 
+java64_home = config["ambariLevelParams"]["java_home"]
+ambari_java_home = config["ambariLevelParams"]["ambari_java_home"]
+ambari_java_exec = format("{ambari_java_home}/bin/java")
+java_version = expect("/ambariLevelParams/java_version", int)
 
 # Heap dump related
 heap_dump_enabled = default("/configurations/hive-env/enable_heap_dump", None)
@@ -232,7 +236,7 @@ if credential_store_enabled:
     ]
     hive_metastore_user_passwd = PasswordString(
       get_password_from_credential_store(
-        alias, provider_path, cs_lib_path, java_home, jdk_location
+        alias, provider_path, cs_lib_path, ambari_java_home, jdk_location
       )
     )
   else:
@@ -498,10 +502,7 @@ hive_metastore_heapsize = config["configurations"]["hive-env"][
   "hive.metastore.heapsize"
 ]
 
-java64_home = config["ambariLevelParams"]["java_home"]
-ambari_java_home = config["ambariLevelParams"]["ambari_java_home"]
-ambari_java_exec = format("{ambari_java_home}/bin/java")
-java_version = expect("/ambariLevelParams/java_version", int)
+
 
 ##### MYSQL
 db_name = config["configurations"]["hive-env"]["hive_database_name"]


### PR DESCRIPTION
…ies and Java version compatibility issues

## What changes were proposed in this pull request?

When installing Hive through Ambari, the following errors occur:
 
1. Missing dependency error:
```
Exception in thread "main" java.lang.NoClassDefFoundError: org/apache/commons/lang/StringUtils
at org.apache.ambari.server.credentialapi.CredentialUtil.getNormalizedPath(CredentialUtil.java:241)
at org.apache.ambari.server.credentialapi.CredentialUtil.run(CredentialUtil.java:166)
at org.apache.hadoop.util.ToolRunner.run(ToolRunner.java:81)
at org.apache.ambari.server.credentialapi.CredentialUtil.main(CredentialUtil.java:104)
Caused by: java.lang.ClassNotFoundException: org.apache.commons.lang.StringUtils
```
 
2. Java version compatibility issue:
The CredentialUtil class is compiled with Java 17, but the params.py script is using Java 8 paths, causing execution failures during credential retrieval.
 

Impact
These issues prevent successful installation of Hive service, blocking cluster deployment and service configuration.
 
Root Cause
1. The commons-lang dependency is missing from the ambari-agent package, which is required by CredentialUtil.
2. There's a Java version mismatch - CredentialUtil is compiled with Java 17 but the credential retrieval process is trying to use Java 8.
 
Priority
High - This is a blocker for Hive service installation.

## How was this patch tested?
manual test
<img width="1371" alt="image" src="https://github.com/user-attachments/assets/e5326049-9449-4f16-a3ff-0e87934c1711" />

(Please explain how this patch was tested. Ex: unit tests, manual tests)
(If this patch involves UI changes, please attach a screen-shot; otherwise, remove this)

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.