### PR TITLE
AMBARI-26337: Fix Ambari Metrics java home and JVM options

### DIFF
--- a/ambari-server/src/main/resources/common-services/AMBARI_METRICS/3.0.0/configuration/ams-env.xml
+++ b/ambari-server/src/main/resources/common-services/AMBARI_METRICS/3.0.0/configuration/ams-env.xml
@@ -161,7 +161,7 @@
 export AMS_INSTANCE_NAME={{hostname}}
 
 # The java implementation to use. Java 1.6 required.
-export JAVA_HOME={{java64_home}}
+export JAVA_HOME={{java_home}}
 
 # Collector Log directory for log4j
 export AMS_COLLECTOR_LOG_DIR={{ams_collector_log_dir}}
@@ -185,13 +185,13 @@ export AMS_COLLECTOR_HEAPSIZE={{metrics_collector_heapsize}}
 export AMS_HBASE_INIT_CHECK_ENABLED={{ams_hbase_init_check_enabled}}
 
 # AMS Collector options
-export AMS_COLLECTOR_OPTS="-Djava.library.path=/usr/lib/ams-hbase/lib/hadoop-native --add-opens java.base/java.lang=ALL-UNNAMED"
+export AMS_COLLECTOR_OPTS="-Djava.library.path=/usr/lib/ams-hbase/lib/hadoop-native"
 {% if security_enabled %}
 export AMS_COLLECTOR_OPTS="$AMS_COLLECTOR_OPTS -Dzookeeper.sasl.client.username={{zk_principal_user}} -Djava.security.auth.login.config={{ams_collector_jaas_config_file}}"
 {% endif %}
 
 # AMS Collector GC options
-export AMS_COLLECTOR_GC_OPTS=" -verbose:gc -XX:+PrintGCDetails  -Xloggc:{{ams_collector_log_dir}}/collector-gc.log-`date +'%Y%m%d%H%M'`"
+export AMS_COLLECTOR_GC_OPTS="-XX:+UseConcMarkSweepGC -verbose:gc -XX:+PrintGCDetails -XX:+PrintGCDateStamps -Xloggc:{{ams_collector_log_dir}}/collector-gc.log-`date +'%Y%m%d%H%M'`"
 export AMS_COLLECTOR_OPTS="$AMS_COLLECTOR_OPTS $AMS_COLLECTOR_GC_OPTS"
 
 # Metrics collector host will be blacklisted for specified number of seconds if metric monitor failed to connect to it.


### PR DESCRIPTION
## What changes were proposed in this pull request?


"After Ambari Metrics was reverted due to incompatibility with JDK 17, JDK 1.8 should be used here during startup as well."


## How was this patch tested?
manual test 
![image](https://github.com/user-attachments/assets/c9b59b92-2ac7-4bdb-ae10-1cb3eeba11f4)


(Please explain how this patch was tested. Ex: unit tests, manual tests)
(If this patch involves UI changes, please attach a screen-shot; otherwise, remove this)

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.