### PR TITLE
AMBARI-26341: Fix Batch restart not worked

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/scheduler/ExecutionScheduleManager.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/scheduler/ExecutionScheduleManager.java
@@ -905,8 +905,7 @@ public class ExecutionScheduleManager {
   }*/
 
   protected BatchRequestResponse performApiGetRequest(String relativeUri, boolean queryAllFields) {
-    Client client = ClientBuilder.newClient();
-    WebTarget target = client.target(relativeUri);
+    WebTarget target = extendApiResource(ambariWebResource, relativeUri);
     if (queryAllFields) {
       target = target.queryParam("fields", "*");
     }
@@ -914,14 +913,14 @@ public class ExecutionScheduleManager {
     try {
       response = target.request().get();
     } catch (Exception e) {
+      LOG.error("Exception occurred during API request to {}: {}", relativeUri, e.getMessage(), e);
       response = null;
     }
     return convertToBatchRequestResponse(response);
   }
 
   protected BatchRequestResponse performApiRequest(String relativeUri, String body, String method, Integer userId) {
-    Client client = ClientBuilder.newClient();
-    WebTarget target = client.target(relativeUri);
+    WebTarget target = extendApiResource(ambariWebResource, relativeUri);
     Response response;
     try {
       Invocation.Builder invocationBuilder = target.request().header(USER_ID_HEADER, userId);
@@ -937,6 +936,7 @@ public class ExecutionScheduleManager {
         throw new IllegalArgumentException("Invalid HTTP method: " + method);
       }
     } catch (Exception e) {
+      LOG.error("Exception occurred during API request to {}: {}", relativeUri, e.getMessage(), e);
       response = null;
     }
     return convertToBatchRequestResponse(response);


### PR DESCRIPTION
## What changes were proposed in this pull request?

This occurs because Jersey Client in Java 17 enforces stricter URI validation, requiring absolute URIs for requests.

## Testing
- Verified batch operations work correctly with Java 17
![image](https://github.com/user-attachments/assets/35d85822-1049-48f9-9792-662c8b565028)



## Notes
This is a minimal change approach that leverages existing infrastructure rather than introducing new patterns or dependencies.

## How was this patch tested?

(Please explain how this patch was tested. Ex: unit tests, manual tests)
(If this patch involves UI changes, please attach a screen-shot; otherwise, remove this)

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.