### PR TITLE
AMBARI-26357: Errors occur when compiling ambari after upgrading jetty

### DIFF
--- a/ambari-admin/pom.xml
+++ b/ambari-admin/pom.xml
@@ -23,7 +23,6 @@
     <relativePath>../ambari-project</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>
-  <groupId>org.apache.ambari</groupId>
   <artifactId>ambari-admin</artifactId>
   <packaging>jar</packaging>
   <name>Ambari Admin View</name>

--- a/ambari-agent/pom.xml
+++ b/ambari-agent/pom.xml
@@ -23,7 +23,6 @@
     <relativePath>../ambari-project</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>
-  <groupId>org.apache.ambari</groupId>
   <artifactId>ambari-agent</artifactId>
   <name>Ambari Agent</name>
   <description>Ambari Agent</description>

--- a/ambari-funtest/pom.xml
+++ b/ambari-funtest/pom.xml
@@ -16,7 +16,6 @@
     <version>${revision}</version>
     <relativePath>../ambari-project</relativePath>
   </parent>
-  <groupId>org.apache.ambari</groupId>
   <artifactId>ambari-funtest</artifactId>
   <packaging>jar</packaging>
   <name>Ambari Functional Tests</name>

--- a/ambari-project/pom.xml
+++ b/ambari-project/pom.xml
@@ -20,7 +20,6 @@
     <artifactId>ambari</artifactId>
     <version>${revision}</version>
   </parent>
-  <groupId>org.apache.ambari</groupId>
   <artifactId>ambari-project</artifactId>
   <description>Apache Ambari Project POM</description>
   <name>Apache Ambari Project POM</name>

--- a/ambari-server-spi/pom.xml
+++ b/ambari-server-spi/pom.xml
@@ -21,7 +21,6 @@
     <version>${revision}</version>
     <relativePath>../ambari-project</relativePath>
   </parent>
-  
   <artifactId>ambari-server-spi</artifactId>
   <url>http://ambari.apache.org</url>
   <name>Ambari Server SPI</name>

--- a/ambari-server/pom.xml
+++ b/ambari-server/pom.xml
@@ -16,7 +16,6 @@
     <relativePath>../ambari-project</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>
-  <groupId>org.apache.ambari</groupId>
   <artifactId>ambari-server</artifactId>
   <packaging>jar</packaging>
   <name>Ambari Server</name>
@@ -1479,11 +1478,6 @@
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
       <version>${fasterxml.jackson.databind.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>com.fasterxml.jackson.core</groupId>
-      <artifactId>jackson-core</artifactId>
-      <version>${fasterxml.jackson.version}</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.jaxrs</groupId>

--- a/ambari-server/src/test/java/org/apache/ambari/server/audit/request/DefaultEventCreatorTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/audit/request/DefaultEventCreatorTest.java
@@ -32,6 +32,7 @@ import java.util.Map;
 import jakarta.servlet.AsyncContext;
 import jakarta.servlet.DispatcherType;
 import jakarta.servlet.RequestDispatcher;
+import jakarta.servlet.ServletConnection;
 import jakarta.servlet.ServletContext;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.ServletInputStream;
@@ -251,11 +252,6 @@ public class DefaultEventCreatorTest {
       }
 
       @Override
-      public boolean isRequestedSessionIdFromUrl() {
-        return false;
-      }
-
-      @Override
       public boolean authenticate(HttpServletResponse httpServletResponse) throws IOException, ServletException {
         return false;
       }
@@ -409,11 +405,6 @@ public class DefaultEventCreatorTest {
       }
 
       @Override
-      public String getRealPath(String s) {
-        return null;
-      }
-
-      @Override
       public int getRemotePort() {
         return 0;
       }
@@ -465,6 +456,21 @@ public class DefaultEventCreatorTest {
 
       @Override
       public DispatcherType getDispatcherType() {
+        return null;
+      }
+
+      @Override
+      public String getRequestId() {
+        return "";
+      }
+
+      @Override
+      public String getProtocolRequestId() {
+        return "";
+      }
+
+      @Override
+      public ServletConnection getServletConnection() {
         return null;
       }
     }));

--- a/ambari-server/src/test/java/org/apache/ambari/server/controller/AmbariServerTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/controller/AmbariServerTest.java
@@ -40,7 +40,6 @@ import java.util.EnumSet;
 
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.TypedQuery;
-import jakarta.servlet.DispatcherType;
 import jakarta.servlet.SessionCookieConfig;
 
 import org.apache.ambari.server.AmbariException;
@@ -164,8 +163,6 @@ public class AmbariServerTest {
 
     handler.setMaxFormContentSize(-1);
     EasyMock.expectLastCall().once();
-    EasyMock.expect(handler.addFilter(GzipFilter.class, "/*",
-        EnumSet.of(DispatcherType.REQUEST))).andReturn(filter).once();
     EasyMock.expect(handler.getMimeTypes()).andReturn(new MimeTypes()).anyTimes();
     replay(handler, filter);
 
@@ -180,8 +177,6 @@ public class AmbariServerTest {
         EasyMock.createNiceMock(ServletContextHandler.class);
     final FilterHolder filter = EasyMock.createNiceMock(FilterHolder.class);
 
-    EasyMock.expect(handler.addFilter(GzipFilter.class, "/*",
-        EnumSet.of(DispatcherType.REQUEST))).andReturn(filter).once();
     filter.setInitParameter(anyObject(String.class),anyObject(String.class));
     EasyMock.expectLastCall().times(3);
     replay(handler, filter);

--- a/ambari-serviceadvisor/pom.xml
+++ b/ambari-serviceadvisor/pom.xml
@@ -30,8 +30,6 @@
     <version>${revision}</version>
     <relativePath>../ambari-project</relativePath>
   </parent>
-
-  <groupId>org.apache.ambari</groupId>
   <artifactId>ambari-serviceadvisor</artifactId>
   <name>Ambari Service Advisor</name>
   <description>Service Advisor</description>

--- a/ambari-utility/pom.xml
+++ b/ambari-utility/pom.xml
@@ -26,9 +26,7 @@
     <version>${revision}</version>
     <relativePath>../ambari-project</relativePath>
   </parent>
-
   <artifactId>ambari-utility</artifactId>
-  <groupId>org.apache.ambari</groupId>
 
   <dependencies>
     <dependency>
@@ -148,12 +146,6 @@
           <artifactId>commons-beanutils</artifactId>
         </exclusion>
       </exclusions>
-    </dependency>
-    <dependency>
-      <groupId>jakarta.ws.rs</groupId>
-      <artifactId>jakarta.ws.rs-api</artifactId>
-      <version>3.1.0</version>
-      <scope>compile</scope>
     </dependency>
   </dependencies>
 

--- a/ambari-views/pom.xml
+++ b/ambari-views/pom.xml
@@ -24,7 +24,6 @@
         <relativePath>../ambari-project</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
-    <groupId>org.apache.ambari</groupId>
     <artifactId>ambari-views</artifactId>
     <packaging>jar</packaging>
     <name>Ambari Views</name>


### PR DESCRIPTION
## What changes were proposed in this pull request?
Details see: [AMBARI-26357](https://issues.apache.org/jira/browse/AMBARI-26357)

## How was this patch tested?

The following command can be successfully executed.
```shell
mvn clean install rpm:rpm -DskipTests -Drat.skip=true  -DbuildNumber=5895e4ed6b30a2da8a90fee2403b6cab91d19972
## Or
mvn -am test -pl ambari-server -DskipPythonTests -Dmaven.test.failure.ignore -Dmaven.artifact.threads=10 -Drat.skip -DskipAdminWebTests=true -Dtest=org.apache.ambari.server.controller.AmbariServerTest -Dsurefire.failIfNoSpecifiedTests=false
```




Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.