### PR TITLE
AMBARI-26252: Service autostart checkbox display issue

### DIFF
--- a/ambari-web/vendor/scripts/ember-latest.js
+++ b/ambari-web/vendor/scripts/ember-latest.js
@@ -19927,6 +19927,7 @@ Ember.Checkbox = Ember.View.extend({
   init: function() {
     this._super();
     this.on("change", this, this._updateElementValue);
+    this.addObserver('checked', this, 'checkedChanged');
   },
 
   /**
@@ -19934,6 +19935,15 @@ Ember.Checkbox = Ember.View.extend({
   */
   _updateElementValue: function() {
     set(this, 'checked', this.$().prop('checked'));
+  },
+
+  checkedChanged: function() {
+    var newCheckValue = this.get('checked');
+    Ember.run.next(() => {
+      if (this.$().prop('checked') !== newCheckValue) {
+        this.$().prop('checked', newCheckValue)
+      }
+    });
   }
 });
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Similar to AMBARI-26192(#3959), because there isn’t enough spare time, this is a temporary fix. Looking forward to a better solution in the future, or perhaps [refactoring with React](https://issues.apache.org/jira/browse/AMBARI-26164) could completely avoid this issue.

The problem can be described as a styling issue: when a background color is applied to the table, the white check icon becomes misaligned.

<img width="1246" alt="image-20250324104536251" src="https://github.com/user-attachments/assets/4421d337-cd1b-48af-9e97-0c2bfc55ceb1" />

Digging deeper, it turns out that the hidden checkbox isn’t responding to events as expected:

https://github.com/user-attachments/assets/91adacde-b0d1-4b20-a6fa-4b36fe8b535d

As long as the hidden checkbox’s state is correctly set, the styling will behave as intended. As for why it’s out of sync, here’s my [guess](https://lists.apache.org/thread/h9ljfx4mfpy5wj3p9ns7xnh98g8bgl46). My temporary solution is to manually update this state in the next event loop whenever the checked attribute changes.

## How was this patch tested?

Manual test.