### PR TITLE
AMBARI-26426: Hosts failed to delete message is missing

### DIFF
--- a/ambari-web/app/controllers/main/host/bulk_operations_controller.js
+++ b/ambari-web/app/controllers/main/host/bulk_operations_controller.js
@@ -438,7 +438,7 @@ App.BulkOperationsController = Em.Controller.extend({
 
       bodyClass: Em.View.extend({
         templateName: require('templates/main/host/delete_hosts_result_popup'),
-        message: Em.I18n.t('hosts.bulkOperation.deleteHosts.dryRun.message').format(undeletableHosts.length),
+        message: Em.I18n.t('hosts.bulkOperation.deleteHosts.result.cannot.delete').format(undeletableHosts.length),
         undeletableHosts: undeletableHosts,
         deletedHosts: deletedHosts,
         onToggleHost: function (host) {
@@ -778,7 +778,7 @@ App.BulkOperationsController = Em.Controller.extend({
 
       bodyClass: Em.View.extend({
         templateName: require('templates/main/host/delete_hosts_result_popup'),
-        message: Em.I18n.t('hosts.bulkOperation.delete.component.dryRun.message').format(componentName),
+        message: Em.I18n.t('hosts.bulkOperation.delete.component.result.cannot.delete').format(componentName),
         componentName: componentName,
         undeletableHosts: undeletableHosts,
         deletedHosts: deletedHosts,

--- a/ambari-web/app/messages.js
+++ b/ambari-web/app/messages.js
@@ -2781,6 +2781,7 @@ Em.I18n.translations = {
   'hosts.bulkOperation.deleteHosts.confirmation.body.msg3': 'please make sure the Ambari Agent process is completely stopped on these hosts before proceeding.',
   'hosts.bulkOperation.deleteHosts.result.header':'Delete Hosts',
   'hosts.bulkOperation.deleteHosts.result.body': 'The following hosts were successfully deleted:',
+  'hosts.bulkOperation.deleteHosts.result.cannot.delete':'The following {0} hosts could not be deleted (expand for reason):',
   'hosts.bulkOperation.confirmation.delete.component.cannot1': 'The following hosts will be skipped (expand for reason):',
   'hosts.bulkOperation.confirmation.delete.component.cannot2': '{0} cannot be deleted from the selected hosts:',
   'hosts.bulkOperation.confirmation.delete.component': '{0} will be deleted from the following hosts',
@@ -2792,7 +2793,7 @@ Em.I18n.translations = {
   'hosts.bulkOperation.confirmation.delete.component.notStopped': '{0} not Stopped',
   'hosts.bulkOperation.confirmation.delete.component.notInstalled': '{0} not Installed',
   'hosts.bulkOperation.delete.component.result.body': ' was successfully removed from the following hosts:',
-  'hosts.bulkOperation.delete.component.dryRun.message':'{0} could not be deleted from the following hosts(expand for reason)',
+  'hosts.bulkOperation.delete.component.result.cannot.delete':'{0} could not be deleted from the following hosts(expand for reason)',
   'hosts.bulkOperation.delete.component.failed.header': 'Delete Component failed',
   'hosts.bulkOperation.delete.component.failed.body': 'Delete {0} component from {1} host failed',
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

The key is used [here](https://github.com/apache/ambari/blob/55c2ba1ac8fa88ebef74109a7033648190237768/ambari-web/app/controllers/main/host/bulk_operations_controller.js#L441), but corresponding string value is not provided by the messages.js.

## How was this patch tested?

(Please explain how this patch was tested. Ex: unit tests, manual tests)
(If this patch involves UI changes, please attach a screen-shot; otherwise, remove this)

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.