### PR TITLE
AMBARI-26427: Handling Translation for Ranger TagSync Component

### DIFF
--- a/ambari-web/app/templates/main/service/services/ranger.hbs
+++ b/ambari-web/app/templates/main/service/services/ranger.hbs
@@ -40,7 +40,7 @@
             {{/if}}
           </div>
           <div class="summary-label">
-            <a href="#" {{action filterHosts view.rangerTagsyncComponent}}>{{t dashboard.services.ranger.rangerTagsync}}</a>
+            <a href="#" {{action filterHosts view.rangerTagsyncComponent}}>{{t dashboard.services.ranger.rangerTagsyncs}}</a>
           </div>
         </div>
       {{/if}}


### PR DESCRIPTION
## What changes were proposed in this pull request?

Proposing the  fix for a typo for ranger tagsyncs.
## How was this patch tested?

With the fix, built the packaging and reinstalled the ranger service on a lab cluster, and tested it, shown as expected. Results were added 

Before the fix:
<img width="910" alt="Before-the-fix" src="https://github.com/user-attachments/assets/5d008939-5397-47c6-9f39-88055ed71779" />

After the fix, tagsyncs shown correctly
refernce screeshot.
<img width="687" alt="Screenshot 2025-04-02 at 08 52 22" src="https://github.com/user-attachments/assets/cd6f4848-5528-4c03-a614-1886b6ca10e2" />
