### PR TITLE
AMBARI-26428: Fix Ambari Server Startup Failure with Jetty SSL and Multiple SAN Entries

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/AmbariServer.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/AmbariServer.java
@@ -631,7 +631,7 @@ public class AmbariServer {
       https_config.setSendServerVersion(false);
 
       // Secured connector - default constructor sets trustAll = true for certs
-      SslContextFactory sslContextFactory = new SslContextFactory();
+      SslContextFactory sslContextFactory = new SslContextFactory.Server();
       disableInsecureProtocols(sslContextFactory);
       sslContextFactory.setKeyStorePath(keystore);
       sslContextFactory.setTrustStorePath(truststore);
@@ -677,7 +677,7 @@ public class AmbariServer {
       https_config.addCustomizer(new SecureRequestCustomizer());
       https_config.setSecurePort(configs.getClientSSLApiPort());
 
-      SslContextFactory contextFactoryApi = new SslContextFactory();
+      SslContextFactory contextFactoryApi = new SslContextFactory.Server();
       disableInsecureProtocols(contextFactoryApi);
       contextFactoryApi.setKeyStorePath(httpsKeystore);
       contextFactoryApi.setTrustStorePath(httpsTruststore);


### PR DESCRIPTION

## What changes were proposed in this pull request?

Use SslContextFactory.Server() instead of SslContextFactory() when constructing the factory.

With Jetty 9.4.x, the base constructor fails to handle a KeyStore with multiple certificates in it.

`
Caused by: java.lang.IllegalStateException:
KeyStores with multiple certificates are not supported on the base class org.eclipse.jetty.util.ssl.SslContextFactory.
(Use org.eclipse.jetty.util.ssl.SslContextFactory$Server or org.eclipse.jetty.util.ssl.SslContextFactory$Client instead)
`

This proposed fix will be handling this issue.

## How was this patch tested?
With the fix, built the packaging and reinstalled the ambari on a lab cluster, and tested it, Able to upgrade the ambari server when it has Multiple SAN entries.

More details are added at [AMBARI-26428](https://issues.apache.org/jira/browse/AMBARI-26428)
