### PR TITLE
AMBARI-26428: [addendum] bump the jetty version to 9.4.57

### DIFF
--- a/ambari-project/pom.xml
+++ b/ambari-project/pom.xml
@@ -31,7 +31,7 @@
     <solr.version>5.5.2</solr.version>
     <ambari.dir>${project.parent.basedir}</ambari.dir>
     <powermock.version>2.0.9</powermock.version>
-    <jetty.version>9.4.12.v20180830</jetty.version>
+    <jetty.version>9.4.57.v20241219</jetty.version>
     <ldap-api.version>1.0.0</ldap-api.version>
     <checkstyle.version>8.9</checkstyle.version>
     <swagger.version>1.6.8</swagger.version>

--- a/ambari-server/src/main/java/org/apache/ambari/server/api/AmbariViewErrorHandlerProxy.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/api/AmbariViewErrorHandlerProxy.java
@@ -30,6 +30,8 @@ import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.handler.ErrorHandler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import javax.servlet.ServletException;
+
 
 import javassist.util.proxy.MethodHandler;
 
@@ -50,7 +52,7 @@ public class AmbariViewErrorHandlerProxy extends ErrorHandler implements MethodH
 
 
   @Override
-  public void handle(String target, Request baseRequest, HttpServletRequest request, HttpServletResponse response) throws IOException {
+  public void handle(String target, Request baseRequest, HttpServletRequest request, HttpServletResponse response) throws IOException, ServletException {
 
     if (isInternalError(request, response)) {
       //invoke the ambari error handler


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR is addendum to AMABI-26428. Addresses [this](https://github.com/apache/ambari/pull/3974#issuecomment-2791539402)  issue.

## How was this patch tested?
Tested locally, able to pass the compilation with this jetty version bup to the latest in 9.4.x lines.