### PR TITLE
AMBARI-26439. Create Rocky8 Dockerfile for development purposes

### DIFF
--- a/dev-support/docker/centos7/Dockerfile
+++ b/dev-support/docker/centos7/Dockerfile
@@ -15,9 +15,13 @@
 
 FROM centos:7
 
+RUN sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-*
+RUN sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
+RUN yum clean all
+RUN yum -y update
 RUN yum -y install sudo wget openssh-clients openssh-server vim mariadb mariadb-server java-1.8.0-openjdk* net-tools chrony krb5-server krb5-libs krb5-workstation git rpm-build
 RUN wget https://repo1.maven.org/maven2/mysql/mysql-connector-java/5.1.47/mysql-connector-java-5.1.47.jar -O /usr/share/java/mysql-connector-java.jar
-RUN wget https://dlcdn.apache.org/maven/maven-3/3.6.3/binaries/apache-maven-3.6.3-bin.tar.gz -O /tmp/apache-maven.tar.gz --no-check-certificate \
+RUN wget https://dlcdn.apache.org/maven/maven-3/3.8.8/binaries/apache-maven-3.8.8-bin.tar.gz -O /tmp/apache-maven.tar.gz --no-check-certificate \
   && mkdir -p /usr/share/maven && tar -xzf /tmp/apache-maven.tar.gz -C /usr/share/maven --strip-components=1 \
   && rm -f /tmp/apache-maven.tar.gz \
   && ln -s /usr/share/maven/bin/mvn /usr/bin/mvn

--- a/dev-support/docker/centos7/Dockerfile
+++ b/dev-support/docker/centos7/Dockerfile
@@ -15,13 +15,9 @@
 
 FROM centos:7
 
-RUN sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-*
-RUN sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
-RUN yum clean all
-RUN yum -y update
 RUN yum -y install sudo wget openssh-clients openssh-server vim mariadb mariadb-server java-1.8.0-openjdk* net-tools chrony krb5-server krb5-libs krb5-workstation git rpm-build
 RUN wget https://repo1.maven.org/maven2/mysql/mysql-connector-java/5.1.47/mysql-connector-java-5.1.47.jar -O /usr/share/java/mysql-connector-java.jar
-RUN wget https://dlcdn.apache.org/maven/maven-3/3.8.8/binaries/apache-maven-3.8.8-bin.tar.gz -O /tmp/apache-maven.tar.gz --no-check-certificate \
+RUN wget https://dlcdn.apache.org/maven/maven-3/3.6.3/binaries/apache-maven-3.6.3-bin.tar.gz -O /tmp/apache-maven.tar.gz --no-check-certificate \
   && mkdir -p /usr/share/maven && tar -xzf /tmp/apache-maven.tar.gz -C /usr/share/maven --strip-components=1 \
   && rm -f /tmp/apache-maven.tar.gz \
   && ln -s /usr/share/maven/bin/mvn /usr/bin/mvn

--- a/dev-support/docker/centos7/build-containers.sh
+++ b/dev-support/docker/centos7/build-containers.sh
@@ -33,7 +33,7 @@ echo -e "\033[32mCreating network ambari\033[0m"
 docker network create --driver bridge ambari
 
 echo -e "\033[32mCreating container ambari-server\033[0m"
-docker run -d -p 3306:3306 -p 5005:5005 -p 8080:8080 --name ambari-server --hostname ambari-server --network ambari --privileged -e "container=docker" -v /sys/fs/cgroup:/sys/fs/cgroup:ro ambari/develop:trunk-centos-7 /usr/sbin/init
+docker run -d -p 3306:3306 -p 5005:5005 -p 8080:8080 -p 8440:8440 --name ambari-server --hostname ambari-server --network ambari --privileged -e "container=docker" -v /sys/fs/cgroup:/sys/fs/cgroup:ro ambari/develop:trunk-centos-7 /usr/sbin/init
 docker cp ../../../ambari-server/target/rpm/ambari-server/RPMS/x86_64/ambari-server*.rpm ambari-server:/root/ambari-server.rpm
 docker cp ../../../ambari-agent/target/rpm/ambari-agent/RPMS/x86_64/ambari-agent*.rpm ambari-server:/root/ambari-agent.rpm
 SERVER_PUB_KEY=`docker exec ambari-server /bin/cat /root/.ssh/id_rsa.pub`

--- a/dev-support/docker/rocky8/Dockerfile
+++ b/dev-support/docker/rocky8/Dockerfile
@@ -15,28 +15,37 @@
 
 FROM rockylinux/rockylinux:8
 
-# Enable PowerTools for Rocky Linux 8
-RUN dnf install -y dnf-plugins-core && dnf config-manager --set-enabled powertools
-
-RUN dnf clean all && \
+# Install essential dependencies, update system, and configure alternatives in a single layer
+RUN dnf install -y dnf-plugins-core && \
+    dnf config-manager --set-enabled powertools && \
     dnf -y update && \
     dnf -y install sudo wget openssh-clients openssh-server vim mariadb mariadb-server \
       java-17-openjdk-devel java-1.8.0-openjdk-devel net-tools chrony krb5-server krb5-libs krb5-workstation \
-      git rpm-build python3
+      git rpm-build python3 && \
+    java_17_path=$(update-alternatives --list | grep 'java-17-openjdk' | head -1 | cut -f3) && \
+    if [ -n "$java_17_path" ]; then \
+        update-alternatives --set java "$java_17_path" || echo "darn"; \
+    else \
+        echo "could not find java17 in alternatives list" >&2; \
+    fi && \
+    alternatives --set java ${java_17_path}/bin/java && \
+    alternatives --set javac ${java_17_path}/bin/javac && \
+    dnf clean all
 
+# Download and install MySQL connector, Apache Maven, and perform SSH configuration in a single layer
 RUN wget https://repo1.maven.org/maven2/mysql/mysql-connector-java/5.1.47/mysql-connector-java-5.1.47.jar \
-      -O /usr/share/java/mysql-connector-java.jar
-
-RUN wget https://dlcdn.apache.org/maven/maven-3/3.8.8/binaries/apache-maven-3.8.8-bin.tar.gz \
+      -O /usr/share/java/mysql-connector-java.jar && \
+    wget https://dlcdn.apache.org/maven/maven-3/3.8.8/binaries/apache-maven-3.8.8-bin.tar.gz \
       -O /tmp/apache-maven.tar.gz --no-check-certificate && \
     mkdir -p /usr/share/maven && \
     tar -xzf /tmp/apache-maven.tar.gz -C /usr/share/maven --strip-components=1 && \
     rm -f /tmp/apache-maven.tar.gz && \
-    ln -s /usr/share/maven/bin/mvn /usr/bin/mvn
+    ln -s /usr/share/maven/bin/mvn /usr/bin/mvn && \
+    sed -i 's,#   StrictHostKeyChecking ask,StrictHostKeyChecking no,g' /etc/ssh/ssh_config && \
+    ssh-keygen -A -m PEM && \
+    ssh-keygen -f "/root/.ssh/id_rsa" -N "" -m PEM
 
-RUN sed -i 's,#   StrictHostKeyChecking ask,StrictHostKeyChecking no,g' /etc/ssh/ssh_config
-
-RUN ssh-keygen -A -m PEM
-RUN ssh-keygen -f "/root/.ssh/id_rsa" -N "" -m PEM
+ENV JAVA_HOME=/usr/lib/jvm/java-17-openjdk
+ENV PATH=$JAVA_HOME/bin:$PATH
 
 EXPOSE 1-65535

--- a/dev-support/docker/rocky8/Dockerfile
+++ b/dev-support/docker/rocky8/Dockerfile
@@ -16,7 +16,7 @@
 FROM rockylinux/rockylinux:8
 
 # Enable PowerTools for Rocky Linux 8
-RUN dnf install dnf-plugins-core && dnf config-manager --set-enabled powertools
+RUN dnf install -y dnf-plugins-core && dnf config-manager --set-enabled powertools
 
 RUN dnf clean all && \
     dnf -y update && \

--- a/dev-support/docker/rocky8/Dockerfile
+++ b/dev-support/docker/rocky8/Dockerfile
@@ -15,10 +15,13 @@
 
 FROM rockylinux/rockylinux:8
 
+# Enable PowerTools for Rocky Linux 8
+RUN dnf install dnf-plugins-core && dnf config-manager --set-enabled powertools
+
 RUN dnf clean all && \
     dnf -y update && \
     dnf -y install sudo wget openssh-clients openssh-server vim mariadb mariadb-server \
-      java-17-openjdk-devel net-tools chrony krb5-server krb5-libs krb5-workstation \
+      java-17-openjdk-devel java-1.8.0-openjdk-devel net-tools chrony krb5-server krb5-libs krb5-workstation \
       git rpm-build python3
 
 RUN wget https://repo1.maven.org/maven2/mysql/mysql-connector-java/5.1.47/mysql-connector-java-5.1.47.jar \

--- a/dev-support/docker/rocky8/Dockerfile
+++ b/dev-support/docker/rocky8/Dockerfile
@@ -33,6 +33,6 @@ RUN wget https://dlcdn.apache.org/maven/maven-3/3.8.8/binaries/apache-maven-3.8.
 
 RUN sed -i 's,#   StrictHostKeyChecking ask,StrictHostKeyChecking no,g' /etc/ssh/ssh_config
 
-RUN ssh-keygen -f "/root/.ssh/id_rsa" -N ""
+RUN ssh-keygen -f "/root/.ssh/id_rsa" -N "" -m PEM
 
 EXPOSE 1-65535

--- a/dev-support/docker/rocky8/Dockerfile
+++ b/dev-support/docker/rocky8/Dockerfile
@@ -1,0 +1,38 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM rockylinux/rockylinux:8
+
+RUN dnf clean all && \
+    dnf -y update && \
+    dnf -y install sudo wget openssh-clients openssh-server vim mariadb mariadb-server \
+      java-17-openjdk-devel net-tools chrony krb5-server krb5-libs krb5-workstation \
+      git rpm-build python3
+
+RUN wget https://repo1.maven.org/maven2/mysql/mysql-connector-java/5.1.47/mysql-connector-java-5.1.47.jar \
+      -O /usr/share/java/mysql-connector-java.jar
+
+RUN wget https://dlcdn.apache.org/maven/maven-3/3.8.8/binaries/apache-maven-3.8.8-bin.tar.gz \
+      -O /tmp/apache-maven.tar.gz --no-check-certificate && \
+    mkdir -p /usr/share/maven && \
+    tar -xzf /tmp/apache-maven.tar.gz -C /usr/share/maven --strip-components=1 && \
+    rm -f /tmp/apache-maven.tar.gz && \
+    ln -s /usr/share/maven/bin/mvn /usr/bin/mvn
+
+RUN sed -i 's,#   StrictHostKeyChecking ask,StrictHostKeyChecking no,g' /etc/ssh/ssh_config
+
+RUN ssh-keygen -f "/root/.ssh/id_rsa" -N ""
+
+EXPOSE 1-65535

--- a/dev-support/docker/rocky8/Dockerfile
+++ b/dev-support/docker/rocky8/Dockerfile
@@ -36,6 +36,7 @@ RUN wget https://dlcdn.apache.org/maven/maven-3/3.8.8/binaries/apache-maven-3.8.
 
 RUN sed -i 's,#   StrictHostKeyChecking ask,StrictHostKeyChecking no,g' /etc/ssh/ssh_config
 
+RUN ssh-keygen -A -m PEM
 RUN ssh-keygen -f "/root/.ssh/id_rsa" -N "" -m PEM
 
 EXPOSE 1-65535

--- a/dev-support/docker/rocky8/README.md
+++ b/dev-support/docker/rocky8/README.md
@@ -1,0 +1,72 @@
+<!--
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+## Build and install Ambari by dev-support
+Dev support is used to quickly develop and test ambari, which runs on the docker containers.
+
+### **Step 1**: Install build tools: Git、Docker
+The scripts require docker to be installed, since the compile process will run in a docker container and Ambari cluster also deploys on containers.
+
+```shell
+yum install -y git docker
+```
+### **Step 2**: Download Ambari source
+```shell
+git clone https://github.com/apache/ambari.git
+```
+### **Step 3**: Enter workspace
+**Rocky Linux 8 :**
+```shell
+cd ambari/dev-support/docker/rocky8/
+```
+### **Step 4**: Build develop basic image
+Run the setup command, you will get `ambari/develop:trunk-rocky-8` image. It has the environment needed to compile Ambari and run servers such as Ambari Server, Ambari Agent, Mysql, etc.
+
+```shell
+./build-image.sh
+```
+### **Step 5**: Build Ambari source & create Ambari cluster
+* The first compilation will take about 1 hour to download resources, and the next compilation will directly use the maven cache.
+* Ambari UI、Ambari Server Debug Port、MariaDB Server are also exposed to local ports: 8080、5005、3306.
+* Docker host names are: ambari-server、ambari-agent-01、ambari-agent-02.
+* Access admin page via http://localhost:8080 on your web browser. Log in with username `admin` and password `admin`.
+* Extra configurations are in `build-containers.sh` last few lines, eg. Kerberos Configuration、Hive DB Configuration.
+
+```shell
+./build-containers.sh
+```
+### **Step 6**: Re-build Ambari Server
+Re-compile Ambari without re-create and deploy clusters.
+
+```shell
+./build-ambari.sh
+```
+
+### **Step 7**: Redistribution stack
+Re-distribute stack scripts without re-create clusters.
+
+```shell
+./distribute-scripts.sh
+```
+### **Step 8**: Clean Ambari cluster
+Clean up the containers of Ambari cluster when you are done developing or testing.
+
+```shell
+./clear-containers.sh
+```
+### Step 9: Clean up the build environment
+**Note :** This operation will completely delete maven cache.
+
+```shell
+docker rm -f ambari-rpm-build
+```

--- a/dev-support/docker/rocky8/build-ambari.sh
+++ b/dev-support/docker/rocky8/build-ambari.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+echo -e "\033[32mStarting container ambari-rpm-build\033[0m"
+if [ `docker inspect --format '{{.State.Running}}' ambari-rpm-build` == true ];then
+  docker exec ambari-rpm-build bash -c "pkill -KILL -f maven"
+else
+  docker start ambari-rpm-build
+fi
+
+echo -e "\033[32mCompiling ambari\033[0m"
+docker exec ambari-rpm-build bash -c "mvn clean install rpm:rpm -DskipTests -Drat.skip=true"
+docker stop ambari-rpm-build
+
+echo -e "\033[32mRestarting ambari-server\033[0m"
+docker exec ambari-server bash -c "ambari-server stop"
+docker exec ambari-server bash -c "ambari-agent stop"
+docker exec ambari-server bash -c "yum -y remove ambari-server"
+docker exec ambari-server bash -c "yum -y remove ambari-agent"
+docker cp ../../../ambari-server/target/rpm/ambari-server/RPMS/x86_64/ambari-server*.rpm ambari-server:/root/ambari-server.rpm
+docker cp ../../../ambari-agent/target/rpm/ambari-agent/RPMS/x86_64/ambari-agent*.rpm ambari-server:/root/ambari-agent.rpm
+docker exec ambari-server bash -c "yum -y install /root/ambari-server.rpm"
+docker exec ambari-server bash -c "yum -y install /root/ambari-agent.rpm"
+docker exec ambari-server bash -c "ambari-server setup --jdbc-db=mysql --jdbc-driver=/usr/share/java/mysql-connector-java.jar"
+docker exec ambari-server bash -c "ambari-server setup --java-home=/usr/lib/jvm/java --database=mysql --databasehost=localhost --databaseport=3306 --databasename=ambari --databaseusername=root --databasepassword=root -s"
+docker exec ambari-server bash -c "ambari-server restart --debug"
+docker exec ambari-server bash -c "ambari-agent restart"
+
+echo -e "\033[32mRestarting ambari-agent-01\033[0m"
+docker exec ambari-agent-01 bash -c "ambari-agent stop"
+docker exec ambari-agent-01 bash -c "yum -y remove ambari-agent"
+docker cp ../../../ambari-agent/target/rpm/ambari-agent/RPMS/x86_64/ambari-agent*.rpm ambari-agent-01:/root/ambari-agent.rpm
+docker exec ambari-agent-01 bash -c "yum -y install /root/ambari-agent.rpm"
+docker exec ambari-agent-01 bash -c "ambari-agent restart"
+
+echo -e "\033[32mRestarting ambari-agent-02\033[0m"
+docker exec ambari-agent-02 bash -c "ambari-agent stop"
+docker exec ambari-agent-02 bash -c "yum -y remove ambari-agent"
+docker cp ../../../ambari-agent/target/rpm/ambari-agent/RPMS/x86_64/ambari-agent*.rpm ambari-agent-02:/root/ambari-agent.rpm
+docker exec ambari-agent-02 bash -c "yum -y install /root/ambari-agent.rpm"
+docker exec ambari-agent-02 bash -c "ambari-agent restart"
+
+echo -e "\033[32mDone!\033[0m"

--- a/dev-support/docker/rocky8/build-ambari.sh
+++ b/dev-support/docker/rocky8/build-ambari.sh
@@ -36,7 +36,7 @@ docker cp ../../../ambari-agent/target/rpm/ambari-agent/RPMS/x86_64/ambari-agent
 docker exec ambari-server bash -c "yum -y install /root/ambari-server.rpm"
 docker exec ambari-server bash -c "yum -y install /root/ambari-agent.rpm"
 docker exec ambari-server bash -c "ambari-server setup --jdbc-db=mysql --jdbc-driver=/usr/share/java/mysql-connector-java.jar"
-docker exec ambari-server bash -c "ambari-server setup --java-home=/usr/lib/jvm/java --database=mysql --databasehost=localhost --databaseport=3306 --databasename=ambari --databaseusername=root --databasepassword=root -s"
+docker exec ambari-server bash -c "ambari-server setup --java-home=/usr/lib/jvm/java --ambari-java-home=/usr/lib/jvm/java --database=mysql --databasehost=ambari-mariadb --databaseport=3306 --databasename=ambari --databaseusername=root --databasepassword=root -s"
 docker exec ambari-server bash -c "ambari-server restart --debug"
 docker exec ambari-server bash -c "ambari-agent restart"
 

--- a/dev-support/docker/rocky8/build-ambari.sh
+++ b/dev-support/docker/rocky8/build-ambari.sh
@@ -36,7 +36,7 @@ docker cp ../../../ambari-agent/target/rpm/ambari-agent/RPMS/x86_64/ambari-agent
 docker exec ambari-server bash -c "yum -y install /root/ambari-server.rpm"
 docker exec ambari-server bash -c "yum -y install /root/ambari-agent.rpm"
 docker exec ambari-server bash -c "ambari-server setup --jdbc-db=mysql --jdbc-driver=/usr/share/java/mysql-connector-java.jar"
-docker exec ambari-server bash -c "ambari-server setup --java-home=/usr/lib/jvm/java --ambari-java-home=/usr/lib/jvm/java --database=mysql --databasehost=ambari-mariadb --databaseport=3306 --databasename=ambari --databaseusername=root --databasepassword=root -s"
+docker exec ambari-server bash -c "ambari-server setup --java-home=/usr/lib/jvm/java-1.8.0 --ambari-java-home=/usr/lib/jvm/java-17 --database=mysql --databasehost=ambari-mariadb --databaseport=3306 --databasename=ambari --databaseusername=root --databasepassword=root -s"
 docker exec ambari-server bash -c "ambari-server restart --debug"
 docker exec ambari-server bash -c "chmod a+x /etc/init.d/ambari-agent"
 docker exec ambari-server bash -c "ambari-agent restart"

--- a/dev-support/docker/rocky8/build-ambari.sh
+++ b/dev-support/docker/rocky8/build-ambari.sh
@@ -38,6 +38,7 @@ docker exec ambari-server bash -c "yum -y install /root/ambari-agent.rpm"
 docker exec ambari-server bash -c "ambari-server setup --jdbc-db=mysql --jdbc-driver=/usr/share/java/mysql-connector-java.jar"
 docker exec ambari-server bash -c "ambari-server setup --java-home=/usr/lib/jvm/java --ambari-java-home=/usr/lib/jvm/java --database=mysql --databasehost=ambari-mariadb --databaseport=3306 --databasename=ambari --databaseusername=root --databasepassword=root -s"
 docker exec ambari-server bash -c "ambari-server restart --debug"
+docker exec ambari-server bash -c "chmod a+x /etc/init.d/ambari-agent"
 docker exec ambari-server bash -c "ambari-agent restart"
 
 echo -e "\033[32mRestarting ambari-agent-01\033[0m"
@@ -45,6 +46,7 @@ docker exec ambari-agent-01 bash -c "ambari-agent stop"
 docker exec ambari-agent-01 bash -c "yum -y remove ambari-agent"
 docker cp ../../../ambari-agent/target/rpm/ambari-agent/RPMS/x86_64/ambari-agent*.rpm ambari-agent-01:/root/ambari-agent.rpm
 docker exec ambari-agent-01 bash -c "yum -y install /root/ambari-agent.rpm"
+docker exec ambari-agent-01 bash -c "chmod a+x /etc/init.d/ambari-agent"
 docker exec ambari-agent-01 bash -c "ambari-agent restart"
 
 echo -e "\033[32mRestarting ambari-agent-02\033[0m"
@@ -52,6 +54,7 @@ docker exec ambari-agent-02 bash -c "ambari-agent stop"
 docker exec ambari-agent-02 bash -c "yum -y remove ambari-agent"
 docker cp ../../../ambari-agent/target/rpm/ambari-agent/RPMS/x86_64/ambari-agent*.rpm ambari-agent-02:/root/ambari-agent.rpm
 docker exec ambari-agent-02 bash -c "yum -y install /root/ambari-agent.rpm"
+docker exec ambari-agent-02 bash -c "chmod a+x /etc/init.d/ambari-agent"
 docker exec ambari-agent-02 bash -c "ambari-agent restart"
 
 echo -e "\033[32mDone!\033[0m"

--- a/dev-support/docker/rocky8/build-containers.sh
+++ b/dev-support/docker/rocky8/build-containers.sh
@@ -39,12 +39,14 @@ docker cp ../../../ambari-agent/target/rpm/ambari-agent/RPMS/x86_64/ambari-agent
 SERVER_PUB_KEY=`docker exec ambari-server /bin/cat /root/.ssh/id_rsa.pub`
 docker exec ambari-server bash -c "yum -y install /root/ambari-server.rpm"
 docker exec ambari-server bash -c "yum -y install /root/ambari-agent.rpm"
+docker exec ambari-server bash -c "chmod a+x /etc/init.d/ambari-agent"
+docker exec ambari-server bash -c "ambari-agent start"
 docker exec ambari-server bash -c "echo '$SERVER_PUB_KEY' > /root/.ssh/authorized_keys"
 # Install a wrapper to workaround systemctl on docker
 docker exec ambari-server bash -c "wget https://raw.githubusercontent.com/gdraheim/docker-systemctl-replacement/master/files/docker/systemctl3.py -O /usr/local/bin/systemctl"
 docker exec ambari-server bash -c "chmod a+x /usr/local/bin/systemctl"
-docker exec ambari-server /usr/local/bin/systemctl enable sshd
-docker exec ambari-server /usr/local/bin/systemctl start sshd
+docker exec ambari-server systemctl enable sshd
+docker exec ambari-server systemctl start sshd
 
 echo -e "\033[32mSetting up mariadb-server\033[0m"
 docker run --name ambari-mariadb --network ambari -e  MYSQL_ROOT_PASSWORD=root -p 3306:3306 -d docker.io/library/mariadb:10.4
@@ -71,21 +73,25 @@ echo -e "\033[32mCreating container ambari-agent-01\033[0m"
 docker run -d -p 9995:9995 --name ambari-agent-01 --hostname ambari-agent-01 --network ambari --privileged -e "container=docker" -v /sys/fs/cgroup:/sys/fs/cgroup:ro ambari/develop:trunk-rocky-8 /usr/sbin/init
 docker cp ../../../ambari-agent/target/rpm/ambari-agent/RPMS/x86_64/ambari-agent*.rpm ambari-agent-01:/root/ambari-agent.rpm
 docker exec ambari-agent-01 bash -c "yum -y install /root/ambari-agent.rpm"
+docker exec ambari-agent-01 bash -c "chmod a+x /etc/init.d/ambari-agent"
+docker exec ambari-agent-01 bash -c "ambari-agent start"
 docker exec ambari-agent-01 bash -c "echo '$SERVER_PUB_KEY' > /root/.ssh/authorized_keys"
 docker exec ambari-agent-01 bash -c "wget https://raw.githubusercontent.com/gdraheim/docker-systemctl-replacement/master/files/docker/systemctl3.py -O /usr/local/bin/systemctl"
 docker exec ambari-agent-01 bash -c "chmod a+x /usr/local/bin/systemctl"
-docker exec ambari-agent-01 /usr/local/bin/systemctl enable sshd
-docker exec ambari-agent-01 /usr/local/bin/systemctl start sshd
+docker exec ambari-agent-01 systemctl enable sshd
+docker exec ambari-agent-01 systemctl start sshd
 
 echo -e "\033[32mCreating container ambari-agent-02\033[0m"
 docker run -d -p 8088:8088 --name ambari-agent-02 --hostname ambari-agent-02 --network ambari --privileged -e "container=docker" -v /sys/fs/cgroup:/sys/fs/cgroup:ro ambari/develop:trunk-rocky-8 /usr/sbin/init
 docker cp ../../../ambari-agent/target/rpm/ambari-agent/RPMS/x86_64/ambari-agent*.rpm ambari-agent-02:/root/ambari-agent.rpm
 docker exec ambari-agent-02 bash -c "yum -y install /root/ambari-agent.rpm"
+docker exec ambari-agent-02 bash -c "chmod a+x /etc/init.d/ambari-agent"
+docker exec ambari-agent-02 bash -c "ambari-agent start"
 docker exec ambari-agent-02 bash -c "echo '$SERVER_PUB_KEY' > /root/.ssh/authorized_keys"
 docker exec ambari-agent-02 bash -c "wget https://raw.githubusercontent.com/gdraheim/docker-systemctl-replacement/master/files/docker/systemctl3.py -O /usr/local/bin/systemctl"
 docker exec ambari-agent-02 bash -c "chmod a+x /usr/local/bin/systemctl"
-docker exec ambari-agent-02 /usr/local/bin/systemctl enable sshd
-docker exec ambari-agent-02 /usr/local/bin/systemctl start sshd
+docker exec ambari-agent-02 systemctl enable sshd
+docker exec ambari-agent-02 systemctl start sshd
 
 echo -e "\033[32mConfiguring hosts file\033[0m"
 AMBARI_SERVER_IP=`docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' ambari-server`

--- a/dev-support/docker/rocky8/build-containers.sh
+++ b/dev-support/docker/rocky8/build-containers.sh
@@ -65,7 +65,7 @@ docker exec ambari-mariadb bash -c "mysql -proot -e \"FLUSH PRIVILEGES\""
 
 echo -e "\033[32mSetting up ambari-server\033[0m"
 docker exec ambari-server bash -c "ambari-server setup --jdbc-db=mysql --jdbc-driver=/usr/share/java/mysql-connector-java.jar"
-docker exec ambari-server bash -c "ambari-server setup --java-home=/usr/lib/jvm/java --ambari-java-home=/usr/lib/jvm/java --database=mysql --databasehost=ambari-mariadb --databaseport=3306 --databasename=ambari --databaseusername=root --databasepassword=root -s"
+docker exec ambari-server bash -c "ambari-server setup --java-home=/usr/lib/jvm/java-1.8.0 --ambari-java-home=/usr/lib/jvm/java-17 --database=mysql --databasehost=ambari-mariadb --databaseport=3306 --databasename=ambari --databaseusername=root --databasepassword=root -s"
 
 echo -e "\033[32mCreating container ambari-agent-01\033[0m"
 docker run -d -p 9995:9995 --name ambari-agent-01 --hostname ambari-agent-01 --network ambari --privileged -e "container=docker" -v /sys/fs/cgroup:/sys/fs/cgroup:ro ambari/develop:trunk-rocky-8 /usr/sbin/init

--- a/dev-support/docker/rocky8/build-containers.sh
+++ b/dev-support/docker/rocky8/build-containers.sh
@@ -33,7 +33,7 @@ echo -e "\033[32mCreating network ambari\033[0m"
 docker network create --driver bridge ambari
 
 echo -e "\033[32mCreating container ambari-server\033[0m"
-docker run -d -p 5005:5005 -p 8080:8080 --name ambari-server --hostname ambari-server --network ambari --privileged -e "container=docker" -v /sys/fs/cgroup:/sys/fs/cgroup:ro ambari/develop:trunk-rocky-8 /usr/sbin/init
+docker run -d -p 5005:5005 -p 8080:8080 -p 8440:8440 -p 8441:8441 -p 8670:8670 --name ambari-server --hostname ambari-server --network ambari --privileged -e "container=docker" -v /sys/fs/cgroup:/sys/fs/cgroup:ro ambari/develop:trunk-rocky-8 /usr/sbin/init
 docker cp ../../../ambari-server/target/rpm/ambari-server/RPMS/x86_64/ambari-server*.rpm ambari-server:/root/ambari-server.rpm
 docker cp ../../../ambari-agent/target/rpm/ambari-agent/RPMS/x86_64/ambari-agent*.rpm ambari-server:/root/ambari-agent.rpm
 SERVER_PUB_KEY=`docker exec ambari-server /bin/cat /root/.ssh/id_rsa.pub`

--- a/dev-support/docker/rocky8/build-containers.sh
+++ b/dev-support/docker/rocky8/build-containers.sh
@@ -33,52 +33,59 @@ echo -e "\033[32mCreating network ambari\033[0m"
 docker network create --driver bridge ambari
 
 echo -e "\033[32mCreating container ambari-server\033[0m"
-docker run -d -p 3306:3306 -p 5005:5005 -p 8080:8080 --name ambari-server --hostname ambari-server --network ambari --privileged -e "container=docker" -v /sys/fs/cgroup:/sys/fs/cgroup:ro ambari/develop:trunk-rocky-8 /usr/sbin/init
+docker run -d -p 5005:5005 -p 8080:8080 --name ambari-server --hostname ambari-server --network ambari --privileged -e "container=docker" -v /sys/fs/cgroup:/sys/fs/cgroup:ro ambari/develop:trunk-rocky-8 /usr/sbin/init
 docker cp ../../../ambari-server/target/rpm/ambari-server/RPMS/x86_64/ambari-server*.rpm ambari-server:/root/ambari-server.rpm
 docker cp ../../../ambari-agent/target/rpm/ambari-agent/RPMS/x86_64/ambari-agent*.rpm ambari-server:/root/ambari-agent.rpm
 SERVER_PUB_KEY=`docker exec ambari-server /bin/cat /root/.ssh/id_rsa.pub`
 docker exec ambari-server bash -c "yum -y install /root/ambari-server.rpm"
 docker exec ambari-server bash -c "yum -y install /root/ambari-agent.rpm"
 docker exec ambari-server bash -c "echo '$SERVER_PUB_KEY' > /root/.ssh/authorized_keys"
-docker exec ambari-server /bin/systemctl enable sshd
-docker exec ambari-server /bin/systemctl start sshd
+# Install a wrapper to workaround systemctl on docker
+docker exec ambari-server bash -c "wget https://raw.githubusercontent.com/gdraheim/docker-systemctl-replacement/master/files/docker/systemctl3.py -O /usr/local/bin/systemctl"
+docker exec ambari-server bash -c "chmod a+x /usr/local/bin/systemctl"
+docker exec ambari-server /usr/local/bin/systemctl enable sshd
+docker exec ambari-server /usr/local/bin/systemctl start sshd
 
 echo -e "\033[32mSetting up mariadb-server\033[0m"
-docker exec ambari-server /bin/systemctl enable mariadb
-docker exec ambari-server /bin/systemctl start mariadb
-docker exec ambari-server bash -c "mysql -e \"UPDATE mysql.user SET Password = PASSWORD('root') WHERE User = 'root'\""
-docker exec ambari-server bash -c "mysql -e \"GRANT ALL PRIVILEGES ON *.* TO 'root'@'%' IDENTIFIED BY 'root' WITH GRANT OPTION\""
-docker exec ambari-server bash -c "mysql -e \"DROP USER ''@'localhost'\""
-docker exec ambari-server bash -c "mysql -e \"DROP USER ''@'ambari-server'\""
-docker exec ambari-server bash -c "mysql -e \"DROP DATABASE test\""
-docker exec ambari-server bash -c "mysql -e \"CREATE DATABASE ambari\""
-docker exec ambari-server bash -c "mysql --database=ambari -e  \"source /var/lib/ambari-server/resources/Ambari-DDL-MySQL-CREATE.sql\""
+docker run --name ambari-mariadb --network ambari -e  MYSQL_ROOT_PASSWORD=root -p 3306:3306 -d docker.io/library/mariadb:10.4
+sleep 10
+docker exec ambari-mariadb bash -c "mysql -proot -e \"UPDATE mysql.user SET Password = PASSWORD('root') WHERE User = 'root'\""
+docker exec ambari-mariadb bash -c "mysql -proot -e \"GRANT ALL PRIVILEGES ON *.* TO 'root'@'%' IDENTIFIED BY 'root' WITH GRANT OPTION\""
+docker exec ambari-mariadb bash -c "mysql -proot -e \"DROP USER ''@'localhost'\""
+docker exec ambari-mariadb bash -c "mysql -proot -e \"DROP USER ''@'ambari-server'\""
+docker exec ambari-mariadb bash -c "mysql -proot -e \"DROP DATABASE test\""
+docker exec ambari-mariadb bash -c "mysql -proot -e \"CREATE DATABASE ambari\""
+docker exec ambari-server bash -c "mysql -proot -h ambari-mariadb --database=ambari -e  \"source /var/lib/ambari-server/resources/Ambari-DDL-MySQL-CREATE.sql\""
 
-docker exec ambari-server bash -c "mysql -e \"CREATE USER 'hive'@'%' IDENTIFIED BY 'hive'\""
-docker exec ambari-server bash -c "mysql  -e \"GRANT ALL PRIVILEGES ON *.* TO 'hive'@'%' IDENTIFIED BY 'hive'\""
-docker exec ambari-server bash -c "mysql -e \"CREATE DATABASE hive\""
+docker exec ambari-mariadb bash -c "mysql -proot -e \"CREATE USER 'hive'@'%' IDENTIFIED BY 'hive'\""
+docker exec ambari-mariadb bash -c "mysql -proot -e \"GRANT ALL PRIVILEGES ON *.* TO 'hive'@'%' IDENTIFIED BY 'hive'\""
+docker exec ambari-mariadb bash -c "mysql -proot -e \"CREATE DATABASE hive\""
 
-docker exec ambari-server bash -c "mysql -e \"FLUSH PRIVILEGES\""
+docker exec ambari-mariadb bash -c "mysql -proot -e \"FLUSH PRIVILEGES\""
 
 echo -e "\033[32mSetting up ambari-server\033[0m"
 docker exec ambari-server bash -c "ambari-server setup --jdbc-db=mysql --jdbc-driver=/usr/share/java/mysql-connector-java.jar"
-docker exec ambari-server bash -c "ambari-server setup --java-home=/usr/lib/jvm/java --database=mysql --databasehost=localhost --databaseport=3306 --databasename=ambari --databaseusername=root --databasepassword=root -s"
+docker exec ambari-server bash -c "ambari-server setup --java-home=/usr/lib/jvm/java --ambari-java-home=/usr/lib/jvm/java --database=mysql --databasehost=ambari-mariadb --databaseport=3306 --databasename=ambari --databaseusername=root --databasepassword=root -s"
 
 echo -e "\033[32mCreating container ambari-agent-01\033[0m"
 docker run -d -p 9995:9995 --name ambari-agent-01 --hostname ambari-agent-01 --network ambari --privileged -e "container=docker" -v /sys/fs/cgroup:/sys/fs/cgroup:ro ambari/develop:trunk-rocky-8 /usr/sbin/init
 docker cp ../../../ambari-agent/target/rpm/ambari-agent/RPMS/x86_64/ambari-agent*.rpm ambari-agent-01:/root/ambari-agent.rpm
 docker exec ambari-agent-01 bash -c "yum -y install /root/ambari-agent.rpm"
 docker exec ambari-agent-01 bash -c "echo '$SERVER_PUB_KEY' > /root/.ssh/authorized_keys"
-docker exec ambari-agent-01 /bin/systemctl enable sshd
-docker exec ambari-agent-01 /bin/systemctl start sshd
+docker exec ambari-agent-01 bash -c "wget https://raw.githubusercontent.com/gdraheim/docker-systemctl-replacement/master/files/docker/systemctl3.py -O /usr/local/bin/systemctl"
+docker exec ambari-agent-01 bash -c "chmod a+x /usr/local/bin/systemctl"
+docker exec ambari-agent-01 /usr/local/bin/systemctl enable sshd
+docker exec ambari-agent-01 /usr/local/bin/systemctl start sshd
 
 echo -e "\033[32mCreating container ambari-agent-02\033[0m"
 docker run -d -p 8088:8088 --name ambari-agent-02 --hostname ambari-agent-02 --network ambari --privileged -e "container=docker" -v /sys/fs/cgroup:/sys/fs/cgroup:ro ambari/develop:trunk-rocky-8 /usr/sbin/init
 docker cp ../../../ambari-agent/target/rpm/ambari-agent/RPMS/x86_64/ambari-agent*.rpm ambari-agent-02:/root/ambari-agent.rpm
 docker exec ambari-agent-02 bash -c "yum -y install /root/ambari-agent.rpm"
 docker exec ambari-agent-02 bash -c "echo '$SERVER_PUB_KEY' > /root/.ssh/authorized_keys"
-docker exec ambari-agent-02 /bin/systemctl enable sshd
-docker exec ambari-agent-02 /bin/systemctl start sshd
+docker exec ambari-agent-02 bash -c "wget https://raw.githubusercontent.com/gdraheim/docker-systemctl-replacement/master/files/docker/systemctl3.py -O /usr/local/bin/systemctl"
+docker exec ambari-agent-02 bash -c "chmod a+x /usr/local/bin/systemctl"
+docker exec ambari-agent-02 /usr/local/bin/systemctl enable sshd
+docker exec ambari-agent-02 /usr/local/bin/systemctl start sshd
 
 echo -e "\033[32mConfiguring hosts file\033[0m"
 AMBARI_SERVER_IP=`docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' ambari-server`
@@ -98,15 +105,15 @@ docker cp ./krb5.conf ambari-agent-01:/etc/krb5.conf
 docker cp ./krb5.conf ambari-agent-02:/etc/krb5.conf
 docker exec ambari-server bash -c "echo -e \"admin\nadmin\" | kdb5_util create -s -r EXAMPLE.COM"
 docker exec ambari-server bash -c "echo -e \"admin\nadmin\" | kadmin.local -q \"addprinc admin/admin\""
-docker exec ambari-server bash -c "systemctl start krb5kdc"
-docker exec ambari-server bash -c "systemctl enable krb5kdc"
-docker exec ambari-server bash -c "systemctl start kadmin"
-docker exec ambari-server bash -c "systemctl enable kadmin"
+docker exec ambari-server bash -c "/usr/local/bin/systemctl start krb5kdc"
+docker exec ambari-server bash -c "/usr/local/bin/systemctl enable krb5kdc"
+docker exec ambari-server bash -c "/usr/local/bin/systemctl start kadmin"
+docker exec ambari-server bash -c "/usr/local/bin/systemctl enable kadmin"
 
 echo -e "\033[32mSynchronize Chrony\033[0m"
-docker exec ambari-server bash -c "systemctl enable chronyd; systemctl start chronyd; chronyc tracking"
-docker exec ambari-agent-01 bash -c "systemctl enable chronyd; systemctl start chronyd; chronyc tracking"
-docker exec ambari-agent-02 bash -c "systemctl enable chronyd; systemctl start chronyd; chronyc tracking"
+docker exec ambari-server bash -c "/usr/local/bin/systemctl enable chronyd; /usr/local/bin/systemctl start chronyd; chronyc tracking"
+docker exec ambari-agent-01 bash -c "/usr/local/bin/systemctl enable chronyd; /usr/local/bin/systemctl start chronyd; chronyc tracking"
+docker exec ambari-agent-02 bash -c "/usr/local/bin/systemctl enable chronyd; /usr/local/bin/systemctl start chronyd; chronyc tracking"
 
 docker exec ambari-server bash -c "ambari-server restart --debug"
 

--- a/dev-support/docker/rocky8/build-containers.sh
+++ b/dev-support/docker/rocky8/build-containers.sh
@@ -1,0 +1,125 @@
+#!/bin/bash
+
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+echo -e "\033[32mStarting container ambari-rpm-build\033[0m"
+if [[ -z $(docker ps -a --format "table {{.Names}}" | grep "ambari-rpm-build") ]];then
+  docker run -it -d --name ambari-rpm-build --privileged=true -e "container=docker" \
+    -v /sys/fs/cgroup:/sys/fs/cgroup:ro -v $PWD/../../../:/opt/ambari/ \
+    -w /opt/ambari \
+    ambari/develop:trunk-rocky-8
+else
+  docker start ambari-rpm-build
+fi
+
+echo -e "\033[32mCompiling ambari\033[0m"
+docker exec ambari-rpm-build bash -c "mvn clean install rpm:rpm -DskipTests -Drat.skip=true"
+docker stop ambari-rpm-build
+
+echo -e "\033[32mCreating network ambari\033[0m"
+docker network create --driver bridge ambari
+
+echo -e "\033[32mCreating container ambari-server\033[0m"
+docker run -d -p 3306:3306 -p 5005:5005 -p 8080:8080 --name ambari-server --hostname ambari-server --network ambari --privileged -e "container=docker" -v /sys/fs/cgroup:/sys/fs/cgroup:ro ambari/develop:trunk-rocky-8 /usr/sbin/init
+docker cp ../../../ambari-server/target/rpm/ambari-server/RPMS/x86_64/ambari-server*.rpm ambari-server:/root/ambari-server.rpm
+docker cp ../../../ambari-agent/target/rpm/ambari-agent/RPMS/x86_64/ambari-agent*.rpm ambari-server:/root/ambari-agent.rpm
+SERVER_PUB_KEY=`docker exec ambari-server /bin/cat /root/.ssh/id_rsa.pub`
+docker exec ambari-server bash -c "yum -y install /root/ambari-server.rpm"
+docker exec ambari-server bash -c "yum -y install /root/ambari-agent.rpm"
+docker exec ambari-server bash -c "echo '$SERVER_PUB_KEY' > /root/.ssh/authorized_keys"
+docker exec ambari-server /bin/systemctl enable sshd
+docker exec ambari-server /bin/systemctl start sshd
+
+echo -e "\033[32mSetting up mariadb-server\033[0m"
+docker exec ambari-server /bin/systemctl enable mariadb
+docker exec ambari-server /bin/systemctl start mariadb
+docker exec ambari-server bash -c "mysql -e \"UPDATE mysql.user SET Password = PASSWORD('root') WHERE User = 'root'\""
+docker exec ambari-server bash -c "mysql -e \"GRANT ALL PRIVILEGES ON *.* TO 'root'@'%' IDENTIFIED BY 'root' WITH GRANT OPTION\""
+docker exec ambari-server bash -c "mysql -e \"DROP USER ''@'localhost'\""
+docker exec ambari-server bash -c "mysql -e \"DROP USER ''@'ambari-server'\""
+docker exec ambari-server bash -c "mysql -e \"DROP DATABASE test\""
+docker exec ambari-server bash -c "mysql -e \"CREATE DATABASE ambari\""
+docker exec ambari-server bash -c "mysql --database=ambari -e  \"source /var/lib/ambari-server/resources/Ambari-DDL-MySQL-CREATE.sql\""
+
+docker exec ambari-server bash -c "mysql -e \"CREATE USER 'hive'@'%' IDENTIFIED BY 'hive'\""
+docker exec ambari-server bash -c "mysql  -e \"GRANT ALL PRIVILEGES ON *.* TO 'hive'@'%' IDENTIFIED BY 'hive'\""
+docker exec ambari-server bash -c "mysql -e \"CREATE DATABASE hive\""
+
+docker exec ambari-server bash -c "mysql -e \"FLUSH PRIVILEGES\""
+
+echo -e "\033[32mSetting up ambari-server\033[0m"
+docker exec ambari-server bash -c "ambari-server setup --jdbc-db=mysql --jdbc-driver=/usr/share/java/mysql-connector-java.jar"
+docker exec ambari-server bash -c "ambari-server setup --java-home=/usr/lib/jvm/java --database=mysql --databasehost=localhost --databaseport=3306 --databasename=ambari --databaseusername=root --databasepassword=root -s"
+
+echo -e "\033[32mCreating container ambari-agent-01\033[0m"
+docker run -d -p 9995:9995 --name ambari-agent-01 --hostname ambari-agent-01 --network ambari --privileged -e "container=docker" -v /sys/fs/cgroup:/sys/fs/cgroup:ro ambari/develop:trunk-rocky-8 /usr/sbin/init
+docker cp ../../../ambari-agent/target/rpm/ambari-agent/RPMS/x86_64/ambari-agent*.rpm ambari-agent-01:/root/ambari-agent.rpm
+docker exec ambari-agent-01 bash -c "yum -y install /root/ambari-agent.rpm"
+docker exec ambari-agent-01 bash -c "echo '$SERVER_PUB_KEY' > /root/.ssh/authorized_keys"
+docker exec ambari-agent-01 /bin/systemctl enable sshd
+docker exec ambari-agent-01 /bin/systemctl start sshd
+
+echo -e "\033[32mCreating container ambari-agent-02\033[0m"
+docker run -d -p 8088:8088 --name ambari-agent-02 --hostname ambari-agent-02 --network ambari --privileged -e "container=docker" -v /sys/fs/cgroup:/sys/fs/cgroup:ro ambari/develop:trunk-rocky-8 /usr/sbin/init
+docker cp ../../../ambari-agent/target/rpm/ambari-agent/RPMS/x86_64/ambari-agent*.rpm ambari-agent-02:/root/ambari-agent.rpm
+docker exec ambari-agent-02 bash -c "yum -y install /root/ambari-agent.rpm"
+docker exec ambari-agent-02 bash -c "echo '$SERVER_PUB_KEY' > /root/.ssh/authorized_keys"
+docker exec ambari-agent-02 /bin/systemctl enable sshd
+docker exec ambari-agent-02 /bin/systemctl start sshd
+
+echo -e "\033[32mConfiguring hosts file\033[0m"
+AMBARI_SERVER_IP=`docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' ambari-server`
+AMBARI_AGENT_01_IP=`docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' ambari-agent-01`
+AMBARI_AGENT_02_IP=`docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' ambari-agent-02`
+docker exec ambari-server bash -c "echo '$AMBARI_AGENT_01_IP      ambari-agent-01' >> /etc/hosts"
+docker exec ambari-server bash -c "echo '$AMBARI_AGENT_02_IP      ambari-agent-02' >> /etc/hosts"
+docker exec ambari-agent-01 bash -c "echo '$AMBARI_SERVER_IP      ambari-server' >> /etc/hosts"
+docker exec ambari-agent-01 bash -c "echo '$AMBARI_AGENT_02_IP      ambari-agent-02' >> /etc/hosts"
+docker exec ambari-agent-02 bash -c "echo '$AMBARI_SERVER_IP      ambari-server' >> /etc/hosts"
+docker exec ambari-agent-02 bash -c "echo '$AMBARI_AGENT_01_IP      ambari-agent-01' >> /etc/hosts"
+
+
+echo -e "\033[32mConfiguring Kerberos\033[0m"
+docker cp ./krb5.conf ambari-server:/etc/krb5.conf
+docker cp ./krb5.conf ambari-agent-01:/etc/krb5.conf
+docker cp ./krb5.conf ambari-agent-02:/etc/krb5.conf
+docker exec ambari-server bash -c "echo -e \"admin\nadmin\" | kdb5_util create -s -r EXAMPLE.COM"
+docker exec ambari-server bash -c "echo -e \"admin\nadmin\" | kadmin.local -q \"addprinc admin/admin\""
+docker exec ambari-server bash -c "systemctl start krb5kdc"
+docker exec ambari-server bash -c "systemctl enable krb5kdc"
+docker exec ambari-server bash -c "systemctl start kadmin"
+docker exec ambari-server bash -c "systemctl enable kadmin"
+
+echo -e "\033[32mSynchronize Chrony\033[0m"
+docker exec ambari-server bash -c "systemctl enable chronyd; systemctl start chronyd; chronyc tracking"
+docker exec ambari-agent-01 bash -c "systemctl enable chronyd; systemctl start chronyd; chronyc tracking"
+docker exec ambari-agent-02 bash -c "systemctl enable chronyd; systemctl start chronyd; chronyc tracking"
+
+docker exec ambari-server bash -c "ambari-server restart --debug"
+
+echo -e "\033[32mPrint Ambari Server RSA Private Key\033[0m"
+docker exec ambari-server bash -c "cat ~/.ssh/id_rsa"
+
+# KDC HOST: ambari-server
+# REALM NAME: EXAMPLE.COM
+# ADMIN PRINCIPAL: admin/admin@EXAMPLE.COM
+# ADMIN PASSWORD: admin
+
+# MySQL HOST: ambari-server
+# MySQL PORT: 3306
+# DATABASE NAME: hive
+# DATABASE USER NAME: hive
+# DATABASE PASSWORD: hive

--- a/dev-support/docker/rocky8/build-image.sh
+++ b/dev-support/docker/rocky8/build-image.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+echo -e "\033[32mRemoving image ambari:trunk-rocky-8\033[0m"
+docker rmi ambari/develop:trunk-rocky8-8
+
+echo -e "\033[32mBuilding image ambari:trunk-rocky-8\033[0m"
+docker build -t ambari/develop:trunk-rocky-8 .

--- a/dev-support/docker/rocky8/clear-containers.sh
+++ b/dev-support/docker/rocky8/clear-containers.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+echo -e "\033[32mStopping container ambari-rpm-build and maven process\033[0m"
+if [ `docker inspect --format '{{.State.Running}}' ambari-rpm-build` == true ];then
+  docker exec ambari-rpm-build bash -c "pkill -KILL -f maven"
+  docker stop ambari-rpm-build
+fi
+
+echo -e "\033[32mRemoving container ambari-server\033[0m"
+docker rm -f ambari-server
+
+echo -e "\033[32mRemoving container ambari-agent-01\033[0m"
+docker rm -f ambari-agent-01
+
+echo -e "\033[32mRemoving container ambari-agent-02\033[0m"
+docker rm -f ambari-agent-02
+
+echo -e "\033[32mRemoving network ambari\033[0m"
+docker network rm ambari

--- a/dev-support/docker/rocky8/clear-containers.sh
+++ b/dev-support/docker/rocky8/clear-containers.sh
@@ -24,6 +24,9 @@ fi
 echo -e "\033[32mRemoving container ambari-server\033[0m"
 docker rm -f ambari-server
 
+echo -e "\033[32mRemoving container ambari-mariadb\033[0m"
+docker rm -f ambari-mariadb
+
 echo -e "\033[32mRemoving container ambari-agent-01\033[0m"
 docker rm -f ambari-agent-01
 

--- a/dev-support/docker/rocky8/distribute-scripts.sh
+++ b/dev-support/docker/rocky8/distribute-scripts.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+echo -e "\033[32mSynchronizing script to ambari-server\033[0m"
+docker exec ambari-server bash -c "mkdir -p /var/lib/ambari-agent/cache/stacks/BIGTOP/3.2.0/services/"
+docker cp ../../../ambari-server/src/main/resources/stacks/ ambari-server:/var/lib/ambari-agent/cache/
+docker cp ../../../ambari-server/src/main/resources/stacks/ ambari-server:/var/lib/ambari-server/resources/
+docker exec ambari-server bash -c "ambari-server restart --debug"
+docker exec ambari-server bash -c "ambari-agent restart"
+
+echo -e "\033[32mSynchronizing script to ambari-agent-01\033[0m"
+docker exec ambari-agent-01 bash -c "mkdir -p /var/lib/ambari-agent/cache/stacks/BIGTOP/3.2.0/services/"
+docker cp ../../../ambari-server/src/main/resources/stacks/ ambari-agent-01:/var/lib/ambari-agent/cache/
+docker exec ambari-agent-01 bash -c "ambari-agent restart"
+
+echo -e "\033[32mSynchronizing script to ambari-agent-02\033[0m"
+docker exec ambari-agent-02 bash -c "mkdir -p /var/lib/ambari-agent/cache/stacks/BIGTOP/3.2.0/services/"
+docker cp ../../../ambari-server/src/main/resources/stacks/ ambari-agent-02:/var/lib/ambari-agent/cache/
+docker exec ambari-agent-02 bash -c "ambari-agent restart"
+
+echo -e "\033[32mDone!\033[0m"

--- a/dev-support/docker/rocky8/distribute-scripts.sh
+++ b/dev-support/docker/rocky8/distribute-scripts.sh
@@ -16,19 +16,19 @@
 # limitations under the License.
 
 echo -e "\033[32mSynchronizing script to ambari-server\033[0m"
-docker exec ambari-server bash -c "mkdir -p /var/lib/ambari-agent/cache/stacks/BIGTOP/3.2.0/services/"
+docker exec ambari-server bash -c "mkdir -p /var/lib/ambari-agent/cache/stacks/BIGTOP/3.3.0/services/"
 docker cp ../../../ambari-server/src/main/resources/stacks/ ambari-server:/var/lib/ambari-agent/cache/
 docker cp ../../../ambari-server/src/main/resources/stacks/ ambari-server:/var/lib/ambari-server/resources/
 docker exec ambari-server bash -c "ambari-server restart --debug"
 docker exec ambari-server bash -c "ambari-agent restart"
 
 echo -e "\033[32mSynchronizing script to ambari-agent-01\033[0m"
-docker exec ambari-agent-01 bash -c "mkdir -p /var/lib/ambari-agent/cache/stacks/BIGTOP/3.2.0/services/"
+docker exec ambari-agent-01 bash -c "mkdir -p /var/lib/ambari-agent/cache/stacks/BIGTOP/3.3.0/services/"
 docker cp ../../../ambari-server/src/main/resources/stacks/ ambari-agent-01:/var/lib/ambari-agent/cache/
 docker exec ambari-agent-01 bash -c "ambari-agent restart"
 
 echo -e "\033[32mSynchronizing script to ambari-agent-02\033[0m"
-docker exec ambari-agent-02 bash -c "mkdir -p /var/lib/ambari-agent/cache/stacks/BIGTOP/3.2.0/services/"
+docker exec ambari-agent-02 bash -c "mkdir -p /var/lib/ambari-agent/cache/stacks/BIGTOP/3.3.0/services/"
 docker cp ../../../ambari-server/src/main/resources/stacks/ ambari-agent-02:/var/lib/ambari-agent/cache/
 docker exec ambari-agent-02 bash -c "ambari-agent restart"
 

--- a/dev-support/docker/rocky8/krb5.conf
+++ b/dev-support/docker/rocky8/krb5.conf
@@ -1,0 +1,41 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+includedir /etc/krb5.conf.d/
+
+[logging]
+ default = FILE:/var/log/krb5libs.log
+ kdc = FILE:/var/log/krb5kdc.log
+ admin_server = FILE:/var/log/kadmind.log
+
+[libdefaults]
+ dns_lookup_realm = false
+ ticket_lifetime = 24h
+ renew_lifetime = 7d
+ forwardable = true
+ rdns = false
+ pkinit_anchors = FILE:/etc/pki/tls/certs/ca-bundle.crt
+ default_realm = EXAMPLE.COM
+ default_ccache_name = KEYRING:persistent:%{uid}
+
+[realms]
+EXAMPLE.COM = {
+ kdc = ambari-server
+ admin_server = ambari-server
+}
+
+[domain_realm]
+.example.com = EXAMPLE.COM
+example.com = EXAMPLE.COM


### PR DESCRIPTION
## What changes were proposed in this pull request?

* Copied centos7 Dockerfile and created a Rocky8 one.
* updated to JDK17, Python3, Maven 3.8

## How was this patch tested?

executed build-image.sh, build-container.sh

Afterwards, I was able to install HDFS, YARN, MapReduce and Zookeeper services with this PR.