### PR TITLE
AMBARI-26443. Failed to execute goal frontend-maven-plugin on MAC M1

### DIFF
--- a/ambari-admin/pom.xml
+++ b/ambari-admin/pom.xml
@@ -59,7 +59,7 @@
       <plugin>
         <groupId>com.github.eirslett</groupId>
         <artifactId>frontend-maven-plugin</artifactId>
-        <version>1.3</version>
+        <version>1.11.0</version>
         <configuration>
           <nodeVersion>v4.5.0</nodeVersion>
           <npmVersion>2.15.0</npmVersion>

--- a/ambari-web/pom.xml
+++ b/ambari-web/pom.xml
@@ -73,7 +73,7 @@
             <plugin>
                 <groupId>com.github.eirslett</groupId>
                 <artifactId>frontend-maven-plugin</artifactId>
-                <version>1.4</version>
+                <version>1.11.0</version>
                 <configuration>
                     <nodeVersion>v4.5.0</nodeVersion>
                     <yarnVersion>v0.23.2</yarnVersion>

--- a/contrib/views/capacity-scheduler/pom.xml
+++ b/contrib/views/capacity-scheduler/pom.xml
@@ -123,7 +123,7 @@
       <plugin>
         <groupId>com.github.eirslett</groupId>
         <artifactId>frontend-maven-plugin</artifactId>
-        <version>1.4</version>
+        <version>1.11.0</version>
         <configuration>
           <yarnVersion>v0.23.2</yarnVersion>
           <workingDirectory>${ui.directory}</workingDirectory>

--- a/contrib/views/files/pom.xml
+++ b/contrib/views/files/pom.xml
@@ -187,7 +187,7 @@
       <plugin>
         <groupId>com.github.eirslett</groupId>
         <artifactId>frontend-maven-plugin</artifactId>
-        <version>1.4</version>
+        <version>1.11.0</version>
         <configuration>
           <nodeVersion>v4.5.0</nodeVersion>
           <yarnVersion>v0.23.2</yarnVersion>

--- a/contrib/views/pig/pom.xml
+++ b/contrib/views/pig/pom.xml
@@ -200,7 +200,7 @@
       <plugin>
         <groupId>com.github.eirslett</groupId>
         <artifactId>frontend-maven-plugin</artifactId>
-        <version>1.4</version>
+        <version>1.11.0</version>
         <configuration>
           <nodeVersion>v4.5.0</nodeVersion>
           <yarnVersion>v0.23.2</yarnVersion>

--- a/contrib/views/wfmanager/pom.xml
+++ b/contrib/views/wfmanager/pom.xml
@@ -141,7 +141,7 @@
 			<plugin>
 				<groupId>com.github.eirslett</groupId>
 				<artifactId>frontend-maven-plugin</artifactId>
-				<version>1.4</version>
+				<version>1.11.0</version>
 				<configuration>
 					<nodeVersion>v4.5.0</nodeVersion>
 					<yarnVersion>v0.23.2</yarnVersion>

--- a/contrib/views/wfmanager/src/main/resources/ui/pom.xml
+++ b/contrib/views/wfmanager/src/main/resources/ui/pom.xml
@@ -40,7 +40,7 @@
             <plugin>
                 <groupId>com.github.eirslett</groupId>
                 <artifactId>frontend-maven-plugin</artifactId>
-                <version>1.3</version>
+                <version>1.11.0</version>
                 <configuration>
                     <nodeVersion>v5.0.0</nodeVersion>
                     <npmVersion>3.5.3</npmVersion>


### PR DESCRIPTION
## What changes were proposed in this pull request?

```
Failed to execute goal com.github.eirslett:frontend-maven-plugin:1.3:install-node-and-npm (install node and npm) on project ambari-admin: Could not download Node.js: Got error code 404 from the server. -> 
```

And the solution is: https://github.com/eirslett/frontend-maven-plugin/issues/952#issuecomment-762163294
> with the M1 you need to use version 1.11.0 (or newer) of this plugin.

## How was this patch tested?

compile successful on mac M1 local
```
mvn clean compile -DskipTests
```

no 
```
Failed to execute goal com.github.eirslett:frontend-maven-plugin:1.3:install-node-and-npm (install node and npm) on project ambari-admin: Could not download Node.js: Got error code 404 from the server. -> 
```
error anymore