### PR TITLE
AMBARI-26454: Two source code files don't have Apache license text

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/configuration/spring/ApiSecurityConfig.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/configuration/spring/ApiSecurityConfig.java
@@ -1,3 +1,20 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.ambari.server.configuration.spring;
 
 import java.util.Arrays;

--- a/ambari-server/src/main/java/org/apache/ambari/server/security/authentication/RequestBodyCachingFilter.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/security/authentication/RequestBodyCachingFilter.java
@@ -1,3 +1,20 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.ambari.server.security.authentication;
 
 import java.io.BufferedReader;


### PR DESCRIPTION
## What changes were proposed in this pull request?

- Added the Apache License 2.0 header to ApiSecurityConfig.java in the org.apache.ambari.server.configuration.spring package.
- Added the Apache License 2.0 header to RequestBodyCachingFilter.java in the org.apache.ambari.server.security.authentication package.

## How was this patch tested?

Running the Apache RAT plugin check using the command:
`mvn org.apache.rat:apache-rat-plugin:check -Dmaven.artifact.threads=10`
Verifying that the build completes successfully with no "unapproved license" errors.

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.