### PR TITLE
AMBARI-26461: NotAMock Argument should be a mock, but is: class java.lang.Class.

### DIFF
--- a/ambari-server/src/test/java/org/apache/ambari/server/checks/AmbariMetricsHadoopSinkVersionCheckTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/checks/AmbariMetricsHadoopSinkVersionCheckTest.java
@@ -169,33 +169,44 @@ public class AmbariMetricsHadoopSinkVersionCheckTest {
 
     AmbariManagementController ambariManagementControllerMock = Mockito.mock(AmbariManagementController.class);
     PowerMockito.mockStatic(AmbariServer.class);
-    when(AmbariServer.getController()).thenReturn(ambariManagementControllerMock);
+    when(AmbariServer.getController()).thenAnswer(
+      invocation -> ambariManagementControllerMock);
 
     ResourceProvider resourceProviderMock = mock(ResourceProvider.class);
     PowerMockito.mockStatic(AbstractControllerResourceProvider.class);
-    when(AbstractControllerResourceProvider.getResourceProvider(Mockito.eq(Resource.Type.Request), any(AmbariManagementController.class))).thenReturn(resourceProviderMock);
+    when(AbstractControllerResourceProvider.getResourceProvider(Mockito.eq(Resource.Type.Request), any(AmbariManagementController.class))).thenAnswer(
+      invocation -> resourceProviderMock);
 
     PowerMockito.mockStatic(PropertyHelper.class);
     Request requestMock = mock(Request.class);
-    when(PropertyHelper.getCreateRequest(any(), any())).thenReturn(requestMock);
-    when(PropertyHelper.getPropertyId("Requests", "id")).thenReturn("requestIdProp");
+    when(PropertyHelper.getCreateRequest(any(), any())).thenAnswer(invocation -> requestMock);
+    when(PropertyHelper.getPropertyId("Requests", "id")).thenAnswer(
+      invocation -> "requestIdProp");
 
     RequestStatus requestStatusMock = mock(RequestStatus.class);
     Resource responseResourceMock = mock(Resource.class);
-    when(resourceProviderMock.createResources(requestMock)).thenReturn(requestStatusMock);
-    when(requestStatusMock.getRequestResource()).thenReturn(responseResourceMock);
-    when(responseResourceMock.getPropertyValue(anyString())).thenReturn(100l);
+    when(resourceProviderMock.createResources(requestMock)).thenAnswer(
+      invocation -> requestStatusMock);
+    when(requestStatusMock.getRequestResource()).thenAnswer(
+      invocation -> responseResourceMock);
+    when(responseResourceMock.getPropertyValue(anyString())).thenAnswer(
+      invocation -> 100l);
 
     Clusters clustersMock = mock(Clusters.class);
-    when(ambariManagementControllerMock.getClusters()).thenReturn(clustersMock);
+    when(ambariManagementControllerMock.getClusters()).thenAnswer(
+      invocation -> clustersMock);
     Cluster clusterMock = mock(Cluster.class);
-    when(clustersMock.getCluster("c1")).thenReturn(clusterMock);
-    when(clusterMock.getHosts(eq("AMBARI_METRICS"), eq("METRICS_MONITOR"))).thenReturn(Collections.singleton("h1"));
+    when(clustersMock.getCluster("c1")).thenAnswer(invocation -> clusterMock);
+    when(clusterMock.getHosts(eq("AMBARI_METRICS"), eq("METRICS_MONITOR"))).thenAnswer(
+      invocation -> Collections.singleton("h1"));
 
     RequestDAO requestDAOMock = mock(RequestDAO.class);
     RequestEntity requestEntityMock  = mock(RequestEntity.class);
-    when(requestDAOMock.findByPks(Collections.singleton(100l), true)).thenReturn(Collections.singletonList(requestEntityMock));
-    when(requestEntityMock.getStatus()).thenReturn(HostRoleStatus.IN_PROGRESS).thenReturn(HostRoleStatus.COMPLETED);
+    when(requestDAOMock.findByPks(Collections.singleton(100l), true)).thenAnswer(
+      invocation -> Collections.singletonList(requestEntityMock));
+    when(requestEntityMock.getStatus()).thenAnswer(
+        invocation -> HostRoleStatus.IN_PROGRESS
+    ).thenAnswer(invocation -> HostRoleStatus.COMPLETED);
 
     Field requestDaoField = m_check.getClass().getDeclaredField("requestDAO");
     requestDaoField.setAccessible(true);

--- a/ambari-server/src/test/java/org/apache/ambari/server/checks/ComponentsInstallationCheckTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/checks/ComponentsInstallationCheckTest.java
@@ -293,12 +293,12 @@ public class ComponentsInstallationCheckTest {
     Mockito.when(hcsMetricsMonitor.getHostName()).thenReturn("host3");
 
     // Mock the static method
-    PowerMockito.when(HostComponentSummary.getHostComponentSummaries("HDFS", "NAMENODE")).thenReturn(Arrays.asList(hcsNameNode));
-    PowerMockito.when(HostComponentSummary.getHostComponentSummaries("HDFS", "DATANODE")).thenReturn(Arrays.asList(hcsDataNode1, hcsDataNode2, hcsDataNode3));
-    PowerMockito.when(HostComponentSummary.getHostComponentSummaries("HDFS", "ZKFC")).thenReturn(Arrays.asList(hcsZKFC));
-    PowerMockito.when(HostComponentSummary.getHostComponentSummaries("TEZ", "TEZ_CLIENT")).thenReturn(Arrays.asList(hcsTezClient));
-    PowerMockito.when(HostComponentSummary.getHostComponentSummaries("AMBARI_METRICS", "METRICS_COLLECTOR")).thenReturn(Arrays.asList(hcsMetricsCollector));
-    PowerMockito.when(HostComponentSummary.getHostComponentSummaries("AMBARI_METRICS", "METRICS_MONITOR")).thenReturn(Arrays.asList(hcsMetricsMonitor));
+    PowerMockito.when(HostComponentSummary.getHostComponentSummaries("HDFS", "NAMENODE")).thenAnswer(invocation -> Arrays.asList(hcsNameNode));
+    PowerMockito.when(HostComponentSummary.getHostComponentSummaries("HDFS", "DATANODE")).thenAnswer(invocation -> Arrays.asList(hcsDataNode1, hcsDataNode2, hcsDataNode3));
+    PowerMockito.when(HostComponentSummary.getHostComponentSummaries("HDFS", "ZKFC")).thenAnswer(invocation -> Arrays.asList(hcsZKFC));
+    PowerMockito.when(HostComponentSummary.getHostComponentSummaries("TEZ", "TEZ_CLIENT")).thenAnswer(invocation -> Arrays.asList(hcsTezClient));
+    PowerMockito.when(HostComponentSummary.getHostComponentSummaries("AMBARI_METRICS", "METRICS_COLLECTOR")).thenAnswer(invocation -> Arrays.asList(hcsMetricsCollector));
+    PowerMockito.when(HostComponentSummary.getHostComponentSummaries("AMBARI_METRICS", "METRICS_MONITOR")).thenAnswer(invocation -> Arrays.asList(hcsMetricsMonitor));
     for (String hostName : hosts.keySet()) {
       Mockito.when(clusters.getHost(hostName)).thenReturn(hosts.get(hostName));
     }

--- a/ambari-server/src/test/java/org/apache/ambari/server/checks/ServicesUpCheckTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/checks/ServicesUpCheckTest.java
@@ -295,12 +295,12 @@ public class ServicesUpCheckTest {
     allHostComponentSummaries.add(hcsMetricsMonitor);
 
     // Mock the static method
-    Mockito.when(HostComponentSummary.getHostComponentSummaries("HDFS", "NAMENODE")).thenReturn(Arrays.asList(hcsNameNode));
-    Mockito.when(HostComponentSummary.getHostComponentSummaries("HDFS", "DATANODE")).thenReturn(Arrays.asList(hcsDataNode1, hcsDataNode2, hcsDataNode3));
-    Mockito.when(HostComponentSummary.getHostComponentSummaries("HDFS", "ZKFC")).thenReturn(Arrays.asList(hcsZKFC));
-    Mockito.when(HostComponentSummary.getHostComponentSummaries("TEZ", "TEZ_CLIENT")).thenReturn(Arrays.asList(hcsTezClient));
-    Mockito.when(HostComponentSummary.getHostComponentSummaries("AMBARI_METRICS", "METRICS_COLLECTOR")).thenReturn(Arrays.asList(hcsMetricsCollector));
-    Mockito.when(HostComponentSummary.getHostComponentSummaries("AMBARI_METRICS", "METRICS_MONITOR")).thenReturn(Arrays.asList(hcsMetricsMonitor));
+    Mockito.when(HostComponentSummary.getHostComponentSummaries("HDFS", "NAMENODE")).thenAnswer(invocation -> Arrays.asList(hcsNameNode));
+    Mockito.when(HostComponentSummary.getHostComponentSummaries("HDFS", "DATANODE")).thenAnswer(invocation -> Arrays.asList(hcsDataNode1, hcsDataNode2, hcsDataNode3));
+    Mockito.when(HostComponentSummary.getHostComponentSummaries("HDFS", "ZKFC")).thenAnswer(invocation -> Arrays.asList(hcsZKFC));
+    Mockito.when(HostComponentSummary.getHostComponentSummaries("TEZ", "TEZ_CLIENT")).thenAnswer(invocation -> Arrays.asList(hcsTezClient));
+    Mockito.when(HostComponentSummary.getHostComponentSummaries("AMBARI_METRICS", "METRICS_COLLECTOR")).thenAnswer(invocation -> Arrays.asList(hcsMetricsCollector));
+    Mockito.when(HostComponentSummary.getHostComponentSummaries("AMBARI_METRICS", "METRICS_MONITOR")).thenAnswer(invocation -> Arrays.asList(hcsMetricsMonitor));
 
     // Case 1. Initialize with good values
     for (HostComponentSummary hcs : allHostComponentSummaries) {

--- a/ambari-server/src/test/java/org/apache/ambari/server/serveraction/upgrades/UpgradeUserKerberosDescriptorTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/serveraction/upgrades/UpgradeUserKerberosDescriptorTest.java
@@ -137,7 +137,7 @@ public class UpgradeUserKerberosDescriptorTest {
     KerberosDescriptor updatedKerberosDescriptor = EasyMock.createMock(KerberosDescriptor.class);
 
     PowerMockito.mockStatic(KerberosDescriptorUpdateHelper.class);
-    PowerMockito.when(KerberosDescriptorUpdateHelper.updateUserKerberosDescriptor(previousDescriptor, newDescriptor, userDescriptor)).thenReturn(updatedKerberosDescriptor);
+    PowerMockito.when(KerberosDescriptorUpdateHelper.updateUserKerberosDescriptor(previousDescriptor, newDescriptor, userDescriptor)).thenAnswer(invocation -> updatedKerberosDescriptor);
     expect(kerberosDescriptorFactory.createInstance((Map)null)).andReturn(userDescriptor).atLeastOnce();
     expect(ambariMetaInfo.getKerberosDescriptor("HDP","2.5", false)).andReturn(newDescriptor).atLeastOnce();
     expect(ambariMetaInfo.getKerberosDescriptor("HDP","2.4",false)).andReturn(previousDescriptor).atLeastOnce();


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix powermock test errors by applying the solution in https://stackoverflow.com/questions/62742777/org-mockito-exceptions-misusing-notamockexception-argument-should-be-a-mock-bu

      You can solve the issue using the below code. Hope this will help you. Please replace below the line
      
      PowerMockito.when(SSLContext.getInstance(anyString())).thenReturn(sslContextMock);
      with
      
      when(SSLContext.getInstance(anyString())).thenAnswer((Answer<SSLContext>) invocation -> sslContextMock);


## How was this patch tested?

mvn -am test -pl ambari-server -DskipPythonTests -Dmaven.test.failure.ignore -Dmaven.artifact.threads=10 -Drat.skip -DskipAdminWebTests=true  -Dtest=AmbariMetricsHadoopSinkVersionCheckTest,ComponentsInstallationCheckTest,ServicesUpCheckTest,UpgradeUserKerberosDescriptorTest -Dsurefire.failIfNoSpecifiedTests=false