### PR TITLE
AMBARI-26462: Alluxio-site-properties.xml does not pass validation

### DIFF
--- a/ambari-server/src/main/resources/stacks/BIGTOP/3.2.0/services/ALLUXIO/configuration/alluxio-site-properties.xml
+++ b/ambari-server/src/main/resources/stacks/BIGTOP/3.2.0/services/ALLUXIO/configuration/alluxio-site-properties.xml
@@ -149,5 +149,6 @@ alluxio.worker.rpc.port={{alluxio_worker_rpc_port}}
 alluxio.worker.web.port={{alluxio_worker_web_port}}
 
         </value>
+        <on-ambari-upgrade add="true"/>
     </property>
 </configuration>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add on-ambari-upgrade property to pass validator.

## How was this patch tested?

    mvn -am test -pl ambari-server -DskipPythonTests -Dmaven.test.failure.ignore -Dmaven.artifact.threads=10 -Drat.skip -DskipAdminWebTests=true  -Dtest=ServicePropertiesTest -Dsurefire.failIfNoSpecifiedTests=false

