### PR TITLE
AMBARI-26453:change to 3.1.0.0-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
   <artifactId>ambari</artifactId>
   <packaging>pom</packaging>
   <name>Ambari Main</name>
-  <version>3.1.0.0-SNAPSHOT</version>
+  <version>${revision}</version>
   <description>Ambari</description>
   <url>https://ambari.apache.org/</url>
   <scm>
@@ -79,7 +79,7 @@
     <url>https://issues.apache.org/jira/browse/AMBARI</url>
   </issueManagement>
   <properties>
-    <revision>3.0.0.0-SNAPSHOT</revision>
+    <revision>3.1.0.0-SNAPSHOT</revision>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <clover.license>${user.home}/clover.license</clover.license>
     <jdk.version>17</jdk.version>

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
   <artifactId>ambari</artifactId>
   <packaging>pom</packaging>
   <name>Ambari Main</name>
-  <version>${revision}</version>
+  <version>3.1.0.0-SNAPSHOT</version>
   <description>Ambari</description>
   <url>https://ambari.apache.org/</url>
   <scm>

--- a/setup.py
+++ b/setup.py
@@ -72,7 +72,7 @@ def create_package_dir_map():
   return package_dirs
 
 
-__version__ = "3.0.0.0-SNAPSHOT"
+__version__ = "3.1.0.0-SNAPSHOT"
 
 
 def get_version():


### PR DESCRIPTION
## What changes were proposed in this pull request?

This pull request updates the project version of Apache Ambari from 3.0.0.0-SNAPSHOT to 3.1.0.0-SNAPSHOT as part of the preparation for the next development cycle following the 3.0.0 release. The change was implemented using the following Maven command:
`mvn versions:set -DnewVersion=3.1.0.0-SNAPSHOT`
This command updates the version number in all `pom.xml` files across the project, including the root and submodule POM files.

## How was this patch tested?

 After running the Maven command, I verified the changes by inspecting the pom.xml files to ensure the version number was correctly updated to 3.1.0.0-SNAPSHOT.

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.