### PR TITLE
AMBARI-26456: Dependency org.mockito:mockito-inline version is not unique

### DIFF
--- a/ambari-server/pom.xml
+++ b/ambari-server/pom.xml
@@ -1409,12 +1409,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.mockito</groupId>
-      <artifactId>mockito-inline</artifactId>
-      <version>3.5.10</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-security</artifactId>
     </dependency>


### PR DESCRIPTION
## What changes were proposed in this pull request?

This pull request proposes to resolve a dependency version conflict in the pom.xml file by ensuring a consistent version of org.mockito:mockito-inline. 
The issue arises from two different versions being declared, causing ambiguity during the build.

## How was this patch tested?
Maven Build