### PR TITLE
AMBARI-26467: AmbariKerberosAuthenticationFilterTest fails

### DIFF
--- a/ambari-server/src/test/java/org/apache/ambari/server/security/authentication/kerberos/AmbariKerberosAuthenticationFilterTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/security/authentication/kerberos/AmbariKerberosAuthenticationFilterTest.java
@@ -18,19 +18,22 @@
 
 package org.apache.ambari.server.security.authentication.kerberos;
 
-import static org.easymock.EasyMock.anyObject;
-import static org.easymock.EasyMock.anyString;
-import static org.easymock.EasyMock.capture;
-import static org.easymock.EasyMock.eq;
-import static org.easymock.EasyMock.expect;
-import static org.easymock.EasyMock.expectLastCall;
-import static org.easymock.EasyMock.getCurrentArguments;
-import static org.easymock.EasyMock.newCapture;
-import static org.easymock.EasyMock.startsWith;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.List;
 
+import jakarta.servlet.DispatcherType;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -43,50 +46,41 @@ import org.apache.ambari.server.security.authentication.AmbariAuthenticationEven
 import org.apache.ambari.server.security.authentication.AmbariAuthenticationException;
 import org.apache.ambari.server.security.authentication.AmbariAuthenticationFilter;
 import org.apache.ambari.server.security.authentication.InvalidUsernamePasswordCombinationException;
-import org.easymock.Capture;
-import org.easymock.CaptureType;
-import org.easymock.EasyMockSupport;
-import org.easymock.IAnswer;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.Mockito;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.web.AuthenticationEntryPoint;
 
-public class AmbariKerberosAuthenticationFilterTest extends EasyMockSupport {
+public class AmbariKerberosAuthenticationFilterTest {
   private Configuration configuration;
-
   private AuthenticationEntryPoint entryPoint;
-
   private AuthenticationManager authenticationManager;
-
   private AmbariAuthenticationEventHandler eventHandler;
 
   @Before
   public void setUp() {
     SecurityContextHolder.getContext().setAuthentication(null);
 
-    entryPoint = createMock(AmbariEntryPoint.class);
-    configuration = createMock(Configuration.class);
-    authenticationManager = createMock(AuthenticationManager.class);
-    eventHandler = createMock(AmbariAuthenticationEventHandler.class);
+    entryPoint = mock(AmbariEntryPoint.class);
+    configuration = mock(Configuration.class);
+    authenticationManager = mock(AuthenticationManager.class);
+    eventHandler = mock(AmbariAuthenticationEventHandler.class);
   }
 
-  @Test (expected = IllegalArgumentException.class)
+  @Test(expected = IllegalArgumentException.class)
   public void ensureNonNullEventHandler() {
     new AmbariKerberosAuthenticationFilter(authenticationManager, entryPoint, configuration, null);
   }
 
   @Test
   public void shouldApplyTrue() throws Exception {
-    HttpServletRequest httpServletRequest = createMock(HttpServletRequest.class);
-    expect(httpServletRequest.getHeader("Authorization")).andReturn("Negotiate .....").once();
-
-    expect(configuration.getKerberosAuthenticationProperties()).andReturn(createProperties(true)).once();
-
-    replayAll();
+    HttpServletRequest httpServletRequest = mock(HttpServletRequest.class);
+    when(httpServletRequest.getHeader("Authorization")).thenReturn("Negotiate .....");
+    doReturn(createProperties(true)).when(configuration).getKerberosAuthenticationProperties();
 
     AmbariKerberosAuthenticationFilter filter = new AmbariKerberosAuthenticationFilter(
         authenticationManager,
@@ -96,18 +90,13 @@ public class AmbariKerberosAuthenticationFilterTest extends EasyMockSupport {
     );
 
     Assert.assertTrue(filter.shouldApply(httpServletRequest));
-
-    verifyAll();
   }
 
   @Test
   public void shouldApplyFalseMissingHeader() throws Exception {
-    HttpServletRequest httpServletRequest = createMock(HttpServletRequest.class);
-    expect(httpServletRequest.getHeader("Authorization")).andReturn(null).once();
-
-    expect(configuration.getKerberosAuthenticationProperties()).andReturn(createProperties(true)).once();
-
-    replayAll();
+    HttpServletRequest httpServletRequest = mock(HttpServletRequest.class);
+    when(httpServletRequest.getHeader("Authorization")).thenReturn(null);
+    doReturn(createProperties(true)).when(configuration).getKerberosAuthenticationProperties();
 
     AmbariKerberosAuthenticationFilter filter = new AmbariKerberosAuthenticationFilter(
         authenticationManager,
@@ -117,17 +106,12 @@ public class AmbariKerberosAuthenticationFilterTest extends EasyMockSupport {
     );
 
     Assert.assertFalse(filter.shouldApply(httpServletRequest));
-
-    verifyAll();
   }
 
   @Test
   public void shouldApplyNotFalseEnabled() throws Exception {
-    HttpServletRequest httpServletRequest = createMock(HttpServletRequest.class);
-
-    expect(configuration.getKerberosAuthenticationProperties()).andReturn(createProperties(false)).once();
-
-    replayAll();
+    HttpServletRequest httpServletRequest = mock(HttpServletRequest.class);
+    doReturn(createProperties(true)).when(configuration).getKerberosAuthenticationProperties();
 
     AmbariKerberosAuthenticationFilter filter = new AmbariKerberosAuthenticationFilter(
         authenticationManager,
@@ -137,55 +121,47 @@ public class AmbariKerberosAuthenticationFilterTest extends EasyMockSupport {
     );
 
     Assert.assertFalse(filter.shouldApply(httpServletRequest));
-
-    verifyAll();
   }
 
   @Test
   public void testDoFilterSuccessful() throws IOException, ServletException {
-    Capture<? extends AmbariAuthenticationFilter> captureFilter = newCapture(CaptureType.ALL);
+    List<AmbariAuthenticationFilter> capturedFilters = new ArrayList<>();
 
-    // GIVEN
-    HttpServletRequest request = createMock(HttpServletRequest.class);
-    HttpServletResponse response = createMock(HttpServletResponse.class);
-    HttpSession session = createMock(HttpSession.class);
-    FilterChain filterChain = createMock(FilterChain.class);
+    HttpServletRequest request = mock(HttpServletRequest.class);
+    HttpServletResponse response = mock(HttpServletResponse.class);
+    HttpSession session = mock(HttpSession.class);
+    FilterChain filterChain = mock(FilterChain.class);
 
-    expect(request.getHeader("Authorization")).andReturn("Negotiate ").once();
-    expect(request.getHeader(startsWith("X-Forwarded-"))).andReturn(null).times(6);
-    expect(request.getRemoteAddr()).andReturn("1.2.3.4").once();
-    expect(request.getSession(false)).andReturn(session).once();
-    expect(request.getQueryString()).andReturn(null).once();
-    expect(request.getParameter(anyString())).andReturn(null).anyTimes();
-    expect(session.getId()).andReturn("sessionID").once();
+    when(request.getHeader("Authorization")).thenReturn("Negotiate ");
 
-    expect(authenticationManager.authenticate(anyObject(Authentication.class)))
-        .andAnswer(new IAnswer<Authentication>() {
-          @Override
-          public Authentication answer() throws Throwable {
-            return (Authentication) getCurrentArguments()[0];
-          }
-        })
-        .anyTimes();
+    when(request.getHeader(Mockito.startsWith("X-Forwarded-"))).thenReturn(null);
+    when(request.getRemoteAddr()).thenReturn("1.2.3.4");
+    when(request.getSession(false)).thenReturn(session);
+    when(request.getQueryString()).thenReturn(null);
+    when(request.getParameter(anyString())).thenReturn(null);
+    when(request.getDispatcherType()).thenReturn(DispatcherType.ASYNC);
+    when(session.getId()).thenReturn("sessionID");
 
-    expect(configuration.getKerberosAuthenticationProperties()).andReturn(createProperties(true)).once();
+    doReturn(createProperties(true)).when(configuration).getKerberosAuthenticationProperties();
 
-    eventHandler.beforeAttemptAuthentication(capture(captureFilter), eq(request), eq(response));
-    expectLastCall().once();
-    eventHandler.onSuccessfulAuthentication(capture(captureFilter), eq(request), eq(response), anyObject(Authentication.class));
-    expectLastCall().once();
+    doAnswer(invocation -> {
+      capturedFilters.add((AmbariAuthenticationFilter) invocation.getArgument(0));
+      return null;
+    }).when(eventHandler).beforeAttemptAuthentication(any(), eq(request), eq(response));
 
-    filterChain.doFilter(request, response);
-    expectLastCall().once();
+    when(authenticationManager.authenticate(any(Authentication.class))).thenAnswer(invocation -> invocation.getArgument(0));
 
-    replayAll();
-    // WHEN
-    AmbariAuthenticationFilter filter = new AmbariKerberosAuthenticationFilter(authenticationManager, entryPoint, configuration, eventHandler);
+    doAnswer(invocation -> {
+      capturedFilters.add((AmbariAuthenticationFilter) invocation.getArgument(0));
+      return null;
+    }).when(eventHandler).onSuccessfulAuthentication(any(), eq(request), eq(response), any(Authentication.class));
+
+    doNothing().when(filterChain).doFilter(request, response);
+
+    AmbariKerberosAuthenticationFilter filter = new AmbariKerberosAuthenticationFilter(authenticationManager, entryPoint, configuration, eventHandler);
     filter.doFilter(request, response, filterChain);
-    // THEN
-    verifyAll();
+    verify(filterChain, times(1)).doFilter(any(), any());
 
-    List<? extends AmbariAuthenticationFilter> capturedFilters = captureFilter.getValues();
     for (AmbariAuthenticationFilter capturedFiltered : capturedFilters) {
       Assert.assertSame(filter, capturedFiltered);
     }
@@ -193,50 +169,49 @@ public class AmbariKerberosAuthenticationFilterTest extends EasyMockSupport {
 
   @Test
   public void testDoFilterUnsuccessful() throws IOException, ServletException {
-    Capture<? extends AmbariAuthenticationFilter> captureFilter = newCapture(CaptureType.ALL);
+    List<AmbariAuthenticationFilter> capturedFilters = new ArrayList<>();
 
-    // GIVEN
-    HttpServletRequest request = createMock(HttpServletRequest.class);
-    HttpServletResponse response = createMock(HttpServletResponse.class);
-    HttpSession session = createMock(HttpSession.class);
-    FilterChain filterChain = createMock(FilterChain.class);
+    HttpServletRequest request = mock(HttpServletRequest.class);
+    HttpServletResponse response = mock(HttpServletResponse.class);
+    HttpSession session = mock(HttpSession.class);
+    FilterChain filterChain = mock(FilterChain.class);
 
-    expect(request.getHeader("Authorization")).andReturn("Negotiate ").once();
-    expect(request.getHeader(startsWith("X-Forwarded-"))).andReturn(null).times(6);
-    expect(request.getRemoteAddr()).andReturn("1.2.3.4").once();
-    expect(request.getSession(false)).andReturn(session).once();
-    expect(request.getQueryString()).andReturn(null).once();
-    expect(request.getParameter(anyString())).andReturn(null).anyTimes();
-    expect(session.getId()).andReturn("sessionID").once();
+    when(request.getHeader("Authorization")).thenReturn("Negotiate ");
+    when(request.getHeader(Mockito.startsWith("X-Forwarded-"))).thenReturn(null);
+    when(request.getRemoteAddr()).thenReturn("1.2.3.4");
+    when(request.getSession(false)).thenReturn(session);
+    when(request.getQueryString()).thenReturn(null);
+    when(request.getParameter(anyString())).thenReturn(null);
+    when(request.getDispatcherType()).thenReturn(DispatcherType.ASYNC);
+    when(session.getId()).thenReturn("sessionID");
 
-    expect(authenticationManager.authenticate(anyObject(Authentication.class))).andThrow(new InvalidUsernamePasswordCombinationException("user")).once();
+    doReturn(createProperties(true)).when(configuration).getKerberosAuthenticationProperties();
 
-    expect(configuration.getKerberosAuthenticationProperties()).andReturn(createProperties(true)).once();
+    doAnswer(invocation -> {
+      capturedFilters.add((AmbariAuthenticationFilter) invocation.getArgument(0));
+      return null;
+    }).when(eventHandler).beforeAttemptAuthentication(any(), eq(request), eq(response));
 
-    eventHandler.beforeAttemptAuthentication(capture(captureFilter), eq(request), eq(response));
-    expectLastCall().once();
-    eventHandler.onUnsuccessfulAuthentication(capture(captureFilter), eq(request), eq(response), anyObject(AmbariAuthenticationException.class));
-    expectLastCall().once();
+    when(authenticationManager.authenticate(any(Authentication.class))).thenThrow(new InvalidUsernamePasswordCombinationException("user"));
 
-    entryPoint.commence(eq(request), eq(response), anyObject(AmbariAuthenticationException.class));
-    expectLastCall().once();
+    doAnswer(invocation -> {
+      capturedFilters.add((AmbariAuthenticationFilter) invocation.getArgument(0));
+      return null;
+    }).when(eventHandler).onUnsuccessfulAuthentication(any(), eq(request), eq(response), any(AmbariAuthenticationException.class));
 
-    replayAll();
-    // WHEN
-    AmbariAuthenticationFilter filter = new AmbariKerberosAuthenticationFilter(authenticationManager, entryPoint, configuration, eventHandler);
+    doNothing().when(entryPoint).commence(eq(request), eq(response), any(AmbariAuthenticationException.class));
+
+    AmbariKerberosAuthenticationFilter filter = new AmbariKerberosAuthenticationFilter(authenticationManager, entryPoint, configuration, eventHandler);
     filter.doFilter(request, response, filterChain);
-    // THEN
-    verifyAll();
 
-    List<? extends AmbariAuthenticationFilter> capturedFilters = captureFilter.getValues();
     for (AmbariAuthenticationFilter capturedFiltered : capturedFilters) {
       Assert.assertSame(filter, capturedFiltered);
     }
   }
 
   private AmbariKerberosAuthenticationProperties createProperties(Boolean enabled) {
-    AmbariKerberosAuthenticationProperties properties = createMock(AmbariKerberosAuthenticationProperties.class);
-    expect(properties.isKerberosAuthenticationEnabled()).andReturn(enabled).once();
+    AmbariKerberosAuthenticationProperties properties = mock(AmbariKerberosAuthenticationProperties.class);
+    when(properties.isKerberosAuthenticationEnabled()).thenReturn(enabled);
     return properties;
   }
 }


### PR DESCRIPTION
Generated-by: ChatGPT 4o

## What changes were proposed in this pull request?

Migrate from EasyMock to Mockito assisted by ChatGPT.

## How was this patch tested?
Unit test only.