### PR TITLE
AMBARI-26449:Update org.postgresql:postgresql to 42.3.9

### DIFF
--- a/ambari-project/pom.xml
+++ b/ambari-project/pom.xml
@@ -43,7 +43,7 @@
     <spring.security.version>6.0.0</spring.security.version>
     <fasterxml.jackson.version>2.18.2</fasterxml.jackson.version>
     <fasterxml.jackson.databind.version>2.18.2</fasterxml.jackson.databind.version>
-    <postgres.version>42.3.8</postgres.version>
+    <postgres.version>42.3.9</postgres.version>
     <testContainers.version>1.17.6</testContainers.version>
     <forkCount>4</forkCount>
     <reuseForks>false</reuseForks>


### PR DESCRIPTION
## What changes were proposed in this pull request?

This pull request updates the PostgreSQL JDBC driver dependency (org.postgresql:postgresql) from version 42.3.8 to 42.3.9 in the `pom.xml`. The update addresses a security vulnerability fixed in 42.3.9:
Security Fix (CVE-2024-1597): In preferQueryMode=simple (non-default), a SQL injection vulnerability existed where a negative numeric parameter followed by a string parameter could generate a line comment, potentially leading to SQL injection. Version 42.3.9 resolves this issue by ensuring line comments are not generated in such cases.
So no other functional or API changes were introduced between 42.3.8 and 42.3.9.

## How was this patch tested?

Dependency Verification: Confirmed the updated version by running `mvn dependency:tree -Dincludes=org.postgresql | grep postgresql`, ensuring org.postgresql:postgresql is resolved to 42.3.9.
Build Verification: Executed `mvn clean install -DskipTests` to verify that the build completes successfully with the updated dependency.

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.