### PR TITLE
AMBARI-26460: module java.base does not "opens sun.nio.fs" to unnamed module

### DIFF
--- a/ambari-server/pom.xml
+++ b/ambari-server/pom.xml
@@ -801,6 +801,7 @@
             --add-opens java.xml/jdk.xml.internal=ALL-UNNAMED
             --add-opens java.naming/com.sun.jndi.ldap=ALL-UNNAMED
             --add-opens java.base/java.security=ALL-UNNAMED
+            --add-opens java.base/sun.nio.fs=ALL-UNNAMED
           </argLine>
 
           <!-- Each profile in the top-level pom.xml defines which test group categories to run. -->


### PR DESCRIPTION
## What changes were proposed in this pull request?

For the precommit test `mvn -am test -pl ambari-server -DskipPythonTests -Dmaven.test.failure.ignore -Dmaven.artifact.threads=10 -Drat.skip -DskipAdminWebTests=true`,
fix the error `module java.base does not "opens sun.nio.fs" to unnamed module` in Surefire java tests.

## How was this patch tested?
Tested via:
`mvn -am test -pl ambari-server -DskipPythonTests -Dmaven.test.failure.ignore -Dmaven.artifact.threads=10 -Drat.skip -DskipAdminWebTests=true  -Dtest=AlertScriptDispatcherTest -Dsurefire.failIfNoSpecifiedTests=false`

#### Before:
```
[INFO] --- maven-surefire-plugin:3.2.5:test (default-test) @ ambari-server ---
[INFO] Using auto detected provider org.apache.maven.surefire.junit4.JUnit4Provider
[INFO] 
[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Running org.apache.ambari.server.notifications.dispatchers.AlertScriptDispatcherTest
[ERROR] Tests run: 18, Failures: 0, Errors: 4, Skipped: 0, Time elapsed: 1.430 s <<< FAILURE! -- in org.apache.ambari.server.notifications.dispatchers.AlertScriptDispatcherTest
[ERROR] org.apache.ambari.server.notifications.dispatchers.AlertScriptDispatcherTest.testNonExistentScriptPath -- Time elapsed: 0.028 s <<< ERROR!
java.lang.reflect.InaccessibleObjectException: Unable to make public sun.nio.fs.UnixPath sun.nio.fs.UnixPath.getName(int) accessible: module java.base does not "opens sun.nio.fs" to unnamed module @528931cf

--------------- snip ------------------

[ERROR] Errors: 
[ERROR]   AlertScriptDispatcherTest.testArgumentEscaping:493 » InaccessibleObject Unable to make public sun.nio.fs.UnixPath sun.nio.fs.UnixPath.getName(int) accessible: module java.base does not "opens sun.nio.fs" to unnamed module @528931cf
[ERROR]   AlertScriptDispatcherTest.testNonExecutableScriptPath:137 » InaccessibleObject Unable to make public sun.nio.fs.UnixPath sun.nio.fs.UnixPath.getName(int) accessible: module java.base does not "opens sun.nio.fs" to unnamed module @528931cf
[ERROR]   AlertScriptDispatcherTest.testNonExistentScriptPath:124 » InaccessibleObject Unable to make public sun.nio.fs.UnixPath sun.nio.fs.UnixPath.getName(int) accessible: module java.base does not "opens sun.nio.fs" to unnamed module @528931cf
[ERROR]   AlertScriptDispatcherTest.testValidScriptPath:184 » InaccessibleObject Unable to make public sun.nio.fs.UnixPath sun.nio.fs.UnixPath.getName(int) accessible: module java.base does not "opens sun.nio.fs" to unnamed module @528931cf
[INFO] 
[ERROR] Tests run: 18, Failures: 0, Errors: 4, Skipped: 0
[INFO] 
[ERROR] 

```
#### After:
```
[INFO] --- maven-surefire-plugin:3.2.5:test (default-test) @ ambari-server ---
[INFO] Using auto detected provider org.apache.maven.surefire.junit4.JUnit4Provider
[INFO] 
[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Running org.apache.ambari.server.notifications.dispatchers.AlertScriptDispatcherTest
[INFO] Tests run: 18, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.280 s -- in org.apache.ambari.server.notifications.dispatchers.AlertScriptDispatcherTest
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 18, Failures: 0, Errors: 0, Skipped: 0

```
Jira: [AMBARI-26460](https://issues.apache.org/jira/browse/AMBARI-26460)