### PR TITLE
AMBARI-26458: Maven -DskipSurefireTests does not skip Java tests

### DIFF
--- a/ambari-project/pom.xml
+++ b/ambari-project/pom.xml
@@ -25,6 +25,7 @@
   <name>Apache Ambari Project POM</name>
   <packaging>pom</packaging>
   <properties>
+    <skipSurefireTests>false</skipSurefireTests>
     <skipPythonTests>false</skipPythonTests>
     <skipFunctionalTests>true</skipFunctionalTests>
     <solr.version>5.5.2</solr.version>
@@ -661,6 +662,9 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>
+          <configuration>
+            <skip>${skipSurefireTests}</skip>
+          </configuration>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
## What changes were proposed in this pull request?

The precommit test `mvn clean -am test -pl ambari-server -DskipSurefireTests -Dmaven.test.failure.ignore -Dmaven.artifact.threads=10 -Drat.skip -Dcheckstyle.skip -DskipAdminWebTests=true` is supposed to skip Java tests but doesn't.

## How was this patch tested?
Verify that Java tests are correctly skipped if -DskipSurefireTests is set.

Command:
`mvn clean -am test -pl ambari-server -DskipSurefireTests -Dmaven.test.failure.ignore -Dmaven.artifact.threads=10 -Drat.skip -Dcheckstyle.skip -DskipAdminWebTests=true` 

Take one of the `maven-surefire-plugin` as an example:
#### Before:
`ambari-utility`:
```
[INFO] --- maven-surefire-plugin:3.2.5:test (default-test) @ ambari-utility ---
[INFO] Using auto detected provider org.apache.maven.surefire.junit4.JUnit4Provider
[INFO] 
[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Running org.apache.ambari.swagger.AmbariSwaggerReaderTest
[INFO] Running org.apache.ambari.checkstyle.AvoidTransactionalOnPrivateMethodsCheckTest
[INFO] Running org.apache.ambari.checkstyle.UndocumentedRestApiOperationCheckTest
[WARNING] Tests run: 1, Failures: 0, Errors: 0, Skipped: 1, Time elapsed: 0.046 s -- in org.apache.ambari.checkstyle.UndocumentedRestApiOperationCheckTest
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.158 s -- in org.apache.ambari.checkstyle.AvoidTransactionalOnPrivateMethodsCheckTest
[ERROR] Tests run: 8, Failures: 0, Errors: 7, Skipped: 0, Time elapsed: 0.958 s <<< FAILURE! -- in org.apache.ambari.swagger.AmbariSwaggerReaderTest
[ERROR] org.apache.ambari.swagger.AmbariSwaggerReaderTest.swaggerBasicCase -- Time elapsed: 0.246 s <<< ERROR!
java.lang.NoClassDefFoundError: com/sun/jersey/api/core/InjectParam
```

#### After:
`ambari-utility`:
```
[INFO] --- maven-surefire-plugin:3.2.5:test (default-test) @ ambari-utility ---
[INFO] Tests are skipped.
```