### PR TITLE
AMBARI-26476:Precommit failed due to checkstyle error

### DIFF
--- a/ambari-server/src/test/java/org/apache/ambari/server/controller/AmbariHandlerListTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/controller/AmbariHandlerListTest.java
@@ -18,6 +18,16 @@
 
 package org.apache.ambari.server.controller;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
 import java.util.Arrays;
 import java.util.List;
 
@@ -48,16 +58,6 @@ import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.springframework.web.filter.DelegatingFilterProxy;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.atLeastOnce;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 /**
  * AmbariHandlerList tests.


### PR DESCRIPTION
## What changes were proposed in this pull request?

There are two ERRORS but one was already completed in https://github.com/apache/ambari/pull/3998/commits/bae0d724e93d16d9294460f536492284e0e438b9.
So this PR only solved :
`[ERROR] /home/jenkins/jenkins-home/workspace/bari-PreCommit-GitHub-PR_PR-3998/ambari-server/src/test/java/org/apache/ambari/server/controller/AmbariHandlerListTest.java:52: Wrong order for 'org.junit.Assert.assertEquals' import. [ImportOrder]`.


## How was this patch tested?

run `mvn -am test -pl ambari-server -DskipPythonTests -Dmaven.test.failure.ignore -Dmaven.artifact.threads=10 -Drat.skip -DskipAdminWebTests=true`


Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.