### PR TITLE
AMBARI-26479: Bump org.apache.commons:commons-compress from 1.21 to 1.26.0 in /ambari-agent

### DIFF
--- a/ambari-agent/pom.xml
+++ b/ambari-agent/pom.xml
@@ -61,7 +61,7 @@
     <commons-lang3.version>3.12.0</commons-lang3.version>
     <commons-io.version>2.14.0</commons-io.version>
     <commons-logging.version>1.1.3</commons-logging.version>
-    <commons-compress.version>1.21</commons-compress.version>
+    <commons-compress.version>1.26.0</commons-compress.version>
     <guava.version>27.0-jre</guava.version>
     <hadoop.version>3.3.4</hadoop.version>
     <hadoop-auth.version>3.3.4</hadoop-auth.version>


### PR DESCRIPTION

## What changes were proposed in this pull request?

Bumps org.apache.commons:commons-compress from 1.21 to 1.26.0.

## How was this patch tested?

`cd ambari-agent`     
`mvn dependency:tree -DignoreErrors | grep commons-compress.version`