### PR TITLE
AMBARI-26471:Python test failures: X509_V_FLAG_NOTIFY_POLICY unsupported

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -121,6 +121,13 @@ pipeline {
 
                 stage('Ambari Server PyTests') {
                     steps {
+                        sh '''
+                           # Install pyOpenSSL in one step
+                           pip3 install --user --upgrade pyOpenSSL
+                           # Verify installations
+                           pip3 --version
+                           openssl version
+                           '''
                         sh 'mvn clean -am test -pl ambari-server -DskipSurefireTests -Dmaven.test.failure.ignore -Dmaven.artifact.threads=10 -Drat.skip -Dcheckstyle.skip -DskipAdminWebTests=true'
                     }
                 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

This pull request upgrades `pip3`, `pyOpenSSL`, and their dependencies, including `cryptography`, to ensure compatibility and security improvements.

## How was this patch tested?

The changes were tested successfully using `pytest`, as verified by the Jenkins build: [PR-3998 Build #15](https://ci-hadoop.apache.org/job/Ambari/job/Ambari-PreCommit-GitHub-PR/job/PR-3998/15/console).
Thanks lot to @jojochuang for his support.

Please review the [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before submitting a pull request.