### PR TITLE
AMBARI-26466: WidgetResourceProviderTest.testUpdateResources fails due to Jakarta Persistence API update

### DIFF
--- a/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/WidgetResourceProviderTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/WidgetResourceProviderTest.java
@@ -361,7 +361,13 @@ public class WidgetResourceProviderTest {
     Assert.assertFalse(oldName.equals(entity.getWidgetName()));
     Assert.assertFalse(oldMetrics.equals(entity.getMetrics()));
     Assert.assertFalse(oldProperties.equals(entity.getProperties()));
-    Assert.assertEquals("[{\"name\":\"new_value\",\"new_name\":\"new_value2\"}]",entity.getMetrics());
+    Assert.assertEquals("[\n" +
+            "  {\n" +
+            "    \"name\": \"new_value\",\n" +
+            "    \"new_name\": \"new_value2\"\n" +
+            "  }\n" +
+            "]",entity.getMetrics());
+
     // Depends on hashing, string representation can be different
     Assert.assertTrue(CollectionPresentationUtils.isJsonsEquals("{\"new_property\":\"new_value2\",\"property1\":\"new_value1\"}", entity.getProperties()));
     Assert.assertEquals("widget name2",entity.getWidgetName());


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix precommit failure in the Java test org.apache.ambari.server.controller.internal.WidgetResourceProviderTest

## How was this patch tested?
Command:
```
mvn -am test -pl ambari-server -DskipPythonTests -Dmaven.test.failure.ignore -Dmaven.artifact.threads=10 -Drat.skip -DskipAdminWebTests=true
```

### Before
```
[ERROR] Tests run: 7, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 2.809 s <<< FAILURE! -- in org.apache.ambari.server.controller.internal.WidgetResourceProviderTest
[ERROR] org.apache.ambari.server.controller.internal.WidgetResourceProviderTest.testUpdateResources -- Time elapsed: 0.061 s <<< FAILURE!
org.junit.ComparisonFailure: 
expected:<[[{"name":"new_value","new_name":"new_value2"}]]> but was:<[[
  {
    "name": "new_value",
    "new_name": "new_value2"
  }
]]>
	at org.junit.Assert.assertEquals(Assert.java:125)
	at org.junit.Assert.assertEquals(Assert.java:147)
```
### After
```
[INFO] Running org.apache.ambari.server.controller.internal.WidgetResourceProviderTest
[INFO] Tests run: 26, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.075 s -- in org.apache.ambari.server.controller.internal.ServiceResourceProviderTest
```