### PR TITLE
AMBARI-26516 : Ambari Agent hung when ambari server sends agent resta…

### DIFF
--- a/ambari-agent/src/main/python/ambari_agent/Utils.py
+++ b/ambari-agent/src/main/python/ambari_agent/Utils.py
@@ -162,11 +162,12 @@ class Utils(object):
 
   @staticmethod
   def restartAgent(stop_event, graceful_stop_timeout=30):
-    ExitHelper().exitcode = AGENT_AUTO_RESTART_EXIT_CODE
+    exit_helper = ExitHelper()
+    exit_helper.exitcode = AGENT_AUTO_RESTART_EXIT_CODE
     stop_event.set()
 
     t = threading.Timer(
-      graceful_stop_timeout, ExitHelper().exit, [AGENT_AUTO_RESTART_EXIT_CODE]
+      graceful_stop_timeout, exit_helper.exit
     )
     t.start()
 


### PR DESCRIPTION
…rt action

## What changes were proposed in this pull request?

Bug in the ExitHelper(), it will not consume any parameter. But in threading.Timer, parameter is passed which is causing issue. As part of this change, Actual bug is getting addressed. exitcode is set in class parameter and method "exit" called without any param

## How was this patch tested?

Seen the issue in cluster and validated the same by applying the proposed fix in python file

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.