### PR TITLE
AMBARI-26517 : Avoid printing password during DB connection check

### DIFF
--- a/ambari-server/src/main/resources/custom_actions/scripts/check_host.py
+++ b/ambari-server/src/main/resources/custom_actions/scripts/check_host.py
@@ -597,7 +597,7 @@ class CheckHost(Script):
 
     if isinstance(db_connection_check_command, str):
       code, out = shell.call(
-        split(db_connection_check_command, comments=True), shell=False
+        split(db_connection_check_command, comments=True), shell=False, quiet=True
       )
     else:
       code, out = shell.call(db_connection_check_command, shell=False)


### PR DESCRIPTION
## What changes were proposed in this pull request?
check_host class uses shlex.split to sanitise the user input. When db_connection_check_command is sanitised, mask password property is lost. 

Proposed:
We don't need to print the command when running the check. Incase of connection error, Appropriate error will get printed without password


## How was this patch tested?
Before Fix
![before_fix](https://github.com/user-attachments/assets/e41fdbae-2717-45ae-8af8-6015f17887f7)

After Fix
![after_fix](https://github.com/user-attachments/assets/5c0f8dfd-eb5d-4e65-b5a9-c7c5b5b0f924)


Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.