### PR TITLE
Ambari-26513: Added Scrolling Functionality in Sidebar Navigation Using Flex

### DIFF
--- a/ambari-web/app/styles/theme/bootstrap-ambari.css
+++ b/ambari-web/app/styles/theme/bootstrap-ambari.css
@@ -906,6 +906,8 @@ th[data-qa="confirm-hosts-table-heading-cell"] label[checked="checked"]:after {
 .navigation-bar-container {
   height: auto;
   width: 230px;
+  display: flex;
+  flex-direction: column;
   background-color: #323544;
   padding: 0;
   -ms-overflow-style: none;
@@ -914,6 +916,7 @@ th[data-qa="confirm-hosts-table-heading-cell"] label[checked="checked"]:after {
 }
 .navigation-bar-container ul.nav.side-nav-header {
   width: 230px;
+  max-height: 50px;
   transition: width 0.5s ease-out;
 }
 .navigation-bar-container ul.nav.side-nav-header li.navigation-header {
@@ -983,6 +986,12 @@ th[data-qa="confirm-hosts-table-heading-cell"] label[checked="checked"]:after {
   background-color: #323544;
   width: 230px;
   transition: width 0.5s ease-out;
+}
+.navigation-bar-container ul.nav.side-nav-menu{
+  max-height: calc(100vh - 110px); 
+}
+.navigation-bar-container ul.nav.side-nav-footer{
+  max-height: 50px;
 }
 .navigation-bar-container ul.nav.side-nav-menu li,
 .navigation-bar-container ul.nav.side-nav-footer li {
@@ -1334,17 +1343,19 @@ th[data-qa="confirm-hosts-table-heading-cell"] label[checked="checked"]:after {
   z-index: 2079;
 }
 .navigation-bar-fit-height .side-nav-header {
-  position: absolute;
-  top: 0;
+  /* position: absolute; */
+  /* top: 0; */
 }
 .navigation-bar-fit-height .side-nav-menu {
-  position: absolute;
-  top: 55px;
+  /* position: absolute; */
+  /* top: 55px; */
 }
 .navigation-bar-fit-height .side-nav-footer {
-  position: absolute;
+  /* position: absolute; */
+  position: fixed;
   bottom: 0;
 }
+
 .navigation-bar-fit-height .more-actions .dropdown-menu {
   position: fixed;
   top: auto;


### PR DESCRIPTION
Ambari-26513 : When there are many components on the left side, there is no scrollbar

Problem
When the sidebar contains too many components, it previously did not scroll, causing the overflowed elements to be cut off and inaccessible.

Solution:
1. Refactored the sidebar layout using Flexbox to ensure proper height management and scroll behavior:

2. Applied display: flex and flex-direction: column to .navigation-bar-container to lay out the sidebar in vertical sections.

3. Assigned max-height to .side-nav-header and .side-nav-footer to restrict their height.

4. Set max-height: calc(100vh - 110px) on .side-nav-menu to allow scrolling while reserving space for the header and footer.

5. Changed .side-nav-footer to use position: fixed so it stays at the bottom regardless of scroll.

6. Commented out conflicting position: absolute styles in .navigation-bar-fit-height. (I dont think it is required if it is I have commented out for now. Will remove it if it's not required).



[Screencast from 2025-06-16 16-51-53.webm](https://github.com/user-attachments/assets/5d4a4414-07b9-4b0b-9759-d302e38dd155)
[Screencast from 2025-06-16 17-11-45.webm](https://github.com/user-attachments/assets/d8f9ccb7-189c-449a-ab2b-97f1788f2604)


Result: 
The sidebar now gracefully scrolls when content exceeds the visible area, ensuring all components are accessible at all times.