### PR TITLE
AMBARI-26520 : Fix deprecated usage string.uppercase

### DIFF
--- a/ambari-server/src/main/resources/host_scripts/alert_disk_space.py
+++ b/ambari-server/src/main/resources/host_scripts/alert_disk_space.py
@@ -185,7 +185,7 @@ def _get_disk_usage(path=None):
   free = 0
   drives = []
   bitmask = ctypes.windll.kernel32.GetLogicalDrives()
-  for letter in string.uppercase:
+  for letter in string.ascii_uppercase:
     if bitmask & 1:
       drives.append(letter)
     bitmask >>= 1


### PR DESCRIPTION
## What changes were proposed in this pull request?

AMBARI-26520 : Fix deprecated usage string.uppercase

## How was this patch tested?

```bash
Python 2.7.5 (default, Nov 14 2023, 16:14:06)
[GCC 4.8.5 20150623 (Red Hat 4.8.5-44)] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> import string
>>> string.ascii_uppercase
'ABCDEFGHIJKLMNOPQRSTUVWXYZ'
>>> string.uppercase
'ABCDEFGHIJKLMNOPQRSTUVWXYZ'
 
Python 3.6.8 (default, Nov 14 2023, 16:29:52)
[GCC 4.8.5 20150623 (Red Hat 4.8.5-44)] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import string
>>>
>>> import string
>>> string.ascii_uppercase
'ABCDEFGHIJKLMNOPQRSTUVWXYZ'
>>> string.uppercase
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
AttributeError: module 'string' has no attribute 'uppercase'
>>>
 
Python 3.11.11 (main, Dec 12 2024, 16:28:23) [GCC 8.5.0 20210514 (Red Hat 8.5.0-22)] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import string
>>> string.ascii_uppercase
'ABCDEFGHIJKLMNOPQRSTUVWXYZ'
>>>
>>> string.uppercase
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
AttributeError: module 'string' has no attribute 'uppercase'
>>>
>>> 
```