### PR TITLE
AMBARI-26528: Add build.os_arch params to support aarch64

### DIFF
--- a/ambari-agent/pom.xml
+++ b/ambari-agent/pom.xml
@@ -422,7 +422,7 @@
             <fileEncoding>utf-8</fileEncoding>
           </postremoveScriptlet>
 
-          <needarch>x86_64</needarch>
+	  <needarch>${build.os_arch}</needarch>
           <autoRequires>false</autoRequires>
           <mappings>
             <mapping>

--- a/ambari-project/pom.xml
+++ b/ambari-project/pom.xml
@@ -25,6 +25,7 @@
   <name>Apache Ambari Project POM</name>
   <packaging>pom</packaging>
   <properties>
+    <build.os_arch>x86_64</build.os_arch>
     <skipSurefireTests>false</skipSurefireTests>
     <skipPythonTests>false</skipPythonTests>
     <skipFunctionalTests>true</skipFunctionalTests>

--- a/ambari-server/pom.xml
+++ b/ambari-server/pom.xml
@@ -609,7 +609,7 @@
             <scriptFile>src/main/package/rpm/postremove.sh</scriptFile>
             <fileEncoding>utf-8</fileEncoding>
           </postremoveScriptlet>
-          <needarch>x86_64</needarch>
+	  <needarch>${build.os_arch}</needarch>
           <mappings>
             <mapping>
               <directory>/etc</directory>


### PR DESCRIPTION
## What changes were proposed in this pull request?

add build.os_arch params, default value: x86_64

when build rpm  on arm(aarch64) platform , can use this command :
mvn -B -T 2C clean install package rpm:rpm \
    -Drat.skip=true \
    -DskipTests \
    -Dmaven.test.skip=true \
    -Dfindbugs.skip=true \
    -Dcheckstyle.skip=true \
    -Dbuild.os_arch=aarch64

## How was this patch tested?

mvn -B -T 2C clean install package rpm:rpm \
    -Drat.skip=true \
    -DskipTests \
    -Dmaven.test.skip=true \
    -Dfindbugs.skip=true \
    -Dcheckstyle.skip=true \
    -Dbuild.os_arch=aarch64


Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.