### PR TITLE
AMBARI-26530: Allow Jetty to serve symlinked resource files

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/AmbariServer.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/AmbariServer.java
@@ -148,12 +148,14 @@ import org.eclipse.jetty.server.handler.RequestLogHandler;
 import org.eclipse.jetty.server.handler.gzip.GzipHandler;
 import org.eclipse.jetty.server.session.DefaultSessionIdManager;
 import org.eclipse.jetty.server.session.SessionHandler;
+import org.eclipse.jetty.server.SymlinkAllowedResourceAliasChecker;
 import org.eclipse.jetty.servlet.DefaultServlet;
 import org.eclipse.jetty.servlet.FilterHolder;
 import org.eclipse.jetty.servlet.ServletContextHandler;
 import org.eclipse.jetty.servlet.ServletHolder;
 import org.eclipse.jetty.util.ssl.SslContextFactory;
 import org.eclipse.jetty.util.thread.QueuedThreadPool;
+import org.eclipse.jetty.util.resource.Resource;
 import org.eclipse.jetty.websocket.server.config.JettyWebSocketServletContainerInitializer;
 import org.glassfish.jersey.server.ResourceConfig;
 import org.glassfish.jersey.servlet.ServletContainer;
@@ -520,6 +522,10 @@ public class AmbariServer {
       resources.setInitParameter("dirAllowed", "false");
       root.addServlet(resources, "/resources/*");
       resources.setInitOrder(5);
+
+      // Allow symlinked files in Jetty 11
+      Resource baseResource = Resource.newResource(resourcesDirectory.getParentFile().getAbsolutePath());
+      root.addAliasCheck(new SymlinkAllowedResourceAliasChecker(root, baseResource));
 
       if (configs.csrfProtectionEnabled()) {
         sh.setInitParameter("org.glassfish.jersey.server.ContainerRequestFilter",


### PR DESCRIPTION
## What changes were proposed in this pull request?
- Allow symlinked files in Jetty 11 to resolve the mpack installation failure on the Ambari UI web.
```
#Error message
WARNING 2025-07-16 01:34:12,850 FileCache.py:229 - Error occurred during cache update. Error tolerate setting is set to true, so ignoring this error and continuing with current cache. Error details: Can not download file from url https://rocky8tpl:8446/resources/common-services/AIRFLOW/2.8.3/package/.hash : HTTP Error 404: Not Found 
```
- JIRA Ticket: https://issues.apache.org/jira/browse/AMBARI-26530

## How was this patch tested?
- Manually tested by installing mpack via Ambari UI web.
