### PR TITLE
AMBARI-26531: Restore java_exec in infra_solr.py

### DIFF
--- a/ambari-server/src/main/resources/common-services/AMBARI_INFRA_SOLR/3.0.0/package/scripts/infra_solr.py
+++ b/ambari-server/src/main/resources/common-services/AMBARI_INFRA_SOLR/3.0.0/package/scripts/infra_solr.py
@@ -174,7 +174,7 @@ class InfraSolr(Script):
       return
     zkmigrator = ZkMigrator(
       zk_host=params.zk_quorum,
-      java_exec=params.ambari_java_home,
+      java_exec=params.ambari_java_exec,
       java_home=params.ambari_java_home,
       jaas_file=params.infra_solr_jaas_file,
       user=params.infra_solr_user,


### PR DESCRIPTION
## What changes were proposed in this pull request?
- Revert incorrect java_exec setting in `infra_solr.py` from PR https://github.com/apache/ambari/pull/3951
- Infra_solr was using `java_home` instead of `java_exec` when starting.
- Jira ticket: https://issues.apache.org/jira/browse/AMBARI-26531

## How was this patch tested?
- Manually confirmed on rocky8 with JDK 17.