### PR TITLE
AMBARI-26538: Fix KeyError by initializing stack_version before use

### DIFF
--- a/ambari-common/src/main/python/resource_management/libraries/functions/setup_ranger_plugin_xml.py
+++ b/ambari-common/src/main/python/resource_management/libraries/functions/setup_ranger_plugin_xml.py
@@ -79,6 +79,11 @@ def setup_ranger_plugin(
   cred_setup_prefix_override=None,
   plugin_home=None,
 ):
+  if stack_version_override is None:
+    stack_version = get_stack_version(component_select_name)
+  else:
+    stack_version = stack_version_override
+
   if not plugin_home:
     stack_root = Script.get_stack_root()
     service_name = str(service_name).lower()
@@ -113,11 +118,6 @@ def setup_ranger_plugin(
 
   if policymgr_mgr_url.endswith("/"):
     policymgr_mgr_url = policymgr_mgr_url.rstrip("/")
-
-  if stack_version_override is None:
-    stack_version = get_stack_version(component_select_name)
-  else:
-    stack_version = stack_version_override
 
   component_conf_dir = conf_dict
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
Jira Ticket: https://issues.apache.org/jira/browse/AMBARI-26538
The variable stack_version is used before initialization, which throws an error when using Ranger.

```
# ambari-common/src/main/python/resource_management/libraries/functions/setup_ranger_plugin_xml.py

def setup_ranger_plugin(...):
if not plugin_home:
  stack_root = Script.get_stack_root()
  service_name = str(service_name).lower()
  plugin_home = format("{stack_root}/{stack_version}/ranger-{service_name}-plugin/")

#...

if stack_version_override is None:
  stack_version = get_stack_version(component_select_name)
else:
  stack_version = stack_version_override
```

## How was this patch tested?

Locally tested