### PR TITLE
AMBARI-26545: Fix rolling restart: use Response.readEntity(String) in ExecutionScheduleManager

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/scheduler/ExecutionScheduleManager.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/scheduler/ExecutionScheduleManager.java
@@ -738,7 +738,7 @@ public class ExecutionScheduleManager {
 
     batchRequestResponse.setReturnCode(retCode);
 
-    String responseString = (String) clientResponse.getEntity();
+    String responseString = clientResponse.readEntity(String.class);
     LOG.debug("Processing API response: status={}, body={}", retCode, responseString);
     Map<String, Object> httpResponseMap;
     try {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Rolling restart batches could fail to chain because the request metadata was not parsed from the Ambari API response.

**Root cause**
`ExecutionScheduleManager.convertToBatchRequestResponse()` used `Response#getEntity()`. With Jakarta/Jersey this often returns `null` (or an unreadable stream), so `"Requests.id"` / `"request_status"` were not parsed.

**Minimal fix (one line)**
```diff
--- a/ambari-server/src/main/java/org/apache/ambari/server/scheduler/ExecutionScheduleManager.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/scheduler/ExecutionScheduleManager.java
@@ -... +...
-    String responseString = (String) clientResponse.getEntity();
+    String responseString = clientResponse.readEntity(String.class);
```

## How was this patch tested :
- Local env: macOS (Apple Silicon M1), JDK 17.

## Targeted unit tests:
```diff
mvn -pl ambari-server \
  -Dtest='**/scheduler/**/*Test.java' \
  -DfailIfNoTests=false -DforkCount=1 -DreuseForks=false \
  org.apache.maven.plugins:maven-surefire-plugin:test
```





