### PR TITLE
AMBARI-26380: Ambari Web React: Kerberos Wizard - Step3: install & Test kerberos client and Step6 Stop Services

### DIFF
--- a/ambari-web/latest/src/screens/KerberosWizard/StartAndTestKerberosClient.tsx
+++ b/ambari-web/latest/src/screens/KerberosWizard/StartAndTestKerberosClient.tsx
@@ -1,0 +1,156 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useContext, useEffect, useState } from "react";
+import { Alert } from "react-bootstrap";
+import { AppContext } from "../../store/context";
+import { translate } from "../../Utils/Utility";
+import { get } from "lodash";
+import { EnableKerberosContext } from "./KerberosStore/context";
+import { RequestApi } from "../../api/requestApi";
+import OperationsProgress from "../../components/OperationProgress";
+import { ActionTypes } from "./KerberosStore/types";
+import WizardFooter from "../../components/StepWizard/WizardFooter";
+
+export default function StartAndTestKerberosClient() {
+
+  const {
+    state,
+    dispatch,
+    flushStateToDb,
+    onExitPopUp,
+    stepWizardUtilities: { currentStep, wizardSteps, handleNextImperitive, handleBackImperitive},
+  } = useContext(EnableKerberosContext);
+
+  const [ completionStatus, setCompletionStatus ] = useState(false);
+  const [ nextEnabled, setNextEnabled ] = useState(true)
+  const { clusterName } = useContext(AppContext);
+
+  useEffect(() => {
+    if(completionStatus) {
+      setNextEnabled(true);
+    }
+  }, [ completionStatus ]);
+
+  const operations = [
+    {
+      id: 1,
+      label: "Install Kerberos Client",
+      skippable: false,
+      context: "Install Kerberos Service",
+      callback: async () => {
+        const installKerberosClientPayload =
+        {
+          "RequestInfo": {
+              "context": "Install Kerberos Service",
+              "operation_level": {
+                  "level": "CLUSTER",
+                  "cluster_name": `${clusterName}`
+              }
+          },
+          "Body": {
+              "ServiceInfo": {
+                  "state": "INSTALLED"
+              }
+          }
+      }
+      const requestData = await RequestApi.performRequests(
+        clusterName,
+        installKerberosClientPayload
+      );
+      
+      return requestData;
+      },
+    },
+    {
+      id: 2,
+      label: "Test Kerberos Client",
+      skippable: false,
+      context: "Kerberos Service Check",
+      callback: async () => {
+        const TestKerberosClientPayload = {
+          "RequestInfo": {
+            "context": "Kerberos Service Check",
+            "command": "KERBEROS_SERVICE_CHECK",
+            "operation_level": {
+              "level": "CLUSTER",
+              "cluster_name": `${clusterName}`
+            }
+          },
+          "Requests/resource_filters": [
+            {
+                "service_name": "KERBEROS"
+            }
+          ]
+        }
+        const requestData = await RequestApi.postRequest(
+          clusterName,
+          TestKerberosClientPayload
+        );
+        return requestData;
+      },
+    },
+  ];
+
+  return (
+    <>
+      { completionStatus &&
+        <Alert variant="success">{translate("admin.kerberos.wizard.step3.notice.completed")}</Alert>
+      }
+      <OperationsProgress
+        operations={
+          (get(
+            state,
+            `kerberosWizardSteps.${wizardSteps[3].name}.data.operationsState`,
+            null
+          ) as any) ||
+          (operations as any)}
+        title="Install and Test Kerberos Client"
+        description="Install and Test Kerberos Client"
+        setCompletionStatus={setCompletionStatus}
+        dispatch={(operationsState: any) => {
+          dispatch({
+            type: ActionTypes.STORE_INFORMATION,
+            payload: {
+              step: currentStep.name,
+              data: {
+                operationsState,
+              },
+            },
+          });
+        }}
+      />
+
+      <WizardFooter
+        isNextEnabled={nextEnabled}
+        step={currentStep}
+        onNext={() => {
+            flushStateToDb("next");
+            handleNextImperitive();
+        }}
+        onCancel={() => {
+          onExitPopUp(false, false);
+        }}
+        onBack={() => {
+          flushStateToDb("back");
+          handleBackImperitive();
+        }}
+      />
+    </>
+  );
+}

--- a/ambari-web/latest/src/screens/KerberosWizard/StopServices.tsx
+++ b/ambari-web/latest/src/screens/KerberosWizard/StopServices.tsx
@@ -1,0 +1,125 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useContext, useEffect, useState } from "react";
+import WizardFooter from "../../components/StepWizard/WizardFooter";
+import { AppContext } from "../../store/context";
+import { Alert } from "react-bootstrap";
+import { translate } from "../../Utils/Utility";
+import { get } from "lodash";
+import { EnableKerberosContext } from "./KerberosStore/context";
+import { RequestApi } from "../../api/requestApi";
+import OperationsProgress from "../../components/OperationProgress";
+import { ActionTypes } from "./KerberosStore/types";
+
+export default function StopServices() {
+  const {
+    state,
+    dispatch,
+    flushStateToDb,
+    onExitPopUp,
+    stepWizardUtilities: { wizardSteps, currentStep, handleNextImperitive, handleBackImperitive},
+  } = useContext(EnableKerberosContext);
+
+  const [completionStatus, setCompletionStatus] = useState(false);
+  const [nextEnabled, setNextEnabled] = useState(false);
+  const { clusterName } = useContext(AppContext);
+
+  useEffect(() => {
+    if (completionStatus) {
+      setNextEnabled(true);
+    }
+  }, [completionStatus]);
+
+  const operations = [
+    {
+      id: "1",
+      label: "Stop services",
+      skippable: false,
+      context: "Stop services",
+      callback: async () => {
+        const stopServicesPayload = {
+          RequestInfo: {
+            context: "Stop services",
+            operation_level: {
+              level: "CLUSTER",
+              cluster_name: `${clusterName}`,
+            },
+          },
+          Body: {
+            ServiceInfo: {
+              state: "INSTALLED",
+            },
+          },
+        };
+
+        const requestData = await RequestApi.stopServices(
+          clusterName,
+          stopServicesPayload
+        );
+        return requestData;
+      },
+    },
+  ];
+
+  return (
+    <>
+      { completionStatus &&
+        <Alert variant="success">{translate("admin.kerberos.wizard.step6.notice.completed")}</Alert>
+      }
+      <OperationsProgress
+        operations={
+          (get(
+            state,
+            `kerberosWizardSteps.${wizardSteps[6].name}.data.operationsState`,
+            null
+          ) as any) ||
+          (operations as any)}
+        title="Stop services"
+        description="Stop services"
+        setCompletionStatus={setCompletionStatus}
+        dispatch={(operationsState: any) => {
+          dispatch({
+            type: ActionTypes.STORE_INFORMATION,
+            payload: {
+              step: currentStep.name,
+              data: {
+                operationsState,
+              },
+            },
+          });
+        }}
+      />
+      <WizardFooter
+        isNextEnabled={nextEnabled}
+        step={currentStep}
+        onNext={() => {
+          flushStateToDb("next");
+          handleNextImperitive();
+        }}
+        onCancel={() => {
+          onExitPopUp(false, false);
+        }}
+        onBack={() => {
+          flushStateToDb("back");
+          handleBackImperitive();
+        }}
+      />
+    </>
+  );
+}

--- a/ambari-web/latest/src/screens/KerberosWizard/kerberosWizardSteps.tsx
+++ b/ambari-web/latest/src/screens/KerberosWizard/kerberosWizardSteps.tsx
@@ -16,6 +16,8 @@
  * limitations under the License.
  */
 
+import StartAndTestKerberosClient from "./StartAndTestKerberosClient";
+
 export default {
   1: {
     label: "Get Started",
@@ -53,7 +55,7 @@ export default {
   3: {
     label: "Install and Test Kerberos Client",
     completed: false,
-    Component: <h1>Install and Test kerberos client</h1>,
+    Component: <StartAndTestKerberosClient />,
     canGoBack: true,
     isNextEnabled: false,
     name: "INSTALL_AND_TEST_KERBEROS_CLIENT",

--- a/ambari-web/latest/src/screens/KerberosWizard/kerberosWizardSteps.tsx
+++ b/ambari-web/latest/src/screens/KerberosWizard/kerberosWizardSteps.tsx
@@ -17,6 +17,7 @@
  */
 
 import StartAndTestKerberosClient from "./StartAndTestKerberosClient";
+import StopServices from "./StopServices";
 
 export default {
   1: {
@@ -97,7 +98,7 @@ export default {
   6: {
     label: "Stop Services",
     completed: false,
-    Component: <h1>Stop services</h1>,
+    Component: <StopServices />,
     canGoBack: true,
     isNextEnabled: true,
     name: "STOP_SERVICES",


### PR DESCRIPTION
AMBARI-26380: Ambari Web React: Kerberos Wizard - Step3: install & Test kerberos client and Step6 Stop Services
## What changes were proposed in this pull request?
react implementation of step3 and step6 of kerberos wizard

(Please fill in changes proposed in this fix)

## How was this patch tested?
tested on local cluster.
<img width="632" height="143" alt="image" src="https://github.com/user-attachments/assets/81b9e743-bc9c-4ba3-9cbf-02ca8adeb07e" />


Merge after 
https://github.com/apache/ambari/pull/4052

(Please explain how this patch was tested. Ex: unit tests, manual tests)
(If this patch involves UI changes, please attach a screen-shot; otherwise, remove this)

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.