### PR TITLE
AMBARI-26546: Disable hostname verifier in ExecutionScheduleManager

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/scheduler/ExecutionScheduleManager.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/scheduler/ExecutionScheduleManager.java
@@ -189,17 +189,7 @@ public class ExecutionScheduleManager {
 
       //Install all trusting cert SSL context for jersey client
       ClientConfig config = new ClientConfig();
-      /*config.getProperties().put(HTTPSProperties.PROPERTY_HTTPS_PROPERTIES, new HTTPSProperties(
-        new HostnameVerifier() {
-          @Override
-          public boolean verify( String s, SSLSession sslSession ) {
-            return true;
-          }
-        },
-        sc
-      ));*/
-
-      client = ClientBuilder.newBuilder().sslContext(sc).withConfig(config)
+      client = ClientBuilder.newBuilder().sslContext(sc).hostnameVerifier((hostname, session) -> true).withConfig(config)
               .build();
 
     } else {


### PR DESCRIPTION
## What changes were proposed in this pull request?
When SSL is enabled for Ambari, And batch restart request is triggered(Service level slave component restarts. Example datanode rolling restart), Batch execution is failed except for the 1st batch. This is because in a SSL enabled environment, When hitting localhost, hostname verification is failing. 

Proposed Fix: Hostname verification is not required for internal API call. It was already disabled in previous versions of Ambari, As part of JDK 17 support, This code was commented out

## How was this patch tested?

Applied the fix in SSL enabled enviroment and verified its working.

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.