### PR TITLE
AMBARI-26552: Upgrade service version to Bigtop 3.4.0

### DIFF
--- a/ambari-server/src/main/resources/stacks/BIGTOP/3.4.0/blueprints/multinode-default.json
+++ b/ambari-server/src/main/resources/stacks/BIGTOP/3.4.0/blueprints/multinode-default.json
@@ -1,0 +1,107 @@
+{
+  "configurations": [
+  ],
+  "host_groups": [
+    {
+      "name": "master_1",
+      "components": [
+        {
+          "name": "NAMENODE"
+        },
+        {
+          "name": "ZOOKEEPER_SERVER"
+        },
+        {
+          "name": "HDFS_CLIENT"
+        },
+        {
+          "name": "YARN_CLIENT"
+        }
+      ],
+      "cardinality": "1"
+    },
+    {
+      "name": "master_2",
+      "components": [
+        {
+          "name": "ZOOKEEPER_CLIENT"
+        },
+        {
+          "name": "HISTORYSERVER"
+        },
+        {
+          "name": "SECONDARY_NAMENODE"
+        },
+        {
+          "name": "HDFS_CLIENT"
+        },
+        {
+          "name": "YARN_CLIENT"
+        },
+        {
+          "name": "POSTGRESQL_SERVER"
+        }
+      ],
+      "cardinality": "1"
+    },
+    {
+      "name": "master_3",
+      "components": [
+        {
+          "name": "RESOURCEMANAGER"
+        },
+        {
+          "name": "ZOOKEEPER_SERVER"
+        }
+      ],
+      "cardinality": "1"
+    },
+    {
+      "name": "master_4",
+      "components": [
+        {
+          "name": "ZOOKEEPER_SERVER"
+        }
+      ],
+      "cardinality": "1"
+    },
+    {
+      "name": "slave",
+      "components": [
+        {
+          "name": "NODEMANAGER"
+        },
+        {
+          "name": "DATANODE"
+        }
+      ],
+      "cardinality": "${slavesCount}"
+    },
+    {
+      "name": "gateway",
+      "components": [
+        {
+          "name": "AMBARI_SERVER"
+        },
+        {
+          "name": "ZOOKEEPER_CLIENT"
+        },
+        {
+          "name": "HDFS_CLIENT"
+        },
+        {
+          "name": "YARN_CLIENT"
+        },
+        {
+          "name": "MAPREDUCE2_CLIENT"
+        }
+      ],
+      "cardinality": "1"
+    }
+  ],
+  "Blueprints": {
+    "blueprint_name": "blueprint-multinode-default",
+    "stack_name": "BIGTOP",
+    "stack_version": "3.4.0"
+  }
+}

--- a/ambari-server/src/main/resources/stacks/BIGTOP/3.4.0/blueprints/singlenode-default.json
+++ b/ambari-server/src/main/resources/stacks/BIGTOP/3.4.0/blueprints/singlenode-default.json
@@ -1,0 +1,65 @@
+{
+  "configurations": [
+  ],
+  "host_groups": [
+    {
+      "name": "host_group_1",
+      "components": [
+        {
+          "name": "HISTORYSERVER"
+        },
+        {
+          "name": "NAMENODE"
+        },
+        {
+          "name": "SUPERVISOR"
+        },
+        {
+          "name": "AMBARI_SERVER"
+        },
+        {
+          "name": "APP_TIMELINE_SERVER"
+        },
+        {
+          "name": "HDFS_CLIENT"
+        },
+        {
+          "name": "NODEMANAGER"
+        },
+        {
+          "name": "DATANODE"
+        },
+        {
+          "name": "RESOURCEMANAGER"
+        },
+        {
+          "name": "ZOOKEEPER_SERVER"
+        },
+        {
+          "name": "ZOOKEEPER_CLIENT"
+        },
+        {
+          "name": "SECONDARY_NAMENODE"
+        },
+        {
+          "name": "YARN_CLIENT"
+        },
+        {
+          "name": "MAPREDUCE2_CLIENT"
+        },
+        {
+          "name": "POSTGRESQL_SERVER"
+        },
+        {
+          "name": "DRPC_SERVER"
+        }
+      ],
+      "cardinality": "1"
+    }
+  ],
+  "Blueprints": {
+    "blueprint_name": "blueprint-singlenode-default",
+    "stack_name": "BIGTOP",
+    "stack_version": "3.4.0"
+  }
+}

--- a/ambari-server/src/main/resources/stacks/BIGTOP/3.4.0/metainfo.xml
+++ b/ambari-server/src/main/resources/stacks/BIGTOP/3.4.0/metainfo.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0"?>
+<!--
+   Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+<metainfo>
+    <versions>
+        <active>true</active>
+    </versions>
+    <extends>3.3.0</extends>
+</metainfo>

--- a/ambari-server/src/main/resources/stacks/BIGTOP/3.4.0/repos/repoinfo.xml
+++ b/ambari-server/src/main/resources/stacks/BIGTOP/3.4.0/repos/repoinfo.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0"?>
+<!--
+   Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+<reposinfo>
+    <os family="redhat8">
+        <repo>
+            <baseurl>https://bigtop-snapshot.s3.amazonaws.com/centos-8/$basearch</baseurl>
+            <repoid>BIGTOP-3.4.0</repoid>
+            <reponame>bigtop</reponame>
+        </repo>
+    </os>
+    <os family="redhat9">
+        <repo>
+            <baseurl>https://bigtop-snapshot.s3.amazonaws.com/centos-9/$basearch</baseurl>
+            <repoid>BIGTOP-3.4.0</repoid>
+            <reponame>bigtop</reponame>
+        </repo>
+    </os>
+    <os family="openeuler22">
+        <repo>
+            <baseurl>https://bigtop-snapshot.s3.amazonaws.com/openeuler-22/$basearch</baseurl>
+            <repoid>BIGTOP-3.4.0</repoid>
+            <reponame>bigtop</reponame>
+        </repo>
+    </os>
+</reposinfo>

--- a/ambari-server/src/main/resources/stacks/BIGTOP/3.4.0/role_command_order.json
+++ b/ambari-server/src/main/resources/stacks/BIGTOP/3.4.0/role_command_order.json
@@ -1,0 +1,193 @@
+{
+  "_comment": "Record format:",
+  "_comment": "blockedRole-blockedCommand: [blockerRole1-blockerCommand1, blockerRole2-blockerCommand2, ...]",
+  "general_deps": {
+    "_comment": "dependencies for all cases",
+    "HBASE_MASTER-START": [
+      "ZOOKEEPER_SERVER-START"
+    ],
+    "HBASE_REGIONSERVER-START": [
+      "HBASE_MASTER-START"
+    ],
+    "APP_TIMELINE_SERVER-START": [
+      "NAMENODE-START",
+      "DATANODE-START"
+    ],
+    "WEBHCAT_SERVER-START": [
+      "NODEMANAGER-START",
+      "HIVE_SERVER-START"
+    ],
+    "WEBHCAT_SERVER-RESTART": [
+      "NODEMANAGER-RESTART",
+      "HIVE_SERVER-RESTART"
+    ],
+    "HIVE_METASTORE-START": [
+      "MYSQL_SERVER-START",
+      "NAMENODE-START"
+    ],
+    "HIVE_METASTORE-RESTART": [
+      "MYSQL_SERVER-RESTART",
+      "NAMENODE-RESTART"
+    ],
+    "HIVE_SERVER-START": [
+      "NODEMANAGER-START",
+      "MYSQL_SERVER-START"
+    ],
+    "HIVE_SERVER-RESTART": [
+      "NODEMANAGER-RESTART",
+      "MYSQL_SERVER-RESTART",
+      "ZOOKEEPER_SERVER-RESTART"
+    ],
+    "MAPREDUCE_SERVICE_CHECK-SERVICE_CHECK": [
+      "NODEMANAGER-START",
+      "RESOURCEMANAGER-START"
+    ],
+    "HBASE_SERVICE_CHECK-SERVICE_CHECK": [
+      "HBASE_MASTER-START",
+      "HBASE_REGIONSERVER-START"
+    ],
+    "HIVE_SERVICE_CHECK-SERVICE_CHECK": [
+      "HIVE_SERVER-START",
+      "HIVE_METASTORE-START",
+      "WEBHCAT_SERVER-START"
+    ],
+    "ZOOKEEPER_SERVICE_CHECK-SERVICE_CHECK": [
+      "ZOOKEEPER_SERVER-START"
+    ],
+    "ZOOKEEPER_QUORUM_SERVICE_CHECK-SERVICE_CHECK": [
+      "ZOOKEEPER_SERVER-START"
+    ],
+    "ZOOKEEPER_SERVER-STOP": [
+      "HBASE_MASTER-STOP",
+      "HBASE_REGIONSERVER-STOP",
+      "METRICS_COLLECTOR-STOP",
+      "SOLR_SERVER-STOP"
+    ],
+    "HBASE_MASTER-STOP": [
+      "HBASE_REGIONSERVER-STOP"
+    ],
+    "SOLR_SERVER-START": [
+      "ZOOKEEPER_SERVER-START"
+    ]
+  },
+  "_comment": "GLUSTERFS-specific dependencies",
+  "optional_glusterfs": {
+    "HBASE_MASTER-START": [
+      "PEERSTATUS-START"
+    ],
+    "GLUSTERFS_SERVICE_CHECK-SERVICE_CHECK": [
+      "PEERSTATUS-START"
+    ]
+  },
+  "_comment": "Dependencies that are used when GLUSTERFS is not present in cluster",
+  "optional_no_glusterfs": {
+    "METRICS_COLLECTOR-START": [
+      "NAMENODE-START",
+      "DATANODE-START",
+      "SECONDARY_NAMENODE-START",
+      "ZOOKEEPER_SERVER-START"
+    ],
+    "AMBARI_METRICS_SERVICE_CHECK-SERVICE_CHECK": [
+      "METRICS_COLLECTOR-START",
+      "HDFS_SERVICE_CHECK-SERVICE_CHECK"
+    ],
+    "SECONDARY_NAMENODE-START": [
+      "NAMENODE-START"
+    ],
+    "SECONDARY_NAMENODE-RESTART": [
+      "NAMENODE-RESTART"
+    ],
+    "RESOURCEMANAGER-START": [
+      "NAMENODE-START",
+      "DATANODE-START"
+    ],
+    "NODEMANAGER-START": [
+      "NAMENODE-START",
+      "DATANODE-START",
+      "RESOURCEMANAGER-START"
+    ],
+    "HISTORYSERVER-START": [
+      "NAMENODE-START",
+      "DATANODE-START"
+    ],
+    "HBASE_MASTER-START": [
+      "NAMENODE-START",
+      "DATANODE-START"
+    ],
+    "HIVE_SERVER-START": [
+      "DATANODE-START"
+    ],
+    "WEBHCAT_SERVER-START": [
+      "DATANODE-START"
+    ],
+    "HISTORYSERVER-RESTART": [
+      "NAMENODE-RESTART"
+    ],
+    "RESOURCEMANAGER-RESTART": [
+      "NAMENODE-RESTART"
+    ],
+    "NODEMANAGER-RESTART": [
+      "NAMENODE-RESTART"
+    ],
+    "HDFS_SERVICE_CHECK-SERVICE_CHECK": [
+      "NAMENODE-START",
+      "DATANODE-START",
+      "SECONDARY_NAMENODE-START"
+    ],
+    "MAPREDUCE2_SERVICE_CHECK-SERVICE_CHECK": [
+      "NODEMANAGER-START",
+      "RESOURCEMANAGER-START",
+      "HISTORYSERVER-START",
+      "YARN_SERVICE_CHECK-SERVICE_CHECK"
+    ],
+    "YARN_SERVICE_CHECK-SERVICE_CHECK": [
+      "NODEMANAGER-START",
+      "RESOURCEMANAGER-START"
+    ],
+    "RESOURCEMANAGER_SERVICE_CHECK-SERVICE_CHECK": [
+      "RESOURCEMANAGER-START"
+    ],
+    "NAMENODE-STOP": [
+      "RESOURCEMANAGER-STOP",
+      "NODEMANAGER-STOP",
+      "HISTORYSERVER-STOP",
+      "HBASE_MASTER-STOP",
+      "METRICS_COLLECTOR-STOP"
+    ],
+    "DATANODE-STOP": [
+      "RESOURCEMANAGER-STOP",
+      "NODEMANAGER-STOP",
+      "HISTORYSERVER-STOP",
+      "HBASE_MASTER-STOP"
+    ],
+    "METRICS_GRAFANA-START": [
+      "METRICS_COLLECTOR-START"
+    ],
+    "METRICS_COLLECTOR-STOP": [
+      "METRICS_GRAFANA-STOP"
+    ]
+  },
+  "_comment": "Dependencies that are used in HA NameNode cluster",
+  "namenode_optional_ha": {
+    "NAMENODE-START": [
+      "ZKFC-START",
+      "JOURNALNODE-START",
+      "ZOOKEEPER_SERVER-START"
+    ],
+    "ZKFC-START": [
+      "ZOOKEEPER_SERVER-START"
+    ],
+    "ZKFC-STOP": [
+      "NAMENODE-STOP"
+    ],
+    "JOURNALNODE-STOP": [
+      "NAMENODE-STOP"
+    ]
+  },
+  "_comment": "Dependencies that are used in ResourceManager HA cluster",
+  "resourcemanager_optional_ha": {
+    "RESOURCEMANAGER-START": [
+      "ZOOKEEPER_SERVER-START"
+    ]
+  }
+}

--- a/ambari-server/src/main/resources/stacks/BIGTOP/3.4.0/services/AMBARI-METRICS/metainfo.xml
+++ b/ambari-server/src/main/resources/stacks/BIGTOP/3.4.0/services/AMBARI-METRICS/metainfo.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0"?>
+<!--
+   Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+<metainfo>
+    <schemaVersion>2.0</schemaVersion>
+    <services>
+        <service>
+            <name>AMBARI_METRICS</name>
+            <extends>common-services/AMBARI_METRICS/3.0.0</extends>
+        </service>
+    </services>
+</metainfo>

--- a/ambari-server/src/main/resources/stacks/BIGTOP/3.4.0/services/AMBARI_INFRA_SOLR/metainfo.xml
+++ b/ambari-server/src/main/resources/stacks/BIGTOP/3.4.0/services/AMBARI_INFRA_SOLR/metainfo.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0"?>
+<!--
+   Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+<metainfo>
+    <schemaVersion>2.0</schemaVersion>
+    <services>
+        <service>
+            <name>AMBARI_INFRA_SOLR</name>
+            <extends>common-services/AMBARI_INFRA_SOLR/3.0.0</extends>
+        </service>
+    </services>
+</metainfo>

--- a/ambari-server/src/main/resources/stacks/BIGTOP/3.4.0/services/FLINK/metainfo.xml
+++ b/ambari-server/src/main/resources/stacks/BIGTOP/3.4.0/services/FLINK/metainfo.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0"?>
+<!--
+   Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+<metainfo>
+    <schemaVersion>2.0</schemaVersion>
+    <services>
+        <service>
+            <name>FLINK</name>
+            <version>1.20.0-1</version>
+        </service>
+    </services>
+</metainfo>

--- a/ambari-server/src/main/resources/stacks/BIGTOP/3.4.0/services/HBASE/metainfo.xml
+++ b/ambari-server/src/main/resources/stacks/BIGTOP/3.4.0/services/HBASE/metainfo.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0"?>
+<!--
+   Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+<metainfo>
+    <schemaVersion>2.0</schemaVersion>
+    <services>
+        <service>
+            <name>HBASE</name>
+            <version>2.6.1-1</version>
+        </service>
+    </services>
+</metainfo>

--- a/ambari-server/src/main/resources/stacks/BIGTOP/3.4.0/services/HDFS/metainfo.xml
+++ b/ambari-server/src/main/resources/stacks/BIGTOP/3.4.0/services/HDFS/metainfo.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0"?>
+<!--
+   Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+<metainfo>
+    <schemaVersion>2.0</schemaVersion>
+    <services>
+        <service>
+            <name>HDFS</name>
+            <version>3.3.6-1</version>
+        </service>
+    </services>
+</metainfo>

--- a/ambari-server/src/main/resources/stacks/BIGTOP/3.4.0/services/HIVE/metainfo.xml
+++ b/ambari-server/src/main/resources/stacks/BIGTOP/3.4.0/services/HIVE/metainfo.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0"?>
+<!--
+   Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+<metainfo>
+    <schemaVersion>2.0</schemaVersion>
+    <services>
+        <service>
+            <name>HIVE</name>
+            <version>4.0.1-1</version>
+        </service>
+    </services>
+</metainfo>

--- a/ambari-server/src/main/resources/stacks/BIGTOP/3.4.0/services/KAFKA/metainfo.xml
+++ b/ambari-server/src/main/resources/stacks/BIGTOP/3.4.0/services/KAFKA/metainfo.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0"?>
+<!--
+   Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+<metainfo>
+    <schemaVersion>2.0</schemaVersion>
+    <services>
+        <service>
+            <name>KAFKA</name>
+            <version>3.4.1-1</version>
+        </service>
+    </services>
+</metainfo>

--- a/ambari-server/src/main/resources/stacks/BIGTOP/3.4.0/services/KERBEROS/metainfo.xml
+++ b/ambari-server/src/main/resources/stacks/BIGTOP/3.4.0/services/KERBEROS/metainfo.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0"?>
+<!--
+   Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+<metainfo>
+    <schemaVersion>2.0</schemaVersion>
+    <services>
+        <service>
+            <name>KERBEROS</name>
+            <version>1.10.3-30</version>
+        </service>
+    </services>
+</metainfo>

--- a/ambari-server/src/main/resources/stacks/BIGTOP/3.4.0/services/LIVY/metainfo.xml
+++ b/ambari-server/src/main/resources/stacks/BIGTOP/3.4.0/services/LIVY/metainfo.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0"?>
+<!--Licensed to the Apache Software Foundation (ASF) under one
+* or more contributor license agreements.  See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership.  The ASF licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+-->
+<metainfo>
+    <schemaVersion>2.0</schemaVersion>
+    <services>
+        <service>
+            <name>LIVY</name>
+            <version>0.8.0-1</version>
+        </service>
+    </services>
+</metainfo>

--- a/ambari-server/src/main/resources/stacks/BIGTOP/3.4.0/services/RANGER/metainfo.xml
+++ b/ambari-server/src/main/resources/stacks/BIGTOP/3.4.0/services/RANGER/metainfo.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0"?>
+<!--Licensed to the Apache Software Foundation (ASF) under one
+* or more contributor license agreements.  See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership.  The ASF licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+-->
+<metainfo>
+    <schemaVersion>2.0</schemaVersion>
+    <services>
+        <service>
+            <name>RANGER</name>
+            <version>2.5.0-1</version>
+        </service>
+    </services>
+</metainfo>

--- a/ambari-server/src/main/resources/stacks/BIGTOP/3.4.0/services/RANGER_KMS/metainfo.xml
+++ b/ambari-server/src/main/resources/stacks/BIGTOP/3.4.0/services/RANGER_KMS/metainfo.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0"?>
+<!--Licensed to the Apache Software Foundation (ASF) under one
+* or more contributor license agreements.  See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership.  The ASF licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+-->
+<metainfo>
+    <schemaVersion>2.0</schemaVersion>
+    <services>
+        <service>
+            <name>RANGER_KMS</name>
+            <version>2.5.0-1</version>
+        </service>
+    </services>
+</metainfo>

--- a/ambari-server/src/main/resources/stacks/BIGTOP/3.4.0/services/SOLR/metainfo.xml
+++ b/ambari-server/src/main/resources/stacks/BIGTOP/3.4.0/services/SOLR/metainfo.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0"?>
+<!--
+   Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+<metainfo>
+    <schemaVersion>2.0</schemaVersion>
+    <services>
+        <service>
+            <name>SOLR</name>
+            <version>8.11.4-1</version>
+        </service>
+    </services>
+</metainfo>

--- a/ambari-server/src/main/resources/stacks/BIGTOP/3.4.0/services/SPARK/metainfo.xml
+++ b/ambari-server/src/main/resources/stacks/BIGTOP/3.4.0/services/SPARK/metainfo.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0"?>
+<!--Licensed to the Apache Software Foundation (ASF) under one
+* or more contributor license agreements.  See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership.  The ASF licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+-->
+<metainfo>
+    <schemaVersion>2.0</schemaVersion>
+    <services>
+        <service>
+            <name>SPARK</name>
+            <version>3.5.3-1</version>
+        </service>
+    </services>
+</metainfo>

--- a/ambari-server/src/main/resources/stacks/BIGTOP/3.4.0/services/TEZ/metainfo.xml
+++ b/ambari-server/src/main/resources/stacks/BIGTOP/3.4.0/services/TEZ/metainfo.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0"?>
+<!--
+   Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+<metainfo>
+    <schemaVersion>2.0</schemaVersion>
+    <services>
+        <service>
+            <name>TEZ</name>
+            <displayName>Tez</displayName>
+            <version>0.10.4-1</version>
+        </service>
+    </services>
+</metainfo>

--- a/ambari-server/src/main/resources/stacks/BIGTOP/3.4.0/services/YARN/metainfo.xml
+++ b/ambari-server/src/main/resources/stacks/BIGTOP/3.4.0/services/YARN/metainfo.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0"?>
+<!--
+   Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+
+<metainfo>
+    <schemaVersion>2.0</schemaVersion>
+    <services>
+        <service>
+            <name>YARN</name>
+            <version>3.3.6-1</version>
+        </service>
+        <service>
+            <name>MAPREDUCE2</name>
+            <version>3.3.6-1</version>
+        </service>
+    </services>
+</metainfo>

--- a/ambari-server/src/main/resources/stacks/BIGTOP/3.4.0/services/ZEPPELIN/metainfo.xml
+++ b/ambari-server/src/main/resources/stacks/BIGTOP/3.4.0/services/ZEPPELIN/metainfo.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<metainfo>
+    <schemaVersion>2.0</schemaVersion>
+    <services>
+        <service>
+            <name>ZEPPELIN</name>
+            <version>0.11.2-1</version>
+        </service>
+    </services>
+</metainfo>

--- a/ambari-server/src/main/resources/stacks/BIGTOP/3.4.0/services/ZOOKEEPER/metainfo.xml
+++ b/ambari-server/src/main/resources/stacks/BIGTOP/3.4.0/services/ZOOKEEPER/metainfo.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0"?>
+<!--
+   Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+<metainfo>
+    <schemaVersion>2.0</schemaVersion>
+    <services>
+        <service>
+            <name>ZOOKEEPER</name>
+            <version>3.8.4-1</version>
+        </service>
+    </services>
+</metainfo>


### PR DESCRIPTION
## What changes were proposed in this pull request?
Add bigtop stack 3.4.0 files

## How was this patch tested?
I built a rockylinux-9 virtual machine cluster in the local environment and tested the installation and use of the Hadoop cluster.
<img width="1728" height="993" alt="image" src="https://github.com/user-attachments/assets/9cfec4dc-3fdc-40e6-bea2-9ebd25110d6b" />
