### PR TITLE
AMBARI-26553: Change admin_password to use str instead of unicode

### DIFF
--- a/ambari-common/src/main/python/resource_management/libraries/functions/ranger_functions_v2.py
+++ b/ambari-common/src/main/python/resource_management/libraries/functions/ranger_functions_v2.py
@@ -178,7 +178,7 @@ class RangeradminV2:
         Logger.error("Connection failed to Ranger Admin !")
     elif is_stack_supports_ranger_kerberos and is_security_enabled:
       ranger_lookup_user = "rangerlookup"
-      admin_password = unicode(admin_password)
+      admin_password = str(admin_password)
       user_resp_code = self.create_ambari_admin_user(
         ranger_lookup_user, admin_password, format("{admin_uname}:{admin_password}")
       )


### PR DESCRIPTION
## What changes were proposed in this pull request?

There are still python2 remnants.
I Found it with my kerberized ranger plugin enabled cluster.
unicode function can be replaced with str function. 

if you don't change like that, you can get error like this

```python
NameError: name 'unicode' is not defined
```

## How was this patch tested?

Manually tested.

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.