### PR TITLE
AMBARI-26560: Unable to execute alert because of mistakenly ambari-agent cache_dir

### DIFF
--- a/ambari-agent/src/main/python/ambari_agent/AmbariConfig.py
+++ b/ambari-agent/src/main/python/ambari_agent/AmbariConfig.py
@@ -107,22 +107,22 @@ class AmbariConfig:
     global content
     self.config = configparser.RawConfigParser()
     self.config.readfp(io.StringIO(content))
-    self._cluster_cache_dir = os.path.join(
-      self.cache_dir, FileCache.CLUSTER_CACHE_DIRECTORY
-    )
-    self._alerts_cachedir = os.path.join(
-      self.cache_dir, FileCache.ALERTS_CACHE_DIRECTORY
-    )
+
+    # initialize derived paths for the cache directories
+    self._recalculate_cache_paths()
+
+  def _recalculate_cache_paths(self):
+    """
+    Recalculate all cache-related paths based on the current cache_dir value.
+    Keeps derived instance variables consistent with the parser-backed `cache_dir`.
+    """
+    self._cluster_cache_dir = os.path.join(self.cache_dir, FileCache.CLUSTER_CACHE_DIRECTORY)
+    self._alerts_cachedir = os.path.join(self.cache_dir, FileCache.ALERTS_CACHE_DIRECTORY)
     self._stacks_dir = os.path.join(self.cache_dir, FileCache.STACKS_CACHE_DIRECTORY)
-    self._common_services_dir = os.path.join(
-      self.cache_dir, FileCache.COMMON_SERVICES_DIRECTORY
-    )
-    self._extensions_dir = os.path.join(
-      self.cache_dir, FileCache.EXTENSIONS_CACHE_DIRECTORY
-    )
-    self._host_scripts_dir = os.path.join(
-      self.cache_dir, FileCache.HOST_SCRIPTS_CACHE_DIRECTORY
-    )
+    self._common_services_dir = os.path.join(self.cache_dir, FileCache.COMMON_SERVICES_DIRECTORY)
+    self._extensions_dir = os.path.join(self.cache_dir, FileCache.EXTENSIONS_CACHE_DIRECTORY)
+    self._host_scripts_dir = os.path.join(self.cache_dir, FileCache.HOST_SCRIPTS_CACHE_DIRECTORY)
+
 
   def get(self, section, value, default=None):
     try:
@@ -143,6 +143,8 @@ class AmbariConfig:
 
   def setConfig(self, customConfig):
     self.config = customConfig
+    # Recalculate derived paths when the underlying parser changes
+    self._recalculate_cache_paths()
 
   def getConfig(self):
     return self.config
@@ -363,9 +365,13 @@ class AmbariConfig:
 
   def load(self, data):
     self.config = configparser.RawConfigParser(data)
+    # Recalculate derived paths after loading config data
+    self._recalculate_cache_paths()
 
   def read(self, filename):
     self.config.read(filename)
+    # Recalculate derived paths after reading configuration file
+    self._recalculate_cache_paths()
 
   def getServerOption(self, url, name, default=None):
     from ambari_agent.NetUtil import NetUtil

--- a/ambari-agent/src/test/python/ambari_agent/TestAmbariConfig.py
+++ b/ambari-agent/src/test/python/ambari_agent/TestAmbariConfig.py
@@ -18,6 +18,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+import os
+import tempfile
 from unittest import TestCase
 from ambari_agent.AmbariConfig import AmbariConfig
 import sys
@@ -63,7 +65,7 @@ class TestAmbariConfig(TestCase):
       config.remove_option("agent", AmbariConfig.COMMAND_FILE_RETENTION_POLICY_PROPERTY)
     self.assertEqual(
       config.command_file_retention_policy,
-      AmbariConfig.COMMAND_FILE_RETENTION_POLICY_KEEP,
+      AmbariConfig.COMMAND_FILE_RETENTION_POLICY_REMOVE,
     )
 
     config.set(
@@ -104,3 +106,46 @@ class TestAmbariConfig(TestCase):
       config.command_file_retention_policy,
       AmbariConfig.COMMAND_FILE_RETENTION_POLICY_KEEP,
     )
+
+  def test_cache_dir_and_derived_paths(self):
+    """
+    Test that cache_dir and derived cache paths (stacks_dir, alerts_cachedir, etc.)
+    are correctly initialized and can be individually updated via their setters.
+    """
+    config = AmbariConfig()
+
+    # Initial state - cache_dir uses built-in default (/tmp)
+    self.assertEqual(config.cache_dir, "/tmp")
+
+    # Derived paths should be based on default cache_dir (/tmp)
+    self.assertEqual(config.stacks_dir, os.path.join("/tmp", "stacks"))
+    self.assertEqual(config.alerts_cachedir, os.path.join("/tmp", "alerts"))
+    self.assertEqual(config.cluster_cache_dir, os.path.join("/tmp", "cluster_cache"))
+    self.assertEqual(config.common_services_dir, os.path.join("/tmp", "common-services"))
+    self.assertEqual(config.extensions_dir, os.path.join("/tmp", "extensions"))
+    self.assertEqual(config.host_scripts_dir, os.path.join("/tmp", "host_scripts"))
+
+    # Test that derived path setters work correctly
+    new_stacks_dir = "/custom/stacks"
+    config.stacks_dir = new_stacks_dir
+    self.assertEqual(config.stacks_dir, new_stacks_dir)
+
+    new_alerts_dir = "/custom/alerts"
+    config.alerts_cachedir = new_alerts_dir
+    self.assertEqual(config.alerts_cachedir, new_alerts_dir)
+
+    new_cluster_cache_dir = "/custom/cluster_cache"
+    config.cluster_cache_dir = new_cluster_cache_dir
+    self.assertEqual(config.cluster_cache_dir, new_cluster_cache_dir)
+
+    new_common_services_dir = "/custom/common-services"
+    config.common_services_dir = new_common_services_dir
+    self.assertEqual(config.common_services_dir, new_common_services_dir)
+
+    new_extensions_dir = "/custom/extensions"
+    config.extensions_dir = new_extensions_dir
+    self.assertEqual(config.extensions_dir, new_extensions_dir)
+
+    new_host_scripts_dir = "/custom/host_scripts"
+    config.host_scripts_dir = new_host_scripts_dir
+    self.assertEqual(config.host_scripts_dir, new_host_scripts_dir)


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix: [AMBARI-26560](https://issues.apache.org/jira/browse/AMBARI-26560)

## How was this patch tested?

Build ambari, deploy ambari, and start it.
Check the `/var/log/ambari-agent/ambari-alert.log`