### PR TITLE
AMBARI-26561: add support for $.browser

### DIFF
--- a/ambari-web/brunch-config.js
+++ b/ambari-web/brunch-config.js
@@ -49,6 +49,7 @@ module.exports.config = {
           'vendor/scripts/console-helper.js',
           'vendor/scripts/jquery-3.7.1.js',
           'vendor/scripts/jquery-migrate.js',
+          'vendor/scripts/jquery-migrate-deprecated.js',
           'vendor/scripts/handlebars-1.0.0.beta.6.js',
           'vendor/scripts/ember-latest.js',
           'vendor/scripts/ember-data-latest.js',

--- a/ambari-web/test/views/wizard/step5_view_test.js
+++ b/ambari-web/test/views/wizard/step5_view_test.js
@@ -207,6 +207,13 @@ describe('App.SelectHostView', function() {
 
   });
 
+  describe('should have jquery browser plugin', function() {
+    it('should test for both chrome and webkit', function() {
+      expect($.browser.chrome).to.be.true;
+      expect($.browser.webkit).to.be.true;
+    })
+  })
+
 });
 
 describe('App.InputHostView', function() {

--- a/ambari-web/vendor/scripts/jquery-migrate-deprecated.js
+++ b/ambari-web/vendor/scripts/jquery-migrate-deprecated.js
@@ -1,0 +1,56 @@
+(function (factory) {
+  "use strict";
+
+  if (typeof define === "function" && define.amd) {
+
+    // AMD. Register as an anonymous module.
+    define(["jquery"], function (jQuery) {
+      return factory(jQuery, window);
+    });
+  } else if (typeof module === "object" && module.exports) {
+
+    // Node/CommonJS
+    // eslint-disable-next-line no-undef
+    module.exports = factory(require("jquery"), window);
+  } else {
+
+    // Browser globals
+    factory(jQuery, window);
+  }
+})(function (jQuery, window) {
+  "use strict";
+  jQuery.uaMatch = function (ua) {
+    ua = ua.toLowerCase();
+
+    var match = /(chrome)[ \/]([\w.]+)/.exec(ua) ||
+        /(webkit)[ \/]([\w.]+)/.exec(ua) ||
+        /(opera)(?:.*version|)[ \/]([\w.]+)/.exec(ua) ||
+        /(msie) ([\w.]+)/.exec(ua) ||
+        ua.indexOf("compatible") < 0 && /(mozilla)(?:.*? rv:([\w.]+)|)/.exec(ua)
+        ||
+        [];
+
+    return {
+      browser: match[1] || "",
+      version: match[2] || "0"
+    };
+  };
+
+  var matched = jQuery.uaMatch(navigator.userAgent);
+  var browser = {};
+
+  if (matched.browser) {
+    browser[matched.browser] = true;
+    browser.version = matched.version;
+  }
+
+// Chrome is Webkit, but Webkit is also Safari.
+  if (browser.chrome) {
+    browser.webkit = true;
+  } else if (browser.webkit) {
+    browser.safari = true;
+  }
+
+  jQuery.browser = browser;
+  return jQuery;
+});


### PR DESCRIPTION
## What changes were proposed in this pull request?

This issue happens when there are more than 25 hosts.

Have add support for $.browser in a new JS called jquery-migrate-deprecated.js

## How was this patch tested?
Before:
<img width="1652" height="916" alt="Screenshot 2025-12-04 at 1 55 04 PM" src="https://github.com/user-attachments/assets/296b53de-2265-4e4f-a31e-2be365c65baf" />

After:
<img width="1645" height="673" alt="Screenshot 2025-12-04 at 1 54 20 PM" src="https://github.com/user-attachments/assets/d3833a34-cae7-482f-8e19-a04d5d722d19" />
