### PR TITLE
AMBARI-26562: Fix UT failure in Kerberos Step2 Controller

### DIFF
--- a/ambari-web/app/controllers/main/admin/kerberos/step2_controller.js
+++ b/ambari-web/app/controllers/main/admin/kerberos/step2_controller.js
@@ -312,6 +312,7 @@ App.KerberosWizardStep2Controller = App.WizardStep7Controller.extend(App.KDCCred
     return App.ajax.send({
       name: 'common.cluster.update',
       sender: this,
+      dataType: 'text',
       data: {
         clusterName: App.get('clusterName'),
         data: [{


### PR DESCRIPTION
## What changes were proposed in this pull request?
Fix UT failure in Kerberos Step2 Controller by updating the signature to match the implementation here:
https://github.com/apache/ambari/blob/trunk/ambari-web/app/utils/ajax/ajax.js#L41

## How was this patch tested?

The test that runs below (https://ci-hadoop.apache.org/job/Ambari/job/Ambari-PreCommit-GitHub-PR/job/PR-4092/1/console) should pass.

```
HeadlessChrome 0.0.0 (Linux 0.0.0): Executed 22250 of 22912 (skipped 643) SUCCESS (0 secs / 2.737 secs)
HeadlessChrome 0.0.0 (Linux 0.0.0): Executed 22250 of 22912 (skipped 662) SUCCESS (17.913 secs / 2.737 secs)
[INFO] 
[INFO] --- apache-rat:0.12:check (default) @ ambari-web ---
[INFO] RAT will not execute since it is configured to be skipped via system property 'rat.skip'.
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary for Ambari Main 3.1.0.0-SNAPSHOT:
[INFO] 
[INFO] Ambari Main ........................................ SUCCESS [  1.168 s]
[INFO] Apache Ambari Project POM .......................... SUCCESS [  0.047 s]
[INFO] Ambari Web ......................................... SUCCESS [01:03 min]
[INFO] Ambari Admin View .................................. SUCCESS [ 10.278 s]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  01:04 min (Wall Clock)
[INFO] Finished at: 2025-12-05T17:54:41Z
[INFO] ------------------------------------------------------------------------
```