### PR TITLE
AMBARI:-26570: Ambari Web React: Component actions for masters/slaves - Turn On / Off Maintenance Mode

### DIFF
--- a/ambari-web/latest/src/screens/Hosts/actions.tsx
+++ b/ambari-web/latest/src/screens/Hosts/actions.tsx
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-import { cloneDeep, get, set } from "lodash";
+import { capitalize, cloneDeep, get, set } from "lodash";
 import { HostsApi } from "../../api/hostsApi";
 import {
   doDecommissionRegionServer,
@@ -39,6 +39,7 @@ import {
 } from "../../Utils/Utility";
 import ConfirmationModal from "../../components/ConfirmationModal";
 import { IHost } from "../../models/host";
+import { t } from "i18next";
 
 export const sendComponentCommand = async (
   component: IHostComponent,
@@ -403,5 +404,35 @@ const executeCustomCommandErrorCallback = (error: any) => {
     translate("services.service.actions.run.executeCustomCommand.error"),
     translate("services.service.actions.run.executeCustomCommand.error") +
     error.message
+  );
+};
+
+export const toggleMaintenanceMode = async (component: IHostComponent) => {
+  if (component.isImpliedState()) return null;
+
+  const hostname = get(component, "hostName");
+  const clusterName = get(component, "clusterName");
+  const componentName = get(component, "componentName");
+  const state = get(component, "passiveState") === "ON" ? "OFF" : "ON";
+  const displayName = get(component, "displayName");
+  let message = t(
+    "passiveState.turn" + capitalize(state.toString()) + "For"
+  ).replace("{0}", displayName);
+
+  const data = JSON.stringify({
+    RequestInfo: {
+      context: message,
+    },
+    Body: {
+      HostRoles: {
+        maintenance_state: state,
+      },
+    },
+  });
+  await HostsApi.updateHostComponentForHost(
+    clusterName,
+    hostname,
+    componentName,
+    data
   );
 };


### PR DESCRIPTION
AMBARI:-26570: Ambari Web React: Component actions for masters/slaves - Turn On / Off Maintenance Mode

## What changes were proposed in this pull request?

(Please fill in changes proposed in this fix)

## How was this patch tested?
<img width="831" height="205" alt="image" src="https://github.com/user-attachments/assets/214135ee-0242-438a-a26e-3ce122a0b752" />


(Please explain how this patch was tested. Ex: unit tests, manual tests)
(If this patch involves UI changes, please attach a screen-shot; otherwise, remove this)

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.