### PR TITLE
AMBARI:-26579: Ambari Web React: Component actions for masters/slaves - Refresh configs

### DIFF
--- a/ambari-web/latest/src/screens/Hosts/HostSummary.tsx
+++ b/ambari-web/latest/src/screens/Hosts/HostSummary.tsx
@@ -88,6 +88,7 @@ import {
   executeCustomCommand,
   installClients,
   installComponent,
+  refreshComponentConfigs
 } from "./actions";
 import { AppContext } from "../../store/context";
 import IHost from "../../models/host";
@@ -841,7 +842,13 @@ export default function HostsSummary({
             <div
               key="refresh-component-configs"
               onClick={() => {
-                //TODO: Will be implemented in future PR
+                setSelectedActionData(
+                  component,
+                  "refresh",
+                  false,
+                  refreshComponentConfigs
+                );
+                setShowConfirmationModal(true);
               }}
             >
               Refresh configs

--- a/ambari-web/latest/src/screens/Hosts/actions.tsx
+++ b/ambari-web/latest/src/screens/Hosts/actions.tsx
@@ -664,3 +664,26 @@ export const installComponent = async (
     defaultSuccessCallbackWithoutReload(requestId);
   });
 };
+export const refreshComponentConfigs = async (component: IHostComponent) => {
+  const clusterName = get(component, "clusterName", "");
+  const context = t("requestInfo.refreshComponentConfigs").replace(
+    "{0}",
+    getComponentDisplayName(component)
+  );
+  const resource_filters = [
+    {
+      service_name: get(component, "serviceName"),
+      component_name: getComponentName(component),
+      hosts: get(component, "hostName"),
+    },
+  ];
+  const data = JSON.stringify({
+    RequestInfo: {
+      command: "CONFIGURE",
+      context: context,
+    },
+    "Requests/resource_filters": resource_filters,
+  });
+
+  await HostsApi.clusterRequests(clusterName, data);
+};


### PR DESCRIPTION
AMBARI:-26579: Ambari Web React: Component actions for masters/slaves - Refresh configs

## What changes were proposed in this pull request?

(Please fill in changes proposed in this fix)

## How was this patch tested?
<img width="834" height="205" alt="Screenshot 2026-01-23 at 11 28 29 PM" src="https://github.com/user-attachments/assets/83a05818-4fa0-431b-b64f-3d314e0d28a4" />

(Please explain how this patch was tested. Ex: unit tests, manual tests)
(If this patch involves UI changes, please attach a screen-shot; otherwise, remove this)

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.