### PR TITLE
AMBARI-26569 Added fix for two-way ssl

### DIFF
--- a/ambari-agent/src/main/python/ambari_agent/security.py
+++ b/ambari-agent/src/main/python/ambari_agent/security.py
@@ -247,7 +247,7 @@ class CertificateManager:
   def checkCertExists(self):
     s = os.path.abspath(self.config.get("security", "keysdir")) + os.sep + "ca.crt"
 
-    server_crt_exists = os.path.exists(s)
+    server_crt_exists = os.path.exists(s) and os.path.getsize(s) > 0
 
     if not server_crt_exists:
       logger.info("Server certicate not exists, downloading")
@@ -255,7 +255,7 @@ class CertificateManager:
     else:
       logger.info("Server certicate exists, ok")
 
-    agent_key_exists = os.path.exists(self.getAgentKeyName())
+    agent_key_exists = os.path.exists(self.getAgentKeyName()) and os.path.getsize(self.getAgentKeyName()) > 0
 
     if not agent_key_exists:
       logger.info("Agent key not exists, generating request")
@@ -263,7 +263,7 @@ class CertificateManager:
     else:
       logger.info("Agent key exists, ok")
 
-    agent_crt_exists = os.path.exists(self.getAgentCrtName())
+    agent_crt_exists = os.path.exists(self.getAgentCrtName()) and os.path.getsize(self.getAgentCrtName()) > 0
 
     if not agent_crt_exists:
       logger.info("Agent certificate not exists, sending sign request")
@@ -280,7 +280,7 @@ class CertificateManager:
     response = stream.read()
     stream.close()
     srvr_crt_f = open(self.getSrvrCrtName(), "w+")
-    srvr_crt_f.write(response)
+    srvr_crt_f.write(response if isinstance(response, str) else response.decode('utf-8'))
     srvr_crt_f.close()
 
   def reqSignCrt(self):
@@ -291,7 +291,7 @@ class CertificateManager:
     passphrase_env_var = self.config.get("security", "passphrase_env_var_name")
     passphrase = os.environ[passphrase_env_var]
     register_data = {"csr": agent_crt_req_content, "passphrase": passphrase}
-    data = json.dumps(register_data)
+    data = json.dumps(register_data).encode('utf-8')
     proxy_handler = urllib.request.ProxyHandler({})
     opener = urllib.request.build_opener(proxy_handler)
     urllib.request.install_opener(opener)

--- a/ambari-agent/src/test/python/ambari_agent/TestSecurity.py
+++ b/ambari-agent/src/test/python/ambari_agent/TestSecurity.py
@@ -156,6 +156,7 @@ class TestSecurity(unittest.TestCase):
     self.assertEqual(res, os.path.abspath("/dummy-keysdir/ca.crt"))
 
   @patch("os.path.exists")
+  @patch("os.path.getsize")
   @patch.object(security.CertificateManager, "loadSrvrCrt")
   @patch.object(security.CertificateManager, "getAgentKeyName")
   @patch.object(security.CertificateManager, "genAgentCrtReq")
@@ -169,6 +170,7 @@ class TestSecurity(unittest.TestCase):
     getAgentKeyName_mock,
     loadSrvrCrt_mock,
     exists_mock,
+    getsize_mock,
   ):
     self.config.set("security", "keysdir", "/dummy-keysdir")
     getAgentKeyName_mock.return_value = "dummy AgentKeyName"
@@ -177,6 +179,7 @@ class TestSecurity(unittest.TestCase):
 
     # Case when all files exist
     exists_mock.side_effect = [True, True, True]
+    getsize_mock.return_value = 100
     man.checkCertExists()
     self.assertFalse(loadSrvrCrt_mock.called)
     self.assertFalse(genAgentCrtReq_mock.called)


### PR DESCRIPTION
## What changes were proposed in this pull request?

Bugfix: Ambari two-way ssl set up is failing because certificate received is byte type but file write object expect string to write certificate.

Error
```
failed write() argument must be str, not bytes
```

## How was this patch tested?

1. Create cluster with security.server.two_way_ssl=true
2. Observed SSL setup and Validate ambari agent is able to download certificates from server.

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.