### PR TITLE
AMBARI-26591: Remove unused form2js dependency from WF Manager UI

### DIFF
--- a/contrib/views/wfmanager/src/main/resources/ui/bower.json
+++ b/contrib/views/wfmanager/src/main/resources/ui/bower.json
@@ -10,7 +10,6 @@
     "jquery-ui": "~1.11.4",
     "dagre": "~0.7.4",
     "x2js": "~1.2.0",
-    "form2js": "maxatwork/form2js#v2.0",
     "moment": "~2.11.2",
     "handlebars": "~4.0.5",
     "spin.js": "~2.3.2",

--- a/contrib/views/wfmanager/src/main/resources/ui/bower.json
+++ b/contrib/views/wfmanager/src/main/resources/ui/bower.json
@@ -10,7 +10,7 @@
     "jquery-ui": "~1.11.4",
     "dagre": "~0.7.4",
     "x2js": "~1.2.0",
-    "form2js": "*",
+    "form2js": "maxatwork/form2js#v2.0",
     "moment": "~2.11.2",
     "handlebars": "~4.0.5",
     "spin.js": "~2.3.2",

--- a/contrib/views/wfmanager/src/main/resources/ui/ember-cli-build.js
+++ b/contrib/views/wfmanager/src/main/resources/ui/ember-cli-build.js
@@ -78,7 +78,6 @@ module.exports = function(defaults) {
     });
 
     app.import('bower_components/x2js/xml2json.js');
-    app.import('bower_components/form2js/src/form2js.js');
     app.import('bower_components/jquery-ui/jquery-ui.js');
     app.import('bower_components/lodash/lodash.js');
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR pins the form2js dependency to a fixed version (maxatwork/form2js#v2.0) in contrib/views/wfmanager/src/main/resources/ui/bower.json.
Previously, "form2js": "*" resolved to the latest tag, which recently changed and no longer contains the expected src/form2js.js structure required by Ambari.
Pinning the version restores the expected folder layout and prevents the ENOENT build failure.

## How was this patch tested?

(Please explain how this patch was tested. Ex: unit tests, manual tests)
(If this patch involves UI changes, please attach a screen-shot; otherwise, remove this)

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.