### PR TITLE
AMBARI-26594: Stack upgrade issue related to null upgrade_id

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/orm/entities/UpgradeEntity.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/orm/entities/UpgradeEntity.java
@@ -185,8 +185,7 @@ public class UpgradeEntity {
    * Uni-directional relationship between an upgrade an all of the components in
    * that upgrade.
    */
-  @OneToMany(orphanRemoval=true, cascade = { CascadeType.ALL })
-  @JoinColumn(name = "upgrade_id")
+  @OneToMany(orphanRemoval=true, mappedBy = "upgrade", cascade = { CascadeType.ALL })
   private List<UpgradeHistoryEntity> upgradeHistory;
 
   /**

--- a/ambari-server/src/main/java/org/apache/ambari/server/orm/entities/UpgradeHistoryEntity.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/orm/entities/UpgradeHistoryEntity.java
@@ -69,7 +69,8 @@ public class UpgradeHistoryEntity {
   @Column(name = "upgrade_id", nullable = false, insertable = false, updatable = false)
   private Long upgradeId;
 
-  @JoinColumn(name = "upgrade_id", nullable = false, insertable = false, updatable = false)
+  @ManyToOne
+  @JoinColumn(name = "upgrade_id", referencedColumnName = "upgrade_id", nullable = false)
   private UpgradeEntity upgrade;
 
   @Column(name = "service_name", nullable = false, insertable = true, updatable = true)


### PR DESCRIPTION
## What changes were proposed in this pull request?

This changes fixes intermittent issue related stack upgrade.
Issue: While doing stack upgrade upgrade_history table is not able to persist as its not able to get upgrade_id from parent table

## How was this patch tested?
Tested stack upgrade multiple times.