### PR TITLE
stack_advisor: fix 'occured' -> 'occurred' typos in print error messages

### DIFF
--- a/ambari-server/src/main/resources/scripts/stack_advisor.py
+++ b/ambari-server/src/main/resources/scripts/stack_advisor.py
@@ -208,9 +208,9 @@ if __name__ == "__main__":
     main(sys.argv)
   except StackAdvisorException as stack_exception:
     traceback.print_exc()
-    print(f"Error occured in stack advisor.\nError details: {str(stack_exception)}")
+    print(f"Error occurred in stack advisor.\nError details: {str(stack_exception)}")
     sys.exit(1)
   except Exception as e:
     traceback.print_exc()
-    print(f"Error occured in stack advisor.\nError details: {str(e)}")
+    print(f"Error occurred in stack advisor.\nError details: {str(e)}")
     sys.exit(2)


### PR DESCRIPTION
Two print statements in `ambari-server/src/main/resources/scripts/stack_advisor.py` (lines 211 and 215) read `Error occured in stack advisor`. User-visible in ambari stack advisor error output. `ast.parse` clean.