### PR TITLE
AMBARI-26596: Fixing fd leak during kerberizing

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/api/services/AmbariMetaInfo.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/api/services/AmbariMetaInfo.java
@@ -944,8 +944,8 @@ public class AmbariMetaInfo {
 
       Gson gson = new Gson();
 
-      try {
-        map = gson.fromJson(new FileReader(svc.getMetricsFile()), type);
+      try (FileReader reader = new FileReader(svc.getMetricsFile())) {
+        map = gson.fromJson(reader, type);
 
         svc.setMetrics(processMetricDefinition(map));
 

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/kerberos/AbstractKerberosDescriptorFactory.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/kerberos/AbstractKerberosDescriptorFactory.java
@@ -51,8 +51,8 @@ abstract class AbstractKerberosDescriptorFactory {
     } else if (!file.isFile() || !file.canRead()) {
       throw new IOException(String.format("%s is not a readable file", file.getAbsolutePath()));
     } else {
-      try {
-        return new Gson().fromJson(new FileReader(file),
+      try (FileReader reader = new FileReader(file)) {
+        return new Gson().fromJson(reader,
             new TypeToken<Map<String, Object>>() {
             }.getType());
       } catch (JsonSyntaxException e) {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Using try-with-resources instead of just try in AbstractKerberosDescriptorFactory.java and AmbariMetaInfo.java

**AbstractKerberosDescriptorFactory.java:**
```diff
-      try {
-        return new Gson().fromJson(new FileReader(file),
+      try (FileReader reader = new FileReader(file)) {
+        return new Gson().fromJson(reader,
             new TypeToken<Map<String, Object>>() {
             }.getType());
```

**AmbariMetaInfo.java:**
```diff
-      try {
-        map = gson.fromJson(new FileReader(svc.getMetricsFile()), type);
+      try (FileReader reader = new FileReader(svc.getMetricsFile())) {
+        map = gson.fromJson(reader, type);
```

## How was this patch tested?

manual tests done
I've built ambari-server jar file and updated my original ambari-server jar.
With the change, I've tried kerberizing test in my cluster.