### PR TITLE
AMBARI-26569: Exclude legacy transitive dependencies causing runtime …

### DIFF
--- a/ambari-server/pom.xml
+++ b/ambari-server/pom.xml
@@ -1582,6 +1582,18 @@
           <groupId>com.sun.jersey</groupId>
           <artifactId>jersey-server</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>com.sun.jersey</groupId>
+          <artifactId>jersey-json</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.sun.jersey</groupId>
+          <artifactId>jersey-servlet</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.sun.jersey</groupId>
+          <artifactId>jersey-client</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>
@@ -1870,6 +1882,22 @@
           <groupId>com.sun.jersey</groupId>
           <artifactId>jersey-servlet</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>com.sun.jersey</groupId>
+          <artifactId>jersey-json</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.sun.jersey</groupId>
+          <artifactId>jersey-client</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>javax.ws.rs</groupId>
+          <artifactId>jsr311-api</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>net.sf.ehcache</groupId>
+          <artifactId>ehcache</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>
@@ -1964,6 +1992,18 @@
         <exclusion>
           <groupId>com.sun.jersey</groupId>
           <artifactId>jersey-server</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.sun.jersey</groupId>
+          <artifactId>jersey-client</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>javax.ws.rs</groupId>
+          <artifactId>jsr311-api</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>net.sf.ehcache</groupId>
+          <artifactId>ehcache</artifactId>
         </exclusion>
       </exclusions>
     </dependency>

--- a/ambari-server/src/main/assemblies/server.xml
+++ b/ambari-server/src/main/assemblies/server.xml
@@ -464,6 +464,19 @@
       <outputDirectory>/usr/lib/ambari-server</outputDirectory>
       <unpack>false</unpack>
       <scope>runtime</scope>
+      <!--
+        Exclude legacy JARs brought transitively by dependencies
+(e.g., Hadoop, swagger-jaxrs) that conflict at runtime with the versions
+currently used by Ambari (ehcache 3.x, Jersey 2.x, JAX-RS 2.x).-->
+      <excludes>
+        <exclude>net.sf.ehcache:ehcache</exclude>
+        <exclude>com.sun.jersey:jersey-core</exclude>
+        <exclude>com.sun.jersey:jersey-server</exclude>
+        <exclude>com.sun.jersey:jersey-json</exclude>
+        <exclude>com.sun.jersey:jersey-servlet</exclude>
+        <exclude>com.sun.jersey:jersey-client</exclude>
+        <exclude>javax.ws.rs:jsr311-api</exclude>
+      </excludes>
     </dependencySet>
   </dependencySets>
 </assembly>

--- a/ambari-server/src/main/assemblies/server.xml
+++ b/ambari-server/src/main/assemblies/server.xml
@@ -464,19 +464,6 @@
       <outputDirectory>/usr/lib/ambari-server</outputDirectory>
       <unpack>false</unpack>
       <scope>runtime</scope>
-      <!--
-        Exclude legacy JARs brought transitively by dependencies
-(e.g., Hadoop, swagger-jaxrs) that conflict at runtime with the versions
-currently used by Ambari (ehcache 3.x, Jersey 2.x, JAX-RS 2.x).-->
-      <excludes>
-        <exclude>net.sf.ehcache:ehcache</exclude>
-        <exclude>com.sun.jersey:jersey-core</exclude>
-        <exclude>com.sun.jersey:jersey-server</exclude>
-        <exclude>com.sun.jersey:jersey-json</exclude>
-        <exclude>com.sun.jersey:jersey-servlet</exclude>
-        <exclude>com.sun.jersey:jersey-client</exclude>
-        <exclude>javax.ws.rs:jsr311-api</exclude>
-      </excludes>
     </dependencySet>
   </dependencySets>
 </assembly>


### PR DESCRIPTION
…conflicts in server assembly

## What changes were proposed in this pull request?

This PR adds `<excludes>` to the ambari-server assembly descriptor (`ambari-server/src/main/assemblies/server.xml`) to prevent legacy JARs from being packaged. Specifically, it excludes:

- `net.sf.ehcache:ehcache` (ehcache 2.x) - conflicts with ehcache 3.x used by Ambari
- Jersey 1.x JARs (`jersey-core`, `jersey-server`, `jersey-json`, `jersey-servlet`, `jersey-client`) - conflicts with Jersey 2.x
- `javax.ws.rs:jsr311-api` (JAX-RS 1.x) - conflicts with JAX-RS 2.x

These JARs are brought transitively by dependencies such as Hadoop and swagger-jaxrs. The exclusions eliminate the need for manual post-installation cleanup (e.g., removing `ehcache-2.10.4.jar` from the Dockerfile) and prevent runtime `ClassNotFoundException` and `NoSuchMethodError` issues caused by classpath conflicts.

## How was this patch tested?

- Built ambari-server with `mvn -pl ambari-server -am -DskipTests package`
- Verified that the excluded JARs are not present in the assembly output
- Confirmed ambari-server starts correctly without the legacy JARs
- Verified Ambari UI loads and API calls work normally
- No `ClassNotFoundException` or `NoSuchMethodError` related to ehcache/Jersey/JAX-RS observed in logs

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.
