### PR TITLE
[AMBARI-26616] Refresh rack topology mappings upon DataNode or NodeManager install

### DIFF
--- a/ambari-server/src/main/resources/stack-hooks/before-START/scripts/params.py
+++ b/ambari-server/src/main/resources/stack-hooks/before-START/scripts/params.py
@@ -385,6 +385,7 @@ all_hosts = default("/clusterHostInfo/all_hosts", [])
 all_racks = default("/clusterHostInfo/all_racks", [])
 all_ipv4_ips = default("/clusterHostInfo/all_ipv4_ips", [])
 slave_hosts = default("/clusterHostInfo/datanode_hosts", [])
+nm_hosts = default("/clusterHostInfo/nodemanager_hosts", [])
 
 # topology files
 net_topology_script_file_path = "/etc/hadoop/conf/topology_script.py"

--- a/ambari-server/src/main/resources/stack-hooks/before-START/templates/topology_mappings.data.j2
+++ b/ambari-server/src/main/resources/stack-hooks/before-START/templates/topology_mappings.data.j2
@@ -17,7 +17,7 @@
 #}
 [network_topology]
 {% for host in all_hosts %}
-{% if host in slave_hosts %}
+{% if host in slave_hosts or host in nm_hosts %}
 {{host}}={{all_racks[loop.index-1]}}
 {{all_ipv4_ips[loop.index-1]}}={{all_racks[loop.index-1]}}
 {% endif %}

--- a/ambari-server/src/main/resources/stacks/BIGTOP/3.2.0/services/HDFS/package/scripts/hdfs_namenode.py
+++ b/ambari-server/src/main/resources/stacks/BIGTOP/3.2.0/services/HDFS/package/scripts/hdfs_namenode.py
@@ -570,15 +570,15 @@ def decommission():
     )
     pass
 
-    # regenerate topology_mappings.data
-    File(
-      params.net_topology_mapping_data_file_path,
-      content=Template("topology_mappings.data.j2"),
-      owner=params.hdfs_user,
-      group=params.user_group,
-      mode=0o644,
-      only_if=format("test -d {hadoop_conf_dir}")
-    )
+  # regenerate topology_mappings.data
+  File(
+    params.net_topology_mapping_data_file_path,
+    content=Template("topology_mappings.data.j2"),
+    owner=params.hdfs_user,
+    group=params.user_group,
+    mode=0o644,
+    only_if=format("test -d {hadoop_conf_dir}")
+  )
 
   if not params.update_files_only:
     Execute(nn_kinit_cmd, user=hdfs_user)

--- a/ambari-server/src/main/resources/stacks/BIGTOP/3.2.0/services/HDFS/package/scripts/hdfs_namenode.py
+++ b/ambari-server/src/main/resources/stacks/BIGTOP/3.2.0/services/HDFS/package/scripts/hdfs_namenode.py
@@ -570,6 +570,16 @@ def decommission():
     )
     pass
 
+    # regenerate topology_mappings.data
+    File(
+      params.net_topology_mapping_data_file_path,
+      content=Template("topology_mappings.data.j2"),
+      owner=params.hdfs_user,
+      group=params.user_group,
+      mode=0o644,
+      only_if=format("test -d {hadoop_conf_dir}")
+    )
+
   if not params.update_files_only:
     Execute(nn_kinit_cmd, user=hdfs_user)
 

--- a/ambari-server/src/main/resources/stacks/BIGTOP/3.2.0/services/HDFS/package/scripts/params_linux.py
+++ b/ambari-server/src/main/resources/stacks/BIGTOP/3.2.0/services/HDFS/package/scripts/params_linux.py
@@ -236,7 +236,14 @@ klist_path_local = get_klist_path(
 kinit_path_local = get_kinit_path(
   default("/configurations/kerberos-env/executable_search_paths", None)
 )
+
+# topology files
+net_topology_mapping_data_file_path = os.path.join(hadoop_conf_dir, "topology_mappings.data")
+
 # hosts
+all_hosts = default("/clusterHostInfo/all_hosts", [])
+all_racks = default("/clusterHostInfo/all_racks", [])
+all_ipv4_ips = default("/clusterHostInfo/all_ipv4_ips", [])
 hostname = config["agentLevelParams"]["hostname"]
 rm_host = default("/clusterHostInfo/resourcemanager_hosts", [])
 public_hostname = config["agentLevelParams"]["public_hostname"]

--- a/ambari-server/src/main/resources/stacks/BIGTOP/3.2.0/services/HDFS/package/templates/topology_mappings.data.j2
+++ b/ambari-server/src/main/resources/stacks/BIGTOP/3.2.0/services/HDFS/package/templates/topology_mappings.data.j2
@@ -1,0 +1,24 @@
+{#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+    #
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#}
+[network_topology]
+{% for host in all_hosts %}
+{% if host in slave_hosts %}
+{{host}}={{all_racks[loop.index-1]}}
+{{all_ipv4_ips[loop.index-1]}}={{all_racks[loop.index-1]}}
+{% endif %}
+{% endfor %}

--- a/ambari-server/src/main/resources/stacks/BIGTOP/3.2.0/services/HDFS/package/templates/topology_mappings.data.j2
+++ b/ambari-server/src/main/resources/stacks/BIGTOP/3.2.0/services/HDFS/package/templates/topology_mappings.data.j2
@@ -17,7 +17,7 @@
 #}
 [network_topology]
 {% for host in all_hosts %}
-{% if host in slave_hosts %}
+{% if host in slave_hosts or host in nm_host %}
 {{host}}={{all_racks[loop.index-1]}}
 {{all_ipv4_ips[loop.index-1]}}={{all_racks[loop.index-1]}}
 {% endif %}

--- a/ambari-server/src/main/resources/stacks/BIGTOP/3.2.0/services/YARN/package/scripts/params_linux.py
+++ b/ambari-server/src/main/resources/stacks/BIGTOP/3.2.0/services/YARN/package/scripts/params_linux.py
@@ -377,6 +377,15 @@ yarn_job_summary_log = format(
 
 user_group = config["configurations"]["cluster-env"]["user_group"]
 
+# topology files
+net_topology_mapping_data_file_path = os.path.join(hadoop_conf_dir, "topology_mappings.data")
+
+# hosts
+all_hosts = default("/clusterHostInfo/all_hosts", [])
+all_racks = default("/clusterHostInfo/all_racks", [])
+all_ipv4_ips = default("/clusterHostInfo/all_ipv4_ips", [])
+slave_hosts = default("/clusterHostInfo/datanode_hosts", [])
+
 # exclude file
 if "all_decommissioned_hosts" in config["commandParams"]:
   exclude_hosts = config["commandParams"]["all_decommissioned_hosts"].split(",")

--- a/ambari-server/src/main/resources/stacks/BIGTOP/3.2.0/services/YARN/package/scripts/resourcemanager.py
+++ b/ambari-server/src/main/resources/stacks/BIGTOP/3.2.0/services/YARN/package/scripts/resourcemanager.py
@@ -188,6 +188,16 @@ class ResourcemanagerDefault(Resourcemanager):
         group=user_group,
       )
 
+    # regenerate topology_mappings.data
+    File(
+      params.net_topology_mapping_data_file_path,
+      content=Template("topology_mappings.data.j2"),
+      owner=params.hdfs_user,
+      group=params.user_group,
+      mode=0o644,
+      only_if=format("test -d {hadoop_conf_dir}")
+    )
+
     if params.update_files_only == False:
       Execute(
         yarn_refresh_cmd, environment={"PATH": params.execute_path}, user=yarn_user

--- a/ambari-server/src/main/resources/stacks/BIGTOP/3.2.0/services/YARN/package/templates/topology_mappings.data.j2
+++ b/ambari-server/src/main/resources/stacks/BIGTOP/3.2.0/services/YARN/package/templates/topology_mappings.data.j2
@@ -1,0 +1,24 @@
+{#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+    #
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#}
+[network_topology]
+{% for host in all_hosts %}
+{% if host in slave_hosts %}
+{{host}}={{all_racks[loop.index-1]}}
+{{all_ipv4_ips[loop.index-1]}}={{all_racks[loop.index-1]}}
+{% endif %}
+{% endfor %}

--- a/ambari-server/src/main/resources/stacks/BIGTOP/3.2.0/services/YARN/package/templates/topology_mappings.data.j2
+++ b/ambari-server/src/main/resources/stacks/BIGTOP/3.2.0/services/YARN/package/templates/topology_mappings.data.j2
@@ -17,7 +17,7 @@
 #}
 [network_topology]
 {% for host in all_hosts %}
-{% if host in slave_hosts %}
+{% if host in slave_hosts or host in nm_hosts %}
 {{host}}={{all_racks[loop.index-1]}}
 {{all_ipv4_ips[loop.index-1]}}={{all_racks[loop.index-1]}}
 {% endif %}


### PR DESCRIPTION
## What changes were proposed in this pull request?

When adding DataNode or NodeManager hosts, Ambari refreshes include/exclude files on NameNode and ResourceManager hosts, but the rack topology mapping file can remain stale because topology regeneration only runs on hosts where worker components are started. This requires restarting NameNode or ResourceManager before new hosts appear with the correct rack information.

Update the HDFS and YARN refresh/decommission workflows to regenerate `topology_mappings.data` during the existing `Update Include/Exclude Files` action, so `hdfs dfsadmin -printTopology`, `hdfs dfsadmin -report`, and `yarn node -status` reflect newly added hosts without restarting master components.

## How was this patch tested?
Tested manually multiple times by adding DataNodes and NodeManagers to Hadoop cluster.
Below screenshots are before/after adding a worker (DataNode + NodeManager) to cluster.

#### Before Adding Worker
<img width="1392" height="394" alt="hdfs-before" src="https://github.com/user-attachments/assets/667f668e-3276-40bc-b895-e8c91c362991" />
<img width="938" height="318" alt="mappings-before" src="https://github.com/user-attachments/assets/c7763d38-b7e0-4c62-aa8d-83d25de79968" />
<img width="1808" height="1698" alt="yarn-before" src="https://github.com/user-attachments/assets/5c7ec3a7-dcc1-494a-b6a5-061e73171da2" />

#### After Adding Worker
<img width="2960" height="937" alt="ambari-action" src="https://github.com/user-attachments/assets/b08411e3-2678-4c7b-a1f6-80c7d68412d6" />
<img width="1386" height="424" alt="hdfs-after" src="https://github.com/user-attachments/assets/a1f81536-7354-4c0f-a441-c9aa11b994db" />
<img width="1048" height="452" alt="mappings-after" src="https://github.com/user-attachments/assets/3752f624-d5f6-4fb7-b2d3-36a83c993cc6" />
<img width="1446" height="1802" alt="yarn-after" src="https://github.com/user-attachments/assets/ecb582cb-e0a6-490e-b02b-29fb9bcf7249" />