### PR TITLE
AMBARI-26622 Fix missing mode in sudo.makedir when Ambari is running as root

### DIFF
--- a/ambari-common/src/main/python/resource_management/core/sudo.py
+++ b/ambari-common/src/main/python/resource_management/core/sudo.py
@@ -139,7 +139,7 @@ if os.geteuid() == 0:
       raise
 
   def makedir(path, mode):
-    os.mkdir(path)
+    os.mkdir(path, mode)
 
   def symlink(source, link_name):
     os.symlink(source, link_name)


### PR DESCRIPTION
## What changes were proposed in this pull request?
This fixes an inconsistent behaviour between the root and non-root branches of makedir in sudo.py.

In the root path, the `mode` option is silently dropped, while it is respected in the non-root path. Since mode is not passed, it will default to 0o777, which is unexpected behaviour when passing some other mode to the function.

This is the non-root path:
```
def makedir(path, mode):
    shell.checked_call(["mkdir", path], sudo=True)
    chmod(path, mode)
```
In this path, mode is honoured and set as expected.

## How was this patch tested?
No testing was performed - this just adds the mode parameter to os.mkdir that was previously silently ignored, but still required.