### PR TITLE
AMBARI-26626: Complete React parity for the Hosts module

### DIFF
--- a/ambari-web/latest/src/Utils/hostConfigs.test.ts
+++ b/ambari-web/latest/src/Utils/hostConfigs.test.ts
@@ -1,0 +1,117 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  buildConfigGroupMembershipUpdates,
+  buildHostConfigGroupState,
+} from "./hostConfigs";
+
+function group(
+  id: number,
+  serviceName: string,
+  groupName: string,
+  hosts: string[],
+) {
+  return {
+    ConfigGroup: {
+      id,
+      group_name: groupName,
+      description: `${groupName} description`,
+      tag: serviceName,
+      service_name: serviceName,
+      hosts: hosts.map((host_name) => ({ host_name })),
+      desired_configs: [{ type: `${serviceName.toLowerCase()}-site`, tag: "version1" }],
+    },
+  };
+}
+
+describe("host config groups", () => {
+  const hdfsBlue = group(1, "HDFS", "Blue", ["host1", "host2"]);
+  const hdfsGreen = group(2, "HDFS", "Green", ["host3"]);
+  const yarnBlue = group(3, "YARN", "Blue", ["host2"]);
+
+  it("tracks assignments independently for every service", () => {
+    expect(buildHostConfigGroupState(
+      [hdfsBlue, hdfsGreen, yarnBlue],
+      ["HDFS", "YARN", "HIVE"],
+      "host1",
+    )).toEqual({
+      assignedGroupByService: {
+        HDFS: "Blue",
+        YARN: "Default",
+        HIVE: "Default",
+      },
+      groupsByService: {
+        HDFS: [hdfsBlue, hdfsGreen],
+        YARN: [yarnBlue],
+        HIVE: [],
+      },
+    });
+  });
+
+  it("adds a host when moving from Default to a non-default group", () => {
+    const updates = buildConfigGroupMembershipUpdates(
+      [hdfsBlue], "HDFS", "Default", "Blue", "host3",
+    );
+
+    expect(updates).toHaveLength(1);
+    expect(updates[0].groupId).toBe("1");
+    expect(updates[0].payload).toEqual([{
+      ConfigGroup: {
+        id: 1,
+        group_name: "Blue",
+        description: "Blue description",
+        tag: "HDFS",
+        service_name: "HDFS",
+        hosts: [
+          { host_name: "host1" },
+          { host_name: "host2" },
+          { host_name: "host3" },
+        ],
+        desired_configs: [{ type: "hdfs-site", tag: "version1" }],
+      },
+    }]);
+  });
+
+  it("removes a host when moving from a non-default group to Default", () => {
+    const updates = buildConfigGroupMembershipUpdates(
+      [hdfsBlue], "HDFS", "Blue", "Default", "host1",
+    );
+
+    expect(updates).toHaveLength(1);
+    expect(updates[0].payload[0].ConfigGroup.hosts).toEqual([
+      { host_name: "host2" },
+    ]);
+  });
+
+  it("updates both memberships when moving between non-default groups", () => {
+    const updates = buildConfigGroupMembershipUpdates(
+      [hdfsBlue, hdfsGreen], "HDFS", "Blue", "Green", "host1",
+    );
+
+    expect(updates.map((update) => update.groupId)).toEqual(["1", "2"]);
+    expect(updates[0].payload[0].ConfigGroup.hosts).toEqual([
+      { host_name: "host2" },
+    ]);
+    expect(updates[1].payload[0].ConfigGroup.hosts).toEqual([
+      { host_name: "host3" },
+      { host_name: "host1" },
+    ]);
+  });
+});

--- a/ambari-web/latest/src/Utils/hostConfigs.ts
+++ b/ambari-web/latest/src/Utils/hostConfigs.ts
@@ -1,0 +1,124 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { get } from "lodash";
+
+export type HostConfigGroupState = {
+  assignedGroupByService: Record<string, string>;
+  groupsByService: Record<string, any[]>;
+};
+
+export type ConfigGroupMembershipUpdate = {
+  group: any;
+  groupId: string;
+  payload: any;
+};
+
+function groupHosts(group: any): string[] {
+  return get(group, "ConfigGroup.hosts", [])
+    .map((host: any) => host?.host_name)
+    .filter(Boolean);
+}
+
+export function buildHostConfigGroupState(
+  groups: any[],
+  serviceNames: string[],
+  hostName: string,
+): HostConfigGroupState {
+  const groupsByService: Record<string, any[]> = {};
+  const assignedGroupByService: Record<string, string> = {};
+
+  serviceNames.forEach((serviceName) => {
+    groupsByService[serviceName] = [];
+    assignedGroupByService[serviceName] = "Default";
+  });
+  groups.forEach((group) => {
+    const serviceName = get(
+      group,
+      "ConfigGroup.service_name",
+      get(group, "ConfigGroup.tag", ""),
+    );
+    if (!groupsByService[serviceName]) {
+      return;
+    }
+    groupsByService[serviceName].push(group);
+    if (groupHosts(group).includes(hostName)) {
+      assignedGroupByService[serviceName] = get(
+        group,
+        "ConfigGroup.group_name",
+        "Default",
+      );
+    }
+  });
+
+  return { assignedGroupByService, groupsByService };
+}
+
+function payloadForHosts(group: any, serviceName: string, hosts: string[]) {
+  const configGroup = get(group, "ConfigGroup", {});
+  return [{
+    ConfigGroup: {
+      ...configGroup,
+      group_name: configGroup.group_name || "",
+      description: configGroup.description || "",
+      tag: configGroup.tag || serviceName,
+      service_name: configGroup.service_name || serviceName,
+      hosts: hosts.map((host_name) => ({ host_name })),
+      desired_configs: configGroup.desired_configs || [],
+    },
+  }];
+}
+
+export function buildConfigGroupMembershipUpdates(
+  groups: any[],
+  serviceName: string,
+  currentGroupName: string,
+  targetGroupName: string,
+  hostName: string,
+): ConfigGroupMembershipUpdate[] {
+  if (currentGroupName === targetGroupName) {
+    return [];
+  }
+
+  return groups.flatMap((group) => {
+    const groupName = get(group, "ConfigGroup.group_name", "");
+    if (groupName !== currentGroupName && groupName !== targetGroupName) {
+      return [];
+    }
+    const hosts = new Set(groupHosts(group));
+    if (groupName === currentGroupName) {
+      hosts.delete(hostName);
+    }
+    if (groupName === targetGroupName) {
+      hosts.add(hostName);
+    }
+    const updatedHosts = [...hosts];
+    const updatedGroup = {
+      ...group,
+      ConfigGroup: {
+        ...group.ConfigGroup,
+        hosts: updatedHosts.map((host_name) => ({ host_name })),
+      },
+    };
+    return [{
+      group: updatedGroup,
+      groupId: String(get(group, "ConfigGroup.id")),
+      payload: payloadForHosts(updatedGroup, serviceName, updatedHosts),
+    }];
+  });
+}

--- a/ambari-web/latest/src/Utils/hostLogs.test.ts
+++ b/ambari-web/latest/src/Utils/hostLogs.test.ts
@@ -1,0 +1,108 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it, vi } from "vitest";
+import {
+  buildLogSearchUrl,
+  hostLogsToText,
+  mapHostLogEntries,
+  mapHostLogRows,
+  mergeHostLogEntries,
+  openTextInNewWindow,
+} from "./hostLogs";
+
+describe("host logs mapping", () => {
+  it("maps logging metadata and tolerates missing logging resources", () => {
+    const rows = mapHostLogRows({
+      host_components: [
+        {
+          HostRoles: {
+            component_name: "NAMENODE",
+            display_name: "NameNode",
+            service_name: "HDFS",
+          },
+          logging: {
+            name: "hdfs_namenode",
+            logs: [{ name: "/var/log/hdfs/namenode.log" }, "/tmp/a.out"],
+          },
+        },
+        { HostRoles: { component_name: "CLIENT" } },
+      ],
+    }, "host1", { HDFS: "HDFS Display" });
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      componentDisplayName: "NameNode",
+      logComponentName: "hdfs_namenode",
+      serviceDisplayName: "HDFS Display",
+    });
+    expect(rows[0].files.map((file) => file.fileName)).toEqual([
+      "namenode.log",
+      "a.out",
+    ]);
+  });
+
+  it("deduplicates polled entries and keeps chronological output", () => {
+    const first = mapHostLogEntries({
+      logList: [
+        { id: 2, logtime: "20", level: "WARN", log_message: "second" },
+        { id: 1, logtime: "10", level: "INFO", log_message: "first" },
+      ],
+    });
+    const merged = mergeHostLogEntries(first, [
+      { id: 2, logtime: 20, level: "ERROR", logMessage: "updated" },
+      { id: 3, logtime: 30, level: "INFO", logMessage: "third" },
+    ]);
+
+    expect(merged.map((row) => row.id)).toEqual([1, 2, 3]);
+    expect(hostLogsToText(merged)).toContain("ERROR updated");
+  });
+
+  it("opens loaded text through textContent instead of document.write", () => {
+    const pre = { textContent: "" };
+    const replaceChildren = vi.fn();
+    const document = {
+      title: "",
+      createElement: vi.fn(() => pre),
+      body: { replaceChildren },
+    };
+    const target = { document, opener: {} };
+    const openWindow = vi.fn(() => target);
+
+    expect(openTextInNewWindow("<script>unsafe()</script>", openWindow as any)).toBe(true);
+    expect(pre.textContent).toBe("<script>unsafe()</script>");
+    expect(replaceChildren).toHaveBeenCalledWith(pre);
+    expect((target as any).opener).toBeNull();
+  });
+
+  it("builds an encoded link from the LOGSEARCH quick-link root", () => {
+    const result = buildLogSearchUrl(
+      "https://logsearch.example:61888/#/",
+      "host one",
+      "hdfs_namenode",
+      "/var/log/hdfs/name node.log",
+    );
+
+    expect(result).toContain("https://logsearch.example:61888/#/logs/serviceLogs");
+    expect(result).toContain("hosts=host%20one");
+    expect(result).toContain("components=hdfs_namenode");
+    expect(decodeURIComponent(result.split(";query=")[1])).toContain(
+      '\"value\":\"/var/log/hdfs/name node.log\"',
+    );
+  });
+});

--- a/ambari-web/latest/src/Utils/hostLogs.ts
+++ b/ambari-web/latest/src/Utils/hostLogs.ts
@@ -1,0 +1,145 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export type HostLogFile = {
+  fileName: string;
+  filePath: string;
+};
+
+export type HostLogRow = {
+  componentDisplayName: string;
+  componentName: string;
+  files: HostLogFile[];
+  hostName: string;
+  id: string;
+  logComponentName: string;
+  serviceDisplayName: string;
+  serviceName: string;
+};
+
+export type HostLogEntry = {
+  id: number | string;
+  level: string;
+  logMessage: string;
+  logtime: number;
+};
+
+const nameFromPath = (path: string) => path.split("/").filter(Boolean).pop() || path;
+
+export function mapHostLogRows(
+  response: Record<string, unknown>,
+  hostName: string,
+  serviceDisplayNames: Record<string, string> = {},
+): HostLogRow[] {
+  const components = Array.isArray(response.host_components)
+    ? response.host_components as Record<string, any>[]
+    : [];
+  return components.flatMap((component) => {
+    const logging = component.logging;
+    if (!logging || !logging.name) {
+      return [];
+    }
+    const roles = component.HostRoles || {};
+    const serviceName = String(roles.service_name || "");
+    const componentName = String(roles.component_name || logging.name || "");
+    const logPaths = Array.isArray(logging.logs) ? logging.logs : [];
+    const files = logPaths
+      .map((item: string | { name?: string }) =>
+        typeof item === "string" ? item : item?.name,
+      )
+      .filter((path: string | undefined): path is string => Boolean(path))
+      .map((filePath: string) => ({ fileName: nameFromPath(filePath), filePath }));
+    return [{
+      componentDisplayName: String(roles.display_name || componentName),
+      componentName,
+      files,
+      hostName,
+      id: `${hostName}_${logging.name}`,
+      logComponentName: String(logging.name),
+      serviceDisplayName: serviceDisplayNames[serviceName] || serviceName,
+      serviceName,
+    }];
+  });
+}
+
+export function mapHostLogEntries(response: Record<string, unknown>): HostLogEntry[] {
+  const rows = Array.isArray(response.logList)
+    ? response.logList as Record<string, unknown>[]
+    : [];
+  return rows.map((item, index) => ({
+    id: item.id as number | string ?? `${item.logtime || 0}-${index}`,
+    level: String(item.level || ""),
+    logMessage: String(item.log_message || ""),
+    logtime: Number(item.logtime || 0),
+  }));
+}
+
+export function mergeHostLogEntries(
+  current: HostLogEntry[],
+  incoming: HostLogEntry[],
+): HostLogEntry[] {
+  const rows = new Map(current.map((item) => [String(item.id), item]));
+  incoming.forEach((item) => rows.set(String(item.id), item));
+  return Array.from(rows.values()).sort((left, right) => left.logtime - right.logtime);
+}
+
+export function hostLogsToText(rows: HostLogEntry[]): string {
+  return rows.map((row) => {
+    const timestamp = row.logtime
+      ? new Date(row.logtime).toISOString().replace("T", " ").replace("Z", "")
+      : "";
+    return [timestamp, row.level, row.logMessage].filter(Boolean).join(" ");
+  }).join("\n");
+}
+
+export function openTextInNewWindow(
+  value: string,
+  openWindow: typeof window.open = window.open.bind(window),
+): boolean {
+  const target = openWindow("about:blank", "_blank");
+  if (!target) {
+    return false;
+  }
+  target.opener = null;
+  target.document.title = "Ambari Log";
+  const pre = target.document.createElement("pre");
+  pre.textContent = value;
+  target.document.body.replaceChildren(pre);
+  return true;
+}
+
+export function buildLogSearchUrl(
+  baseUrl: string,
+  hostName: string,
+  componentName: string,
+  filePath: string,
+): string {
+  if (!baseUrl) {
+    return "";
+  }
+  const root = baseUrl.split("#", 1)[0].replace(/\/$/, "");
+  const query = encodeURIComponent(JSON.stringify([{
+    id: 0,
+    name: "path",
+    label: "Path",
+    value: filePath,
+    isExclude: false,
+  }]));
+  return `${root}/#/logs/serviceLogs;hosts=${encodeURIComponent(hostName)}`
+    + `;components=${encodeURIComponent(componentName)};query=${query}`;
+}

--- a/ambari-web/latest/src/Utils/hostWizard.test.ts
+++ b/ambari-web/latest/src/Utils/hostWizard.test.ts
@@ -1,0 +1,156 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  addHostRegistrationTimeoutSecs,
+  buildAddHostComponentAssignments,
+  buildAddHostConfigGroupUpdates,
+  buildAddHostConfigGroups,
+  buildBootstrapPayload,
+  prepareHostInput,
+  selectedAddHostServices,
+} from "./hostWizard";
+
+describe("Add Host install options", () => {
+  it("normalizes, expands, de-duplicates, and filters installed hosts", () => {
+    expect(prepareHostInput(
+      "Node[01-03].EXAMPLE.COM node02.example.com OLD.EXAMPLE.COM",
+      ["old.example.com"],
+    )).toEqual({
+      alreadyInstalled: ["old.example.com"],
+      hadPattern: true,
+      hosts: [
+        "node01.example.com",
+        "node02.example.com",
+        "node03.example.com",
+      ],
+    });
+  });
+
+  it("forces root unless the customize-agent-user flag is enabled", () => {
+    expect(buildBootstrapPayload({
+      customizeAgentUserAccount: false,
+      hosts: ["host1"],
+      agentUserAccount: "ambari",
+    }).userRunAs).toBe("root");
+    expect(buildBootstrapPayload({
+      customizeAgentUserAccount: true,
+      hosts: ["host1"],
+      agentUserAccount: "ambari",
+    }).userRunAs).toBe("ambari");
+  });
+
+  it("allows automatic bootstrap longer to register than manual Agent mode", () => {
+    expect(addHostRegistrationTimeoutSecs(true)).toBe(120);
+    expect(addHostRegistrationTimeoutSecs(false)).toBe(15);
+  });
+
+  it("loads config groups only for services with selected components", () => {
+    expect(selectedAddHostServices(
+      [{ checkboxes: [
+        { checked: true, label: "DATANODE" },
+        { checked: false, label: "NODEMANAGER" },
+        { checked: true, label: "CLIENT" },
+      ] }],
+      [
+        { component_name: "DATANODE", service_name: "HDFS" },
+        { component_name: "NODEMANAGER", service_name: "YARN" },
+      ],
+    )).toEqual(["HDFS"]);
+  });
+
+  it("preserves a restored non-default config group", () => {
+    const result = buildAddHostConfigGroups(
+      ["HDFS"],
+      { items: [{ ConfigGroup: { tag: "HDFS", group_name: "workers" } }] },
+      "c1",
+      [{
+        serviceName: "HDFS",
+        configGroups: [{ group_name: "workers", isSelected: true }],
+      }],
+    );
+    expect(result[0].configGroups.find((group: any) => group.isSelected).group_name)
+      .toBe("workers");
+  });
+
+  it("expands the generic CLIENT selection to concrete client components", () => {
+    const metadata = [
+      { component_name: "HDFS_CLIENT", service_name: "HDFS", is_client: true },
+      { component_name: "YARN_CLIENT", service_name: "YARN", component_category: "CLIENT" },
+      { component_name: "DATANODE", service_name: "HDFS", is_client: false },
+    ];
+    const assignments = [{
+      hostname: "host1",
+      checkboxes: [{ checked: true, label: "CLIENT" }],
+    }];
+
+    expect(selectedAddHostServices(assignments, metadata)).toEqual(["HDFS", "YARN"]);
+    expect(buildAddHostComponentAssignments(assignments, metadata)).toEqual({
+      HDFS_CLIENT: ["host1"],
+      YARN_CLIENT: ["host1"],
+    });
+  });
+
+  it("builds a complete classic-compatible config-group membership update", () => {
+    const assignments = [
+      { hostname: "host1", checkboxes: [{ checked: true, label: "DATANODE" }] },
+      { hostname: "host2", checkboxes: [{ checked: true, label: "DATANODE" }] },
+    ];
+    const metadata = [
+      { component_name: "DATANODE", service_name: "HDFS", is_client: false },
+    ];
+    const configurations = [{
+      serviceName: "HDFS",
+      configGroups: [{
+        id: 7,
+        group_name: "workers",
+        tag: "HDFS",
+        service_name: "HDFS",
+        description: "Worker hosts",
+        desired_configs: [{ type: "hdfs-site", tag: "version1" }],
+        hosts: [{ host_name: "existing" }],
+        isSelected: true,
+      }],
+    }];
+
+    expect(buildAddHostConfigGroupUpdates(
+      configurations,
+      assignments,
+      metadata,
+    )).toEqual([{
+      groupId: "7",
+      serviceName: "HDFS",
+      payload: [{
+        ConfigGroup: {
+          id: 7,
+          group_name: "workers",
+          tag: "HDFS",
+          service_name: "HDFS",
+          description: "Worker hosts",
+          desired_configs: [{ type: "hdfs-site", tag: "version1" }],
+          hosts: [
+            { host_name: "existing" },
+            { host_name: "host1" },
+            { host_name: "host2" },
+          ],
+        },
+      }],
+    }]);
+  });
+});

--- a/ambari-web/latest/src/Utils/hostWizard.ts
+++ b/ambari-web/latest/src/Utils/hostWizard.ts
@@ -1,0 +1,257 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export type PreparedHostInput = {
+  alreadyInstalled: string[];
+  hadPattern: boolean;
+  hosts: string[];
+};
+
+export function prepareHostInput(
+  input: string,
+  installedHosts: string[] = [],
+): PreparedHostInput {
+  let hadPattern = false;
+  const expanded = input
+    .split(/\s+/)
+    .map((host) => host.trim().toLowerCase())
+    .filter(Boolean)
+    .flatMap((host) => {
+      const match = /^(.*)\[(\d+)-(\d+)\](.*)$/.exec(host);
+      if (!match) {
+        return [host];
+      }
+      const [, prefix, startText, endText, suffix] = match;
+      const start = Number(startText);
+      const end = Number(endText);
+      if (end < start) {
+        return [host];
+      }
+      hadPattern = true;
+      const width = Math.max(startText.length, endText.length);
+      return Array.from({ length: end - start + 1 }, (_, index) =>
+        `${prefix}${String(start + index).padStart(width, "0")}${suffix}`,
+      );
+    });
+  const uniqueHosts = Array.from(new Set(expanded));
+  const installed = new Set(installedHosts.map((host) => host.toLowerCase()));
+  return {
+    alreadyInstalled: uniqueHosts.filter((host) => installed.has(host)),
+    hadPattern,
+    hosts: uniqueHosts.filter((host) => !installed.has(host)),
+  };
+}
+
+export type BootstrapSettings = {
+  agentUserAccount?: string;
+  customizeAgentUserAccount: boolean;
+  hosts: string[];
+  sshKey?: string;
+  sshPortNumber?: number;
+  sshUserAccount?: string;
+};
+
+export function buildBootstrapPayload(settings: BootstrapSettings) {
+  return {
+    verbose: true,
+    sshKey: settings.sshKey || "",
+    hosts: settings.hosts,
+    user: settings.sshUserAccount || "",
+    sshPort: String(settings.sshPortNumber || ""),
+    userRunAs: settings.customizeAgentUserAccount
+      ? settings.agentUserAccount || ""
+      : "root",
+  };
+}
+
+export function addHostRegistrationTimeoutSecs(
+  usesAutomaticBootstrap: boolean,
+): number {
+  return usesAutomaticBootstrap ? 120 : 15;
+}
+
+export function selectedAddHostServices(
+  assignments: AddHostAssignment[] = [],
+  componentMetadata: AddHostComponentMetadata[] = [],
+): string[] {
+  const selectedComponents = new Set(
+    assignments.flatMap((assignment) => (assignment.checkboxes || [])
+      .filter((component) => component.checked && component.label !== "CLIENT")
+      .map((component) => component.label || "")),
+  );
+  const clientsSelected = assignments.some((assignment) =>
+    (assignment.checkboxes || []).some(
+      (component) => component.checked && component.label === "CLIENT",
+    ),
+  );
+  return Array.from(new Set(componentMetadata
+    .filter((component) => selectedComponents.has(component.component_name || "")
+      || (clientsSelected && isClientComponent(component)))
+    .map((component) => component.service_name || "")
+    .filter(Boolean)));
+}
+
+export type AddHostAssignment = {
+  hostname?: string;
+  checkboxes?: Array<{ checked?: boolean; label?: string }>;
+};
+
+export type AddHostComponentMetadata = {
+  component_category?: string;
+  component_name?: string;
+  is_client?: boolean;
+  service_name?: string;
+};
+
+export type AddHostConfigGroupUpdate = {
+  groupId: string;
+  payload: Array<{ ConfigGroup: Record<string, any> }>;
+  serviceName: string;
+};
+
+function isClientComponent(component: AddHostComponentMetadata) {
+  return component.is_client === true || component.component_category === "CLIENT";
+}
+
+export function buildAddHostComponentAssignments(
+  assignments: AddHostAssignment[] = [],
+  componentMetadata: AddHostComponentMetadata[] = [],
+): Record<string, string[]> {
+  const clientComponents = componentMetadata
+    .filter(isClientComponent)
+    .map((component) => component.component_name || "")
+    .filter(Boolean);
+  const hostsByComponent: Record<string, Set<string>> = {};
+
+  assignments.forEach((assignment) => {
+    if (!assignment.hostname) return;
+    (assignment.checkboxes || [])
+      .filter((component) => component.checked)
+      .flatMap((component) => component.label === "CLIENT"
+        ? clientComponents
+        : [component.label || ""])
+      .filter(Boolean)
+      .forEach((componentName) => {
+        if (!hostsByComponent[componentName]) {
+          hostsByComponent[componentName] = new Set();
+        }
+        hostsByComponent[componentName].add(assignment.hostname!);
+      });
+  });
+
+  return Object.fromEntries(Object.entries(hostsByComponent).map(
+    ([componentName, hosts]) => [componentName, [...hosts]],
+  ));
+}
+
+export function buildAddHostServiceHosts(
+  assignments: AddHostAssignment[] = [],
+  componentMetadata: AddHostComponentMetadata[] = [],
+): Record<string, string[]> {
+  const serviceByComponent = Object.fromEntries(componentMetadata.map((component) => [
+    component.component_name || "",
+    component.service_name || "",
+  ]));
+  const hostsByComponent = buildAddHostComponentAssignments(assignments, componentMetadata);
+  const hostsByService: Record<string, Set<string>> = {};
+
+  Object.entries(hostsByComponent).forEach(([componentName, hosts]) => {
+    const serviceName = serviceByComponent[componentName];
+    if (!serviceName) return;
+    if (!hostsByService[serviceName]) {
+      hostsByService[serviceName] = new Set();
+    }
+    hosts.forEach((hostName) => hostsByService[serviceName].add(hostName));
+  });
+
+  return Object.fromEntries(Object.entries(hostsByService).map(
+    ([serviceName, hosts]) => [serviceName, [...hosts]],
+  ));
+}
+
+export function buildAddHostConfigGroupUpdates(
+  configurations: Array<Record<string, any>> = [],
+  assignments: AddHostAssignment[] = [],
+  componentMetadata: AddHostComponentMetadata[] = [],
+): AddHostConfigGroupUpdate[] {
+  const hostsByService = buildAddHostServiceHosts(assignments, componentMetadata);
+
+  return configurations.flatMap((serviceConfiguration) => {
+    const serviceName = serviceConfiguration.serviceName || "";
+    const selectedGroup = (serviceConfiguration.configGroups || []).find(
+      (group: Record<string, any>) => group.isSelected,
+    );
+    if (!selectedGroup || selectedGroup.group_name === "Default" || selectedGroup.id == null) {
+      return [];
+    }
+    const existingHosts = (selectedGroup.hosts || [])
+      .map((host: Record<string, any>) => host.host_name)
+      .filter(Boolean);
+    const hosts = Array.from(new Set([
+      ...existingHosts,
+      ...(hostsByService[serviceName] || []),
+    ]));
+    const {
+      isSelected: _isSelected,
+      ...groupData
+    } = selectedGroup;
+    return [{
+      groupId: String(selectedGroup.id),
+      serviceName,
+      payload: [{
+        ConfigGroup: {
+          ...groupData,
+          hosts: hosts.map((host_name) => ({ host_name })),
+        },
+      }],
+    }];
+  });
+}
+
+export function buildAddHostConfigGroups(
+  serviceNames: string[],
+  response: Record<string, any>,
+  clusterName: string,
+  restored: Array<Record<string, any>> = [],
+) {
+  return serviceNames.map((serviceName) => {
+    const restoredService = restored.find((item) => item.serviceName === serviceName);
+    const restoredSelection = restoredService?.configGroups?.find(
+      (group: Record<string, any>) => group.isSelected,
+    )?.group_name;
+    const groups = (response.items || [])
+      .filter((item: Record<string, any>) => item.ConfigGroup?.tag === serviceName)
+      .map((item: Record<string, any>) => ({
+        ...item.ConfigGroup,
+        isSelected: item.ConfigGroup.group_name === restoredSelection,
+      }));
+    groups.unshift({
+      cluster_name: clusterName,
+      description: "",
+      desired_configs: [],
+      group_name: "Default",
+      hosts: [],
+      tag: serviceName,
+      isSelected: !restoredSelection || restoredSelection === "Default",
+    });
+    if (restoredSelection && !groups.some((group: Record<string, any>) => group.isSelected)) {
+      groups[0].isSelected = true;
+    }
+    return { serviceName, configGroups: groups };
+  });
+}

--- a/ambari-web/latest/src/Utils/hosts.test.ts
+++ b/ambari-web/latest/src/Utils/hosts.test.ts
@@ -1,0 +1,265 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it, vi } from "vitest";
+import {
+  applyCompletedDecommissionRequest,
+  applyHostComponentEvent,
+  applyHostEvent,
+  applyHostStackVersionVisibility,
+  buildHostSuggestionPredicate,
+  deleteHostComponentsInOrder,
+  hasCrossStackHostVersions,
+  hostComponentConfigRules,
+  shouldLoadCompatibleRepositoryVersions,
+  shouldExcludeAddableHostComponent,
+} from "./hosts";
+
+type TestHost = {
+  alertsSummary?: unknown;
+  hostComponents: Array<{
+    adminState: string;
+    componentName: string;
+    hostName: string;
+    passiveState: string;
+    staleConfigs: boolean;
+    workStatus: string;
+  }>;
+  hostName: string;
+  lastHeartBeatTime?: number;
+  passiveState: string;
+};
+
+const hosts: TestHost[] = [
+  {
+    hostName: "host1",
+    passiveState: "ON",
+    hostComponents: [
+      {
+        hostName: "host1",
+        componentName: "DATANODE",
+        workStatus: "STARTED",
+        staleConfigs: true,
+        passiveState: "IMPLIED_FROM_HOST",
+        adminState: "INSERVICE",
+      },
+    ],
+  },
+  {
+    hostName: "host2",
+    passiveState: "OFF",
+    hostComponents: [
+      {
+        hostName: "host2",
+        componentName: "DATANODE",
+        workStatus: "STARTED",
+        staleConfigs: true,
+        passiveState: "OFF",
+        adminState: "INSERVICE",
+      },
+    ],
+  },
+];
+
+describe("Hosts realtime reconciliation", () => {
+  it("matches component events by host and retains false and OFF values", () => {
+    const result = applyHostComponentEvent(hosts, {
+      hostComponents: [{
+        hostName: "host2",
+        componentName: "DATANODE",
+        currentState: "INSTALLED",
+        staleConfigs: false,
+        maintenanceState: "OFF",
+      }],
+    });
+
+    expect(result[0].hostComponents[0].workStatus).toBe("STARTED");
+    expect(result[1].hostComponents[0]).toMatchObject({
+      workStatus: "INSTALLED",
+      staleConfigs: false,
+      passiveState: "OFF",
+    });
+  });
+
+  it("retains zero values and removes implied host maintenance", () => {
+    const result = applyHostEvent(hosts, {
+      host_name: "host1",
+      last_heartbeat_time: 0,
+      maintenance_state: "OFF",
+      alerts_summary: {},
+    });
+
+    expect(result[0].lastHeartBeatTime).toBe(0);
+    expect(result[0].alertsSummary).toEqual({});
+    expect(result[0].hostComponents[0].passiveState).toBe("OFF");
+  });
+
+  it("updates every task host in a completed decommission request", () => {
+    const result = applyCompletedDecommissionRequest(hosts, {
+      requestStatus: "COMPLETED",
+      requestContext: "Decommission DataNode",
+      Tasks: [
+        { hostName: "host1", role: "DATANODE" },
+        { hostName: "host2", role: "DATANODE" },
+      ],
+    });
+
+    expect(result.map((host) => host.hostComponents[0].adminState)).toEqual([
+      "DECOMMISSIONED",
+      "DECOMMISSIONED",
+    ]);
+  });
+});
+
+describe("host suggestion predicates", () => {
+  it("escapes regex metacharacters without double encoding POST data", () => {
+    expect(buildHostSuggestionPredicate("host_name", "node[1].a+b"))
+      .toBe("Hosts/host_name.matches(.*node\\[1\\]\\.a\\+b.*)");
+  });
+
+  it("rejects fields that could inject a predicate", () => {
+    expect(() => buildHostSuggestionPredicate("host_name)|Hosts/ip", "x"))
+      .toThrow("Unsupported host suggestion field");
+  });
+});
+
+describe("host deletion sequencing", () => {
+  it("stops deleting components at the first failure", async () => {
+    const deleteComponent = vi.fn()
+      .mockResolvedValueOnce(undefined)
+      .mockRejectedValueOnce(new Error("component delete failed"));
+
+    await expect(deleteHostComponentsInOrder(
+      ["DATANODE", "NODEMANAGER", "HBASE_REGIONSERVER"],
+      deleteComponent,
+    )).rejects.toThrow("component delete failed");
+
+    expect(deleteComponent.mock.calls).toEqual([
+      ["DATANODE"],
+      ["NODEMANAGER"],
+    ]);
+  });
+});
+
+describe("host component configuration rules", () => {
+  const rules = hostComponentConfigRules({
+    items: [{
+      configurations: [
+        {
+          type: "hive-env",
+          properties: { hive_database: "Existing MySQL Database" },
+        },
+        {
+          type: "hive-interactive-env",
+          properties: { enable_hive_interactive: "true" },
+        },
+        {
+          type: "oozie-env",
+          properties: { oozie_database: "New Derby Database" },
+        },
+      ],
+    }],
+  }, ["HDFS", "HIVE", "OOZIE"]);
+
+  it("derives Oozie, Hive Interactive, and Hive database decisions from current configs", () => {
+    expect(rules).toEqual({
+      enableHiveInteractive: true,
+      hiveDatabaseType: "Existing MySQL Database",
+      isOozieServerAddable: false,
+    });
+  });
+
+  it("matches classic exclusions for optional components", () => {
+    expect(shouldExcludeAddableHostComponent(
+      "OOZIE_SERVER", ["HDFS", "HIVE", "OOZIE"], rules,
+    )).toBe(true);
+    expect(shouldExcludeAddableHostComponent(
+      "HIVE_SERVER_INTERACTIVE", ["HDFS", "HIVE", "OOZIE"], rules,
+    )).toBe(false);
+    expect(shouldExcludeAddableHostComponent(
+      "OZONE_DATANODE", ["HDFS", "HIVE", "OOZIE"], rules,
+    )).toBe(true);
+  });
+});
+
+describe("host stack-version visibility", () => {
+  const version = (
+    stack: string,
+    repositoryVersion: string,
+    state: string,
+  ): {
+    HostStackVersions: { stack: string; state: string };
+    is_visible?: boolean;
+    repository_versions: Array<{
+      RepositoryVersions: { repository_version: string };
+    }>;
+  } => ({
+    HostStackVersions: { stack, state },
+    repository_versions: [{
+      RepositoryVersions: { repository_version: repositoryVersion },
+    }],
+  });
+
+  it("matches classic older-version and cross-stack compatibility rules", () => {
+    const host = {
+      stack_versions: [
+        version("HDP-3.1", "3.1.4.0", "INSTALLED"),
+        version("HDP-3.1", "3.1.5.0", "CURRENT"),
+        version("HDP-3.1", "3.1.6.0", "OUT_OF_SYNC"),
+        version("HDP-4.0", "4.0.0.0", "OUT_OF_SYNC"),
+        version("HDP-5.0", "5.0.0.0", "OUT_OF_SYNC"),
+      ],
+    };
+
+    expect(hasCrossStackHostVersions([host])).toBe(true);
+    applyHostStackVersionVisibility([host], ["4.0.0.0"], false);
+
+    expect(host.stack_versions.map((item) => item.is_visible)).toEqual([
+      false,
+      true,
+      true,
+      true,
+      false,
+    ]);
+  });
+
+  it("shows same-stack older versions when the support flag is enabled", () => {
+    const host = {
+      stack_versions: [
+        version("HDP-3.1", "3.1.4.0", "INSTALLED"),
+        version("HDP-3.1", "3.1.5.0", "CURRENT"),
+      ],
+    };
+
+    applyHostStackVersionVisibility([host], [], true);
+    expect(host.stack_versions.every((item) => item.is_visible)).toBe(true);
+  });
+
+  it("waits for stack context before loading cross-stack compatibility", () => {
+    const host = {
+      stack_versions: [
+        version("HDP-3.1", "3.1.5.0", "CURRENT"),
+        version("HDP-4.0", "4.0.0.0", "OUT_OF_SYNC"),
+      ],
+    };
+
+    expect(shouldLoadCompatibleRepositoryVersions([host], "", "3.1")).toBe(false);
+    expect(shouldLoadCompatibleRepositoryVersions([host], "HDP", "")).toBe(false);
+    expect(shouldLoadCompatibleRepositoryVersions([host], "HDP", "3.1")).toBe(true);
+  });
+});

--- a/ambari-web/latest/src/Utils/hosts.ts
+++ b/ambari-web/latest/src/Utils/hosts.ts
@@ -1,0 +1,319 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { cloneDeep } from "lodash";
+import { PassiveStateOnFilters } from "../screens/Hosts/enums";
+import stringUtilsObj from "./StringUtilsObj";
+
+type HostComponentLike = {
+  adminState?: string;
+  componentName?: string;
+  hostName?: string;
+  passiveState?: string;
+  staleConfigs?: boolean;
+  workStatus?: string;
+};
+
+type HostLike = {
+  alertsSummary?: unknown;
+  healthStatus?: string;
+  hostComponents: HostComponentLike[];
+  hostName: string;
+  lastHeartBeatTime?: number;
+  passiveState?: string;
+  state?: string;
+};
+
+const hasOwn = (value: unknown, property: string): boolean =>
+  Object.prototype.hasOwnProperty.call(value, property);
+
+function applyHostMaintenanceToComponent(
+  component: HostComponentLike,
+  desiredState: string,
+) {
+  const currentState = component.passiveState || "OFF";
+  if (currentState === desiredState) {
+    return;
+  }
+  if (desiredState === "OFF") {
+    if (currentState === PassiveStateOnFilters.IMPLIED_FROM_SERVICE_AND_HOST) {
+      component.passiveState = PassiveStateOnFilters.IMPLIED_FROM_SERVICE;
+    } else if (currentState === PassiveStateOnFilters.IMPLIED_FROM_HOST) {
+      component.passiveState = "OFF";
+    }
+    return;
+  }
+  if (currentState === PassiveStateOnFilters.IMPLIED_FROM_SERVICE) {
+    component.passiveState = PassiveStateOnFilters.IMPLIED_FROM_SERVICE_AND_HOST;
+  } else if (currentState === "OFF") {
+    component.passiveState = PassiveStateOnFilters.IMPLIED_FROM_HOST;
+  }
+}
+
+export function applyHostComponentEvent<T extends HostLike>(
+  hosts: T[],
+  event: Record<string, unknown>,
+): T[] {
+  const result = cloneDeep(hosts);
+  const updates = Array.isArray(event.hostComponents) ? event.hostComponents : [];
+  updates.forEach((update: Record<string, unknown>) => {
+    const hostName = String(update.hostName || "");
+    const componentName = String(update.componentName || "");
+    const host = result.find((item) => item.hostName === hostName);
+    const component = host?.hostComponents.find(
+      (item) => item.componentName === componentName,
+    );
+    if (!component) {
+      return;
+    }
+    if (hasOwn(update, "currentState")) {
+      component.workStatus = update.currentState as string;
+    }
+    if (hasOwn(update, "staleConfigs")) {
+      component.staleConfigs = update.staleConfigs as boolean;
+    }
+    if (hasOwn(update, "maintenanceState")) {
+      component.passiveState = update.maintenanceState as string;
+    }
+  });
+  return result;
+}
+
+export function applyHostEvent<T extends HostLike>(
+  hosts: T[],
+  event: Record<string, unknown>,
+): T[] {
+  const result = cloneDeep(hosts);
+  const host = result.find((item) => item.hostName === event.host_name);
+  if (!host) {
+    return result;
+  }
+  const fields: Array<[keyof HostLike, string]> = [
+    ["alertsSummary", "alerts_summary"],
+    ["healthStatus", "host_status"],
+    ["state", "host_state"],
+    ["lastHeartBeatTime", "last_heartbeat_time"],
+    ["passiveState", "maintenance_state"],
+  ];
+  fields.forEach(([target, source]) => {
+    if (hasOwn(event, source)) {
+      Object.assign(host, { [target]: event[source] });
+    }
+  });
+  if (hasOwn(event, "maintenance_state")) {
+    host.hostComponents.forEach((component) =>
+      applyHostMaintenanceToComponent(component, String(event.maintenance_state)),
+    );
+  }
+  return result;
+}
+
+const DECOMMISSION_COMPONENTS = [
+  "DATANODE",
+  "NODEMANAGER",
+  "HBASE_REGIONSERVER",
+  "TASKTRACKER",
+];
+
+function componentFromRequest(context: string, task: Record<string, unknown>): string {
+  const taskComponent = String(
+    task.componentName || task.component_name || task.role || "",
+  ).toUpperCase();
+  if (DECOMMISSION_COMPONENTS.includes(taskComponent)) {
+    return taskComponent;
+  }
+  return DECOMMISSION_COMPONENTS.find((component) =>
+    context.includes(component.toLowerCase().replace("hbase_", "")),
+  ) || "";
+}
+
+export function applyCompletedDecommissionRequest<T extends HostLike>(
+  hosts: T[],
+  event: Record<string, unknown>,
+): T[] {
+  if (event.requestStatus !== "COMPLETED") {
+    return cloneDeep(hosts);
+  }
+  const context = String(event.requestContext || "").toLowerCase();
+  const isRecommission = context.includes("recommission");
+  const isDecommission = !isRecommission && context.includes("decommission");
+  if (!isDecommission && !isRecommission) {
+    return cloneDeep(hosts);
+  }
+  const tasks = Array.isArray(event.Tasks)
+    ? event.Tasks
+    : Array.isArray(event.tasks)
+      ? event.tasks
+      : [];
+  const result = cloneDeep(hosts);
+  tasks.forEach((task: Record<string, unknown>) => {
+    const hostName = String(task.hostName || task.host_name || "");
+    const componentName = componentFromRequest(context, task);
+    const component = result
+      .find((host) => host.hostName === hostName)
+      ?.hostComponents.find((item) => item.componentName === componentName);
+    if (component) {
+      component.adminState = isRecommission ? "INSERVICE" : "DECOMMISSIONED";
+    }
+  });
+  return result;
+}
+
+export function escapeAmbariPredicateValue(value: string): string {
+  return value.replace(/[\\^$.*+?()[\]{}|]/g, "\\$&");
+}
+
+export function buildHostSuggestionPredicate(field: string, value: string): string {
+  if (!/^[a-z_]+$/i.test(field)) {
+    throw new Error(`Unsupported host suggestion field: ${field}`);
+  }
+  return value
+    ? `Hosts/${field}.matches(.*${escapeAmbariPredicateValue(value)}.*)`
+    : "";
+}
+
+export async function deleteHostComponentsInOrder<T>(
+  components: T[],
+  deleteComponent: (component: T) => Promise<unknown>,
+): Promise<void> {
+  for (const component of components) {
+    await deleteComponent(component);
+  }
+}
+
+export type HostComponentConfigRules = {
+  enableHiveInteractive: boolean;
+  hiveDatabaseType: string;
+  isOozieServerAddable: boolean;
+};
+
+type CurrentServiceConfig = {
+  properties?: Record<string, string>;
+  type?: string;
+};
+
+type CurrentServiceConfigResponse = {
+  items?: Array<{ configurations?: CurrentServiceConfig[] }>;
+};
+
+export function hostComponentConfigRules(
+  response: CurrentServiceConfigResponse,
+  installedServices: string[],
+): HostComponentConfigRules {
+  const configurations = (response.items || []).flatMap(
+    (item) => item.configurations || [],
+  );
+  const hiveEnv = configurations.find((config) => config.type === "hive-env");
+  const hiveInteractiveEnv = configurations.find(
+    (config) => config.type === "hive-interactive-env",
+  );
+  const oozieEnv = configurations.find((config) => config.type === "oozie-env");
+  const oozieDatabase = oozieEnv?.properties?.oozie_database || "";
+
+  return {
+    enableHiveInteractive:
+      hiveInteractiveEnv?.properties?.enable_hive_interactive === "true",
+    hiveDatabaseType: hiveEnv?.properties?.hive_database || "",
+    isOozieServerAddable: !installedServices.includes("OOZIE")
+      || Boolean(oozieDatabase && oozieDatabase !== "New Derby Database"),
+  };
+}
+
+export function shouldExcludeAddableHostComponent(
+  componentName: string,
+  installedServices: string[],
+  rules: HostComponentConfigRules,
+): boolean {
+  return (componentName === "OOZIE_SERVER" && !rules.isOozieServerAddable)
+    || (componentName === "HIVE_SERVER_INTERACTIVE" && !rules.enableHiveInteractive)
+    || (componentName === "OZONE_DATANODE" && installedServices.includes("HDFS"));
+}
+
+type RawHostStackVersion = {
+  HostStackVersions?: {
+    stack?: string;
+    state?: string;
+  };
+  is_visible?: boolean;
+  repository_versions?: Array<{
+    RepositoryVersions?: { repository_version?: string };
+  }>;
+};
+
+type RawHostWithStackVersions = {
+  stack_versions?: RawHostStackVersion[];
+};
+
+const repositoryVersionOf = (version: RawHostStackVersion): string =>
+  String(version.repository_versions?.[0]?.RepositoryVersions?.repository_version || "");
+
+export function hasCrossStackHostVersions(
+  hosts: RawHostWithStackVersions[],
+): boolean {
+  return hosts.some((host) => {
+    const versions = host.stack_versions || [];
+    const current = versions.find(
+      (version) => version.HostStackVersions?.state === "CURRENT",
+    );
+    const currentStack = current?.HostStackVersions?.stack;
+    return Boolean(currentStack) && versions.some(
+      (version) => version.HostStackVersions?.stack !== currentStack,
+    );
+  });
+}
+
+export function shouldLoadCompatibleRepositoryVersions(
+  hosts: RawHostWithStackVersions[],
+  stackName: string,
+  stackVersion: string,
+): boolean {
+  return Boolean(stackName && stackVersion) && hasCrossStackHostVersions(hosts);
+}
+
+export function applyHostStackVersionVisibility(
+  hosts: RawHostWithStackVersions[],
+  compatibleRepositoryVersions: Iterable<string>,
+  displayOlderVersions: boolean,
+): void {
+  const compatible = new Set(compatibleRepositoryVersions);
+  hosts.forEach((host) => {
+    const versions = host.stack_versions || [];
+    const current = versions.find(
+      (version) => version.HostStackVersions?.state === "CURRENT",
+    );
+    const currentStack = current?.HostStackVersions?.stack;
+    const currentRepositoryVersion = current ? repositoryVersionOf(current) : "";
+
+    versions.forEach((version) => {
+      const repositoryVersion = repositoryVersionOf(version);
+      const isDifferentStack = Boolean(current)
+        && version.HostStackVersions?.stack !== currentStack;
+      if (isDifferentStack && !compatible.has(repositoryVersion)) {
+        version.is_visible = false;
+        return;
+      }
+      version.is_visible = isDifferentStack
+        || displayOlderVersions
+        || !currentRepositoryVersion
+        || stringUtilsObj.compareVersions(
+          repositoryVersion,
+          currentRepositoryVersion,
+        ) >= 0;
+    });
+  });
+}

--- a/ambari-web/latest/src/api/alertsApi.test.ts
+++ b/ambari-web/latest/src/api/alertsApi.test.ts
@@ -1,0 +1,45 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({ request: vi.fn() }));
+vi.mock("./config/axiosConfig", () => ({ ambariApi: { request: mocks.request } }));
+
+import { AlertsApi } from "./alertsApi";
+
+describe("alerts API", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.request.mockResolvedValue({ data: { items: [] } });
+  });
+
+  it("loads alert instances for an encoded cluster and an exact host", async () => {
+    await AlertsApi.getHostAlertInstances("cluster/name", "host & one", 1234);
+
+    expect(mocks.request).toHaveBeenCalledWith({
+      url: "/clusters/cluster%2Fname/alerts",
+      method: "GET",
+      params: {
+        fields: "*",
+        "Alert/host_name": "host & one",
+        _: 1234,
+      },
+    });
+  });
+});

--- a/ambari-web/latest/src/api/alertsApi.ts
+++ b/ambari-web/latest/src/api/alertsApi.ts
@@ -74,6 +74,22 @@ export const AlertsApi = {
     });
     return response.data
   },
+  getHostAlertInstances: async function (
+    clusterName: string,
+    hostName: string,
+    time: number = Date.now()
+  ) {
+    const response = await ambariApi.request({
+      url: `/clusters/${encodeURIComponent(clusterName)}/alerts`,
+      method: "GET",
+      params: {
+        fields: "*",
+        "Alert/host_name": hostName,
+        _: time,
+      },
+    });
+    return response.data;
+  },
   getAlertDetails: async function (
     clusterName: string,
       alert_id: string,

--- a/ambari-web/latest/src/api/configGroupApi.test.ts
+++ b/ambari-web/latest/src/api/configGroupApi.test.ts
@@ -1,0 +1,60 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({ request: vi.fn() }));
+vi.mock("./config/axiosConfig", () => ({ ambariApi: { request: mocks.request } }));
+
+import ConfigGroupApi from "./configGroupApi";
+
+describe("config group API", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.request.mockResolvedValue({ data: { items: [] } });
+  });
+
+  it("loads all groups for the requested services in one encoded query", async () => {
+    await ConfigGroupApi.getConfigGroupsForServices(
+      "cluster/name",
+      ["HDFS", "SERVICE/ONE"],
+    );
+
+    expect(mocks.request).toHaveBeenCalledWith({
+      url: "/clusters/cluster%2Fname/config_groups?ConfigGroup/tag.in(HDFS,SERVICE%2FONE)&fields=*",
+      method: "GET",
+    });
+  });
+
+  it("encodes both identifiers when updating full group membership", async () => {
+    const data = [{
+      ConfigGroup: {
+        id: 1,
+        group_name: "workers",
+        hosts: [{ host_name: "host1" }],
+      },
+    }];
+    await ConfigGroupApi.updateConfigGroup("cluster/name", "group/1", data);
+
+    expect(mocks.request).toHaveBeenCalledWith({
+      url: "/clusters/cluster%2Fname/config_groups/group%2F1",
+      method: "PUT",
+      data,
+    });
+  });
+});

--- a/ambari-web/latest/src/api/configGroupApi.ts
+++ b/ambari-web/latest/src/api/configGroupApi.ts
@@ -73,7 +73,7 @@ const ConfigGroupApi = {
     return response.data;
   },
   updateConfigGroup: async (clusterName: string, configGroupId: string, data: any) => {
-    const url = `clusters/${clusterName}/config_groups/${configGroupId}`;
+    const url = `/clusters/${encodeURIComponent(clusterName)}/config_groups/${encodeURIComponent(configGroupId)}`;
     const response = await ambariApi.request({
       url,
       method: "PUT",
@@ -86,6 +86,18 @@ const ConfigGroupApi = {
     fields: string
   ) => {
     const url = `clusters/${clusterName}/config_groups?fields=${fields}`;
+    const response = await ambariApi.request({
+      url,
+      method: "GET",
+    });
+    return response.data;
+  },
+  getConfigGroupsForServices: async (
+    clusterName: string,
+    serviceNames: string[],
+  ) => {
+    const servicePredicate = serviceNames.map(encodeURIComponent).join(",");
+    const url = `/clusters/${encodeURIComponent(clusterName)}/config_groups?ConfigGroup/tag.in(${servicePredicate})&fields=*`;
     const response = await ambariApi.request({
       url,
       method: "GET",

--- a/ambari-web/latest/src/api/hostLogsApi.test.ts
+++ b/ambari-web/latest/src/api/hostLogsApi.test.ts
@@ -1,0 +1,54 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({ request: vi.fn() }));
+vi.mock("./config/axiosConfig", () => ({ ambariApi: { request: mocks.request } }));
+
+import HostLogsApi from "./hostLogsApi";
+
+describe("host logs API", () => {
+  beforeEach(() => mocks.request.mockResolvedValue({ data: {} }));
+
+  it("loads host logging metadata with encoded resource identifiers", async () => {
+    await HostLogsApi.fetchHostLogs("cluster/name", "host name");
+    expect(mocks.request).toHaveBeenCalledWith({
+      url: "/clusters/cluster%2Fname/hosts/host%20name",
+      method: "GET",
+      params: {
+        fields: "host_components/logging,host_components/HostRoles/service_name,host_components/HostRoles/component_name,host_components/HostRoles/display_name",
+        minimal_response: true,
+      },
+    });
+  });
+
+  it("loads a bounded log tail without interpolating query values", async () => {
+    await HostLogsApi.fetchLogTail("c1", "hdfs_namenode", "host&1", 100, 25);
+    expect(mocks.request).toHaveBeenCalledWith({
+      url: "/clusters/c1/logging/searchEngine",
+      method: "GET",
+      params: {
+        component_name: "hdfs_namenode",
+        host_name: "host&1",
+        pageSize: 100,
+        startIndex: 25,
+      },
+    });
+  });
+});

--- a/ambari-web/latest/src/api/hostLogsApi.ts
+++ b/ambari-web/latest/src/api/hostLogsApi.ts
@@ -1,0 +1,62 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ambariApi } from "./config/axiosConfig";
+
+const HOST_LOG_FIELDS = [
+  "host_components/logging",
+  "host_components/HostRoles/service_name",
+  "host_components/HostRoles/component_name",
+  "host_components/HostRoles/display_name",
+].join(",");
+
+const HostLogsApi = {
+  fetchHostLogs: async (clusterName: string, hostName: string) => {
+    const response = await ambariApi.request({
+      url: `/clusters/${encodeURIComponent(clusterName)}/hosts/${encodeURIComponent(hostName)}`,
+      method: "GET",
+      params: {
+        fields: HOST_LOG_FIELDS,
+        minimal_response: true,
+      },
+    });
+    return response.data;
+  },
+
+  fetchLogTail: async (
+    clusterName: string,
+    componentName: string,
+    hostName: string,
+    pageSize: number,
+    startIndex: number,
+  ) => {
+    const response = await ambariApi.request({
+      url: `/clusters/${encodeURIComponent(clusterName)}/logging/searchEngine`,
+      method: "GET",
+      params: {
+        component_name: componentName,
+        host_name: hostName,
+        pageSize,
+        startIndex,
+      },
+    });
+    return response.data;
+  },
+};
+
+export default HostLogsApi;

--- a/ambari-web/latest/src/api/hostsApi.test.ts
+++ b/ambari-web/latest/src/api/hostsApi.test.ts
@@ -1,0 +1,57 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({ request: vi.fn() }));
+vi.mock("./config/axiosConfig", () => ({ ambariApi: { request: mocks.request } }));
+
+import { HostsApi } from "./hostsApi";
+
+describe("Hosts API", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.request.mockResolvedValue({ data: {} });
+  });
+
+  it("sends suggestion paging as Axios params and the predicate in the override body", async () => {
+    await HostsApi.getHostListFilterSuggestions("cluster/name", {
+      filter: "host_name",
+      pageSize: 25,
+      searchTerm: "node[1]",
+    });
+
+    expect(mocks.request).toHaveBeenCalledWith({
+      url: "/clusters/cluster%2Fname/hosts",
+      method: "POST",
+      params: {
+        fields: "Hosts/host_name",
+        minimal_response: true,
+        page_size: 25,
+      },
+      headers: {
+        "X-Http-Method-Override": "GET",
+      },
+      data: JSON.stringify({
+        RequestInfo: {
+          query: "Hosts/host_name.matches(.*node\\[1\\].*)",
+        },
+      }),
+    });
+  });
+});

--- a/ambari-web/latest/src/api/hostsApi.ts
+++ b/ambari-web/latest/src/api/hostsApi.ts
@@ -18,6 +18,7 @@
 
 import { set } from "lodash";
 import { ambariApi } from "./config/axiosConfig";
+import { buildHostSuggestionPredicate } from "../Utils/hosts";
 
 export const HostsApi = {
   getAllHosts: async function (clusterName: string) {
@@ -48,7 +49,7 @@ export const HostsApi = {
     clusterName: string,
     requestData: any
   ) {
-    const url = `/clusters/${clusterName}/hosts`;
+    const url = `/clusters/${encodeURIComponent(clusterName)}/hosts`;
     const response = await ambariApi.request({
       url,
       method: "POST",
@@ -70,7 +71,7 @@ export const HostsApi = {
     hostName: string,
     fields: string
   ) {
-    const url = `clusters/${clusterName}/hosts/${hostName}?fields=${fields}`;
+    const url = `/clusters/${encodeURIComponent(clusterName)}/hosts/${encodeURIComponent(hostName)}?fields=${fields}`;
     const response = await ambariApi.request({
       url: url,
       method: "GET",
@@ -190,7 +191,7 @@ export const HostsApi = {
     urlParams: string,
     data: any
   ) {
-    const url = `/clusters/${clusterName}/host_components?${urlParams}`;
+    const url = `/clusters/${encodeURIComponent(clusterName)}/host_components?${urlParams}`;
     const response = await ambariApi.request({
       url: url,
       method: "PUT",
@@ -271,7 +272,7 @@ export const HostsApi = {
       "host_components/HostRoles/state,host_components/HostRoles/maintenance_state," +
       "Hosts/total_mem,stack_versions/HostStackVersions,stack_versions/repository_versions/RepositoryVersions/repository_version," +
       "stack_versions/repository_versions/RepositoryVersions/id," +
-      "host_components/HostRoles/stale_configs" +
+      "host_components/HostRoles/stale_configs," +
       "host_components/HostRoles/service_name&minimal_response=true";
     const response = await ambariApi.request({
       url: url,
@@ -635,18 +636,21 @@ export const HostsApi = {
     clusterName: string,
     data: any
   ) {
-    const url = `/clusters/${clusterName}/hosts?fields=Hosts/${data.filter}&minimal_response=true&page_size=${data.pageSize}`;
+    const url = `/clusters/${encodeURIComponent(clusterName)}/hosts`;
     const response = await ambariApi.request({
       url: url,
       method: "POST",
+      params: {
+        fields: `Hosts/${data.filter}`,
+        minimal_response: true,
+        page_size: data.pageSize,
+      },
       headers: {
         "X-Http-Method-Override": "GET",
       },
       data: JSON.stringify({
         RequestInfo: {
-          query: data.searchTerm
-            ? "Hosts/" + data.filter + ".matches(.*" + data.searchTerm + ".*)"
-            : "",
+          query: buildHostSuggestionPredicate(data.filter, data.searchTerm),
         },
       }),
     });

--- a/ambari-web/latest/src/api/versionsApi.test.ts
+++ b/ambari-web/latest/src/api/versionsApi.test.ts
@@ -1,0 +1,69 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({ request: vi.fn() }));
+vi.mock("./config/axiosConfig", () => ({ ambariApi: { request: mocks.request } }));
+
+import VersionsApi from "./versionsApi";
+
+describe("versions API", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.request.mockResolvedValue({ data: { Requests: { id: 17 } } });
+  });
+
+  it("installs a repository version on one encoded host", async () => {
+    const response = await VersionsApi.installHostStackVersion(
+      "cluster/name",
+      "host one",
+      {
+        stack: "HDP-3.1",
+        version: "3.1.5",
+        repoVersion: "3.1.5.0-1",
+      },
+    );
+
+    expect(mocks.request).toHaveBeenCalledWith({
+      url: "/clusters/cluster%2Fname/hosts/host%20one/stack_versions",
+      method: "POST",
+      data: {
+        HostStackVersions: {
+          stack: "HDP-3.1",
+          version: "3.1.5",
+          repository_version: "3.1.5.0-1",
+        },
+      },
+    });
+    expect(response).toEqual({ Requests: { id: 17 } });
+  });
+
+  it("loads repository versions compatible with the current stack", async () => {
+    await VersionsApi.getCompatibleRepositoryVersions("HDP/name", "3.1 version");
+
+    expect(mocks.request).toHaveBeenCalledWith({
+      url: "/stacks/HDP%2Fname/versions/3.1%20version/compatible_repository_versions",
+      method: "GET",
+      params: {
+        fields: "CompatibleRepositoryVersions/repository_version",
+        minimal_response: true,
+      },
+    });
+  });
+});

--- a/ambari-web/latest/src/api/versionsApi.ts
+++ b/ambari-web/latest/src/api/versionsApi.ts
@@ -191,6 +191,25 @@ const VersionsApi = {
     });
     return response.data;
   },
+  installHostStackVersion: async function (
+    clusterName: string,
+    hostName: string,
+    version: { stack: string; version: string; repoVersion: string }
+  ) {
+    const url = `/clusters/${encodeURIComponent(clusterName)}/hosts/${encodeURIComponent(hostName)}/stack_versions`;
+    const response = await ambariApi.request({
+      url,
+      method: "POST",
+      data: {
+        HostStackVersions: {
+          stack: version.stack,
+          version: version.version,
+          repository_version: version.repoVersion,
+        },
+      },
+    });
+    return response.data;
+  },
   getAllStacks: async function (clusterName: string) {
     const url = `/clusters/${clusterName}/stack_versions?fields=*,repository_versions/*,repository_versions/operating_systems/OperatingSystems/*,repository_versions/operating_systems/repositories/*`;
     const response = await ambariApi.request({
@@ -208,6 +227,21 @@ const VersionsApi = {
     const response = await ambariApi.request({
       url: url,
       method: "GET",
+    });
+    return response.data;
+  },
+  getCompatibleRepositoryVersions: async function (
+    stackName: string,
+    stackVersion: string,
+  ) {
+    const url = `/stacks/${encodeURIComponent(stackName)}/versions/${encodeURIComponent(stackVersion)}/compatible_repository_versions`;
+    const response = await ambariApi.request({
+      url,
+      method: "GET",
+      params: {
+        fields: "CompatibleRepositoryVersions/repository_version",
+        minimal_response: true,
+      },
     });
     return response.data;
   },

--- a/ambari-web/latest/src/api/wizardApi.test.ts
+++ b/ambari-web/latest/src/api/wizardApi.test.ts
@@ -1,0 +1,44 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({ request: vi.fn() }));
+vi.mock("./config/axiosConfig", () => ({ ambariApi: { request: mocks.request } }));
+
+import WizardApi from "./wizardApi";
+
+describe("host bootstrap API", () => {
+  beforeEach(() => mocks.request.mockResolvedValue({ data: {} }));
+
+  it("launches and polls bootstrap without interpolating the request body", async () => {
+    const payload = { hosts: ["host1"], userRunAs: "root" };
+    await WizardApi.launchBootstrap(payload);
+    await WizardApi.getBootstrapStatus("request/1");
+
+    expect(mocks.request).toHaveBeenNthCalledWith(1, {
+      url: "/bootstrap",
+      method: "POST",
+      data: payload,
+    });
+    expect(mocks.request).toHaveBeenNthCalledWith(2, {
+      url: "/bootstrap/request%2F1",
+      method: "GET",
+    });
+  });
+});

--- a/ambari-web/latest/src/api/wizardApi.ts
+++ b/ambari-web/latest/src/api/wizardApi.ts
@@ -19,6 +19,21 @@
 import { ambariApi } from "./config/axiosConfig";
 
 const WizardApi = {
+  launchBootstrap: async (data: Record<string, unknown>) => {
+    const response = await ambariApi.request({
+      url: "/bootstrap",
+      method: "POST",
+      data,
+    });
+    return response.data;
+  },
+  getBootstrapStatus: async (requestId: string) => {
+    const response = await ambariApi.request({
+      url: `/bootstrap/${encodeURIComponent(requestId)}`,
+      method: "GET",
+    });
+    return response.data;
+  },
   isHostsRegistered: async () => {
     const url = `/hosts?fields=Hosts/host_status`;
     const response = await ambariApi.request({

--- a/ambari-web/latest/src/hooks/useHostConfigUpdater.ts
+++ b/ambari-web/latest/src/hooks/useHostConfigUpdater.ts
@@ -27,8 +27,15 @@ import HostStackVersion, {
   IHostStackVersion,
 } from "../models/hostStackVersion";
 import { sortBasedOnMasterSlave } from "../screens/Hosts/utils";
-import { PassiveStateOnFilters } from "../screens/Hosts/enums";
 import usePolling from "./usePolling";
+import {
+  applyCompletedDecommissionRequest,
+  applyHostComponentEvent,
+  applyHostEvent,
+  applyHostStackVersionVisibility,
+  shouldLoadCompatibleRepositoryVersions,
+} from "../Utils/hosts";
+import VersionsApi from "../api/versionsApi";
 
 export const useHostConfigUpdater = (
   hostApiQueryParams: any,
@@ -38,10 +45,19 @@ export const useHostConfigUpdater = (
   setPaginationLoading?: Function
 ) => {
   const [hostsData, setHostsData] = useState<any>({});
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [retryCount, setRetryCount] = useState(0);
   const queryData = useRef({});
   const allHostModelsRef = useRef<Host[]>(allHostModels);
 
-  const { clusterName, serviceComponentInfo, parsedSocketMessages } =
+  const {
+    cluster,
+    clusterName,
+    parsedSocketMessages,
+    serviceComponentInfo,
+    supports,
+  } =
     useContext(AppContext);
 
   // Keep the ref updated with the latest allHostModels
@@ -53,13 +69,25 @@ export const useHostConfigUpdater = (
     if (parsedSocketMessages.length) {
       switch (get(parsedSocketMessages[0], "destination", "")) {
         case "/events/hostcomponents":
-          updateHostComponent(parsedSocketMessages[0]);
+          setAllHostModels(
+            applyHostComponentEvent(
+              allHostModelsRef.current,
+              parsedSocketMessages[0],
+            ),
+          );
           break;
         case "/events/hosts":
-          updateHost(parsedSocketMessages[0]);
+          setAllHostModels(
+            applyHostEvent(allHostModelsRef.current, parsedSocketMessages[0]),
+          );
           break;
         case "/events/requests":
-          updateHostOnRequests(parsedSocketMessages[0]);
+          setAllHostModels(
+            applyCompletedDecommissionRequest(
+              allHostModelsRef.current,
+              parsedSocketMessages[0],
+            ),
+          );
           break;
         default:
       }
@@ -67,10 +95,27 @@ export const useHostConfigUpdater = (
   }, [parsedSocketMessages]);
 
   useEffect(() => {
-    if (!isEmpty(serviceComponentInfo)) {
-      getHostsData();
+    if (clusterName && !isEmpty(serviceComponentInfo)) {
+      setLoadError(null);
+      setIsLoading(true);
+      void getHostsData()
+        .catch((error) => {
+          setLoadError(
+            get(error, "response.data.message", "Ambari could not load host data."),
+          );
+          setPaginationLoading?.(false);
+        })
+        .finally(() => setIsLoading(false));
     }
-  }, [serviceComponentInfo, hostApiQueryParams]);
+  }, [
+    clusterName,
+    serviceComponentInfo,
+    hostApiQueryParams,
+    retryCount,
+    get(cluster, "stack", ""),
+    get(cluster, "versionNum", ""),
+    supports.displayOlderVersions,
+  ]);
 
   useEffect(() => {
     if (!isEmpty(hostsData)) {
@@ -136,188 +181,6 @@ export const useHostConfigUpdater = (
   };
 
   usePolling(getHostMetrics, 15000);
-
-  const updateHostComponent = (message: any) => {
-    const config = {
-      workStatus: "currentState",
-      staleConfigs: "staleConfigs",
-      passiveState: "maintenanceState",
-    };
-    // Use the ref to get the latest allHostModels value
-    let allHostModelsCopy = cloneDeep(allHostModelsRef.current);
-    get(message, "hostComponents", []).forEach((hostComponent: any) => {
-      allHostModelsCopy.forEach((host: Host) => {
-        host.hostComponents.forEach((hostComponentModel: HostComponent) => {
-          if (
-            hostComponentModel.componentName ===
-            get(hostComponent, "componentName")
-          ) {
-            Object.keys(config).forEach((key) => {
-              if (get(hostComponent, config[key as keyof typeof config])) {
-                set(
-                  hostComponentModel,
-                  key,
-                  get(
-                    hostComponent,
-                    config[key as keyof typeof config],
-                    get(hostComponentModel, key)
-                  )
-                );
-              }
-            });
-          }
-        });
-      });
-    });
-    setAllHostModels(allHostModelsCopy);
-  };
-
-  const updateHost = (message: any) => {
-    const config = {
-      alertsSummary: "alerts_summary",
-      healthStatus: "host_status",
-      state: "host_state",
-      lastHeartBeatTime: "last_heartbeat_time",
-      passiveState: "maintenance_state",
-    };
-    // Use the ref to get the latest allHostModels value
-    let allHostModelsCopy = cloneDeep(allHostModelsRef.current);
-    allHostModelsCopy.forEach((host: Host) => {
-      if (host.hostName === get(message, "host_name", "")) {
-        Object.keys(config).forEach((key) => {
-          if (get(message, config[key as keyof typeof config])) {
-            set(
-              host,
-              key,
-              get(message, config[key as keyof typeof config], get(host, key))
-            );
-
-            if (key === "passiveState") {
-              handlePassiveStateChange(config, key, message, host);
-            }
-          }
-        });
-      }
-    });
-    setAllHostModels(allHostModelsCopy);
-  };
-
-  const updateHostOnRequests = (message: any) => {
-
-    const requestContext = get(message, "requestContext", "").toLowerCase();
-    const requestStatus = get(message, "requestStatus", "");
-    const hostName = get(message, "Tasks.[0].hostName", "");
-
-    if (requestStatus !== "COMPLETED" || !hostName) {
-      return;
-    }
-
-    let operation = "";
-    let componentType = "";
-
-    if (requestContext.includes("decommission")) {
-      operation = "DECOMMISSION";
-      if (requestContext.includes("datanode")) {
-        componentType = "DATANODE";
-      } else if (requestContext.includes("nodemanager")) {
-        componentType = "NODEMANAGER";
-      } else if (requestContext.includes("regionserver")) {
-        componentType = "HBASE_REGIONSERVER";
-      } else if (requestContext.includes("tasktracker")) {
-        componentType = "TASKTRACKER";
-      }
-    } else if (requestContext.includes("recommission")) {
-      operation = "RECOMMISSION";
-      if (requestContext.includes("datanode")) {
-        componentType = "DATANODE";
-      } else if (requestContext.includes("nodemanager")) {
-        componentType = "NODEMANAGER";
-      } else if (requestContext.includes("regionserver")) {
-        componentType = "HBASE_REGIONSERVER";
-      } else if (requestContext.includes("tasktracker")) {
-        componentType = "TASKTRACKER";
-      }
-    }
-
-    if (operation && componentType) {
-      updateComponentAdminState(hostName, componentType, operation);
-    }
-  };
-
-  const updateComponentAdminState = (
-    hostName: string,
-    componentType: string,
-    operation: string
-  ) => {
-    // Use the ref to get the latest allHostModels value
-    const allHostModelsCopy = cloneDeep(allHostModelsRef.current);
-
-    allHostModelsCopy.forEach((host: Host) => {
-      if (host.hostName === hostName) {
-        host.hostComponents.forEach((hostComponent: HostComponent) => {
-          if (hostComponent.componentName === componentType) {
-            if (operation === "DECOMMISSION") {
-              set(hostComponent, "adminState", "DECOMMISSIONED");
-            } else if (operation === "RECOMMISSION") {
-              set(hostComponent, "adminState", "INSERVICE");
-            }
-          }
-        });
-      }
-    });
-
-    setAllHostModels(allHostModelsCopy);
-  };
-
-  const handlePassiveStateChange = (
-    config: any,
-    key: string,
-    message: any,
-    host: Host
-  ) => {
-    host.hostComponents.forEach((hostComponent: HostComponent) => {
-      const currentPassiveState = get(hostComponent, "passiveState", "");
-      const desiredPassiveState = get(
-        message,
-        config[key as keyof typeof config],
-        get(host, key)
-      );
-      if (desiredPassiveState !== currentPassiveState) {
-        if (desiredPassiveState === "OFF") {
-          if (
-            currentPassiveState ===
-            PassiveStateOnFilters.IMPLIED_FROM_SERVICE_AND_HOST
-          ) {
-            set(
-              hostComponent,
-              "passiveState",
-              PassiveStateOnFilters.IMPLIED_FROM_SERVICE
-            );
-          } else if (
-            currentPassiveState === PassiveStateOnFilters.IMPLIED_FROM_HOST
-          ) {
-            set(hostComponent, "passiveState", desiredPassiveState);
-          }
-        } else {
-          if (
-            currentPassiveState === PassiveStateOnFilters.IMPLIED_FROM_SERVICE
-          ) {
-            set(
-              hostComponent,
-              "passiveState",
-              PassiveStateOnFilters.IMPLIED_FROM_SERVICE_AND_HOST
-            );
-          } else if (currentPassiveState === "OFF") {
-            set(
-              hostComponent,
-              "passiveState",
-              PassiveStateOnFilters.IMPLIED_FROM_HOST
-            );
-          }
-        }
-      }
-    });
-  };
 
   const getHostNamesForCurrentFilters = async (url: string) => {
     const response = await HostsApi.getHostComponentsDetails(clusterName, url);
@@ -386,6 +249,32 @@ export const useHostConfigUpdater = (
 
     const response = await HostsApi.getHostsList(clusterName, url, data);
 
+    const stackName = get(cluster, "stack", "");
+    const stackVersion = get(cluster, "versionNum", "");
+    let compatibleRepositoryVersions: string[] = [];
+    if (shouldLoadCompatibleRepositoryVersions(
+      get(response, "items", []),
+      stackName,
+      stackVersion,
+    )) {
+      const compatibleResponse = await VersionsApi.getCompatibleRepositoryVersions(
+        stackName,
+        stackVersion,
+      );
+      compatibleRepositoryVersions = get(compatibleResponse, "items", [])
+        .map((item: any) => get(
+          item,
+          "CompatibleRepositoryVersions.repository_version",
+          "",
+        ))
+        .filter(Boolean);
+    }
+    applyHostStackVersionVisibility(
+      get(response, "items", []),
+      compatibleRepositoryVersions,
+      Boolean(supports.displayOlderVersions),
+    );
+
     let allComponents: any[] = [];
     get(serviceComponentInfo, "items", []).forEach((service: any) => {
       allComponents = allComponents.concat(
@@ -408,16 +297,17 @@ export const useHostConfigUpdater = (
     }
 
     get(response, "items", []).forEach((host: any) => {
-      get(host, "host_components", []).forEach((component: any) =>
+      get(host, "host_components", []).forEach((component: any) => {
+        const metadata = allComponents.find(
+          (candidate) =>
+            get(candidate, "HostRoles.component_name") ===
+            get(component, "HostRoles.component_name"),
+        );
         set(component, "HostRoles", {
           ...get(component, "HostRoles", {}),
-          ...allComponents.filter(
-            (c) =>
-              get(c, "HostRoles.component_name") ===
-              get(component, "HostRoles.component_name")
-          )[0].HostRoles,
-        })
-      );
+          ...get(metadata, "HostRoles", {}),
+        });
+      });
       if (!isGetHostsList()) {
         set(
           host,
@@ -494,5 +384,11 @@ export const useHostConfigUpdater = (
     if (setPaginationLoading) {
       setPaginationLoading(false);
     }
+  };
+
+  return {
+    error: loadError,
+    isLoading,
+    retry: () => setRetryCount((value) => value + 1),
   };
 };

--- a/ambari-web/latest/src/hooks/useKDCSessionState.test.tsx
+++ b/ambari-web/latest/src/hooks/useKDCSessionState.test.tsx
@@ -1,0 +1,86 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { act, renderHook } from "@testing-library/react";
+import type { PropsWithChildren } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import adminApi from "../api/adminApi";
+import { AppContext } from "../store/context";
+import useKDCSessionState from "./useKDCSessionState";
+
+vi.mock("../api/adminApi", () => ({
+  default: {
+    getKerberosSessionState: vi.fn(),
+    getSecurityStatus: vi.fn(),
+    getSecurityType: vi.fn(),
+  },
+}));
+
+const contextValue = {
+  clusterName: "c1",
+  isKerberosEnabled: true,
+} as any;
+
+function wrapper({ children }: PropsWithChildren) {
+  return <AppContext.Provider value={contextValue}>{children}</AppContext.Provider>;
+}
+
+describe("useKDCSessionState", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(adminApi.getSecurityStatus).mockResolvedValue({
+      Clusters: { security_type: "KERBEROS" },
+    } as any);
+  });
+
+  it("reports a security-type request failure instead of leaving the caller waiting", async () => {
+    const requestError = new Error("security type unavailable");
+    vi.mocked(adminApi.getSecurityType).mockRejectedValue(requestError);
+    const callback = vi.fn();
+    const errorCallback = vi.fn();
+    const { result } = renderHook(() => useKDCSessionState(() => {}), { wrapper });
+
+    await result.current.getKDCSessionState(callback, errorCallback);
+
+    expect(callback).not.toHaveBeenCalled();
+    expect(errorCallback).toHaveBeenCalledWith(requestError);
+  });
+
+  it("waits for the protected operation when manual Kerberos needs no session check", async () => {
+    vi.mocked(adminApi.getSecurityType).mockResolvedValue({
+      items: [{
+        configurations: [{
+          type: "kerberos-env",
+          properties: { kdc_type: "none" },
+        }],
+      }],
+    } as any);
+    let operationCompleted = false;
+    const { result } = renderHook(() => useKDCSessionState(() => {}), { wrapper });
+
+    await act(async () => {
+      await result.current.getKDCSessionState(async () => {
+        await Promise.resolve();
+        operationCompleted = true;
+      });
+    });
+
+    expect(operationCompleted).toBe(true);
+    expect(adminApi.getKerberosSessionState).not.toHaveBeenCalled();
+  });
+});

--- a/ambari-web/latest/src/hooks/useKDCSessionState.tsx
+++ b/ambari-web/latest/src/hooks/useKDCSessionState.tsx
@@ -22,27 +22,26 @@ import { AppContext } from "../store/context";
 import { get } from "lodash";
 import modalManager from "../store/ModalManager";
 import InvalidKdcPopup from "../components/InvalidKdcPopup";
-//@ts-ignore
-function useKDCSessionState(cancelHandler: unknown) {
+
+type KDCSessionCallback = () => void | Promise<void>;
+type KDCSessionErrorCallback = (error: unknown) => void;
+type KerberosConfiguration = {
+  properties?: { kdc_type?: string };
+  type?: string;
+};
+
+function useKDCSessionState(_cancelHandler: unknown) {
   const [securityEnabled, setSecurityEnabled] = useState(false);
   const [isLoaded, setIsLoaded] = useState(false);
   const { clusterName, isKerberosEnabled } = useContext(AppContext);
   const kdc_type = useRef("");
-  async function getSecurityType(additionalCallback: any) {
+  async function getSecurityType() {
     if (securityEnabled || isKerberosEnabled) {
-      try {
-        const data = await adminApi.getSecurityType(clusterName);
-        const kdcType =
-          data?.items?.[0]?.configurations?.find(
-            (config: any) => config.type === "kerberos-env"
-          )?.properties?.kdc_type ?? "none";
-        kdc_type.current = kdcType;
-        additionalCallback();
-      } catch (err) {
-        console.error("Could not get security type", err);
-      }
-    } else {
-      additionalCallback();
+      const data = await adminApi.getSecurityType(clusterName);
+      kdc_type.current =
+        data?.items?.[0]?.configurations?.find(
+          (config: KerberosConfiguration) => config.type === "kerberos-env"
+        )?.properties?.kdc_type ?? "none";
     }
   }
   useEffect(() => {
@@ -52,7 +51,7 @@ function useKDCSessionState(cancelHandler: unknown) {
         setIsLoaded(true);
         const securityType = data.Clusters.security_type;
         setSecurityEnabled(securityType === "KERBEROS");
-      } catch (error) {
+      } catch {
         setIsLoaded(true);
         modalManager.show(<InvalidKdcPopup />);
       }
@@ -62,30 +61,39 @@ function useKDCSessionState(cancelHandler: unknown) {
     }
   }, [clusterName]);
 
-  const getKDCSessionState = async (callback: Function) => {
-    if (securityEnabled || isKerberosEnabled) {
-      getSecurityType(async function () {
+  const getKDCSessionState = async (
+    callback: KDCSessionCallback,
+    errorCallback?: KDCSessionErrorCallback,
+  ): Promise<void> => {
+    try {
+      if (securityEnabled || isKerberosEnabled) {
+        await getSecurityType();
         if (kdc_type.current !== "none") {
           const data = await adminApi.getKerberosSessionState(clusterName);
-          const res = get(data, "Services.attributes.kdc_validation_result");
-          get(data, "Services.attributes.kdc_validation_failure_details");
-          if (res.toUpperCase() === "OK") {
-            callback();
+          const result = get(data, "Services.attributes.kdc_validation_result", "");
+          if (result.toUpperCase() === "OK") {
+            await callback();
           } else {
             modalManager.show(
               <InvalidKdcPopup
                 getKdcSessionState={() => {
-                  getKDCSessionState(callback);
+                  void getKDCSessionState(callback, errorCallback);
                 }}
               />
             );
           }
         } else {
-          callback();
+          await callback();
         }
-      });
-    } else {
-      callback();
+      } else {
+        await callback();
+      }
+    } catch (error) {
+      if (errorCallback) {
+        errorCallback(error);
+        return;
+      }
+      console.error("Could not validate the KDC session", error);
     }
   };
 

--- a/ambari-web/latest/src/hooks/useKerberosMode.test.ts
+++ b/ambari-web/latest/src/hooks/useKerberosMode.test.ts
@@ -1,0 +1,31 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from "vitest";
+import { kerberosTypeFromConfig } from "./useKerberosMode";
+
+describe("Kerberos mode", () => {
+  it("reads manual and managed KDC types from the current kerberos-env", () => {
+    expect(kerberosTypeFromConfig({
+      items: [{ configurations: [{ type: "kerberos-env", properties: { kdc_type: "none" } }] }],
+    })).toBe("none");
+    expect(kerberosTypeFromConfig({
+      items: [{ configurations: [{ type: "kerberos-env", properties: { kdc_type: "mit-kdc" } }] }],
+    })).toBe("mit-kdc");
+  });
+});

--- a/ambari-web/latest/src/hooks/useKerberosMode.ts
+++ b/ambari-web/latest/src/hooks/useKerberosMode.ts
@@ -1,0 +1,70 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useContext, useEffect, useState } from "react";
+import adminApi from "../api/adminApi";
+import { AppContext } from "../store/context";
+
+export function kerberosTypeFromConfig(response: any): string {
+  return response?.items?.[0]?.configurations?.find(
+    (configuration: any) => configuration.type === "kerberos-env",
+  )?.properties?.kdc_type || "none";
+}
+
+export default function useKerberosMode() {
+  const { clusterName, isKerberosEnabled } = useContext(AppContext);
+  const [kdcType, setKdcType] = useState("");
+  const [isLoaded, setIsLoaded] = useState(!isKerberosEnabled);
+
+  useEffect(() => {
+    let active = true;
+    if (!isKerberosEnabled || !clusterName) {
+      setKdcType("");
+      setIsLoaded(true);
+      return () => {
+        active = false;
+      };
+    }
+    setIsLoaded(false);
+    void adminApi.getSecurityType(clusterName)
+      .then((response) => {
+        if (active) {
+          setKdcType(kerberosTypeFromConfig(response));
+        }
+      })
+      .catch(() => {
+        if (active) {
+          setKdcType("");
+        }
+      })
+      .finally(() => {
+        if (active) {
+          setIsLoaded(true);
+        }
+      });
+    return () => {
+      active = false;
+    };
+  }, [clusterName, isKerberosEnabled]);
+
+  return {
+    isLoaded,
+    isManualKerberos: isKerberosEnabled && kdcType === "none",
+    kdcType,
+  };
+}

--- a/ambari-web/latest/src/hooks/usePolling.test.tsx
+++ b/ambari-web/latest/src/hooks/usePolling.test.tsx
@@ -1,0 +1,49 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { act, cleanup, render } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import usePolling from "./usePolling";
+
+function PollingHarness({ callback }: { callback: () => Promise<void> }) {
+  usePolling(callback, 1000);
+  return null;
+}
+
+describe("usePolling", () => {
+  afterEach(() => {
+    cleanup();
+    vi.useRealTimers();
+  });
+
+  it("does not schedule another poll when an in-flight request finishes after unmount", async () => {
+    vi.useFakeTimers();
+    let finishRequest: () => void = () => undefined;
+    const callback = vi.fn(() => new Promise<void>((resolve) => {
+      finishRequest = resolve;
+    }));
+    const view = render(<PollingHarness callback={callback} />);
+    expect(callback).toHaveBeenCalledTimes(1);
+
+    view.unmount();
+    await act(async () => finishRequest());
+    await act(async () => vi.advanceTimersByTimeAsync(5000));
+
+    expect(callback).toHaveBeenCalledTimes(1);
+  });
+});

--- a/ambari-web/latest/src/hooks/usePolling.ts
+++ b/ambari-web/latest/src/hooks/usePolling.ts
@@ -23,6 +23,7 @@ function usePolling(apiFunction: Function, interval = 2000) {
   const savedCallback = useRef<Function | undefined>(undefined);
   const timeoutId = useRef<NodeJS.Timeout | null>(null);
   const isPausedRef = useRef(false);
+  const isActiveRef = useRef(false);
   const [isPaused, setIsPaused] = useState(false);
 
   const stopPolling = useCallback(() => {
@@ -52,8 +53,10 @@ function usePolling(apiFunction: Function, interval = 2000) {
 
   // Set up the timeout-based polling.
   useEffect(() => {
+    isActiveRef.current = true;
+
     async function tick() {
-      if (!savedCallback.current || isPausedRef.current) {
+      if (!savedCallback.current || isPausedRef.current || !isActiveRef.current) {
         return;
       }
 
@@ -65,7 +68,7 @@ function usePolling(apiFunction: Function, interval = 2000) {
         console.error('Polling error:', error);
       } finally {
         // Schedule next poll only after current request completes
-        if (!isPausedRef.current && interval !== null) {
+        if (isActiveRef.current && !isPausedRef.current && interval !== null) {
           timeoutId.current = setTimeout(tick, interval);
         }
       }
@@ -78,7 +81,10 @@ function usePolling(apiFunction: Function, interval = 2000) {
     }
 
     // Cleanup on unmount or when dependencies change
-    return () => stopPolling();
+    return () => {
+      isActiveRef.current = false;
+      stopPolling();
+    };
   }, [interval, isPaused, stopPolling]);
 
   return { stopPolling, pausePolling, resumePolling, isPaused };

--- a/ambari-web/latest/src/mappers/hostsMapper.ts
+++ b/ambari-web/latest/src/mappers/hostsMapper.ts
@@ -82,6 +82,7 @@ export const hostMapper = {
     repo: "repository_versions[0].RepositoryVersions",
     repoVersion: "repository_versions[0].RepositoryVersions.repository_version",
     displayName: "repository_versions[0].RepositoryVersions.display_name",
+    isVisible: "is_visible",
     status: "HostStackVersions.state",
     hostName: "HostStackVersions.host_name",
   },

--- a/ambari-web/latest/src/models/hostStackVersion.test.ts
+++ b/ambari-web/latest/src/models/hostStackVersion.test.ts
@@ -1,0 +1,32 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from "vitest";
+import HostStackVersion from "./hostStackVersion";
+
+describe("HostStackVersion", () => {
+  it.each([
+    ["OUT_OF_SYNC", false],
+    ["INSTALL_FAILED", false],
+    ["INSTALLED", true],
+    ["CURRENT", true],
+  ])("derives installDisabled for %s", (status, disabled) => {
+    const version = new HostStackVersion({ status } as any);
+    expect(version.installDisabled()).toBe(disabled);
+  });
+});

--- a/ambari-web/latest/src/models/hostStackVersion.ts
+++ b/ambari-web/latest/src/models/hostStackVersion.ts
@@ -85,7 +85,7 @@ class HostStackVersion implements IHostStackVersion {
   }
 
   installDisabled(): boolean {
-    return !this.installEnabled;
+    return !this.installEnabled();
   }
 
   updateObject(updates: Partial<IHostStackVersion>) {

--- a/ambari-web/latest/src/screens/Alerts/AlertFilters.tsx
+++ b/ambari-web/latest/src/screens/Alerts/AlertFilters.tsx
@@ -16,135 +16,119 @@
  * limitations under the License.
  */
 
-import { useState, useEffect, useMemo, useContext } from 'react';
-import { Form, Row, Col, Dropdown } from 'react-bootstrap';
-import { MergedAlert } from './types';
+import { useContext, useEffect, useMemo, useState } from "react";
+import { Col, Form, Row } from "react-bootstrap";
+import { ServiceContext } from "../../store/ServiceContext";
 import { AlertStatus } from "./alertStatus";
-import { ServiceApi } from '../../api/serviceApi';
-import { AppContext } from '../../store/context';
+import { MergedAlert } from "./types";
 
 interface AlertFiltersProps {
-    data: MergedAlert[];
-    onFilter: (filteredData: MergedAlert[]) => void;
+  data: MergedAlert[];
+  onFilter: (filteredData: MergedAlert[]) => void;
 }
 
-interface AlertItem {
-    serviceDisplayName: string;
-    label: string;
-    statuses: Array<{ status: string; count: number }>;
-    latest_text?: string;
-}
-
-const formatServiceName = (name: string): string => {
-    return name.replace(/_/g, ' ');
+type ServiceOption = {
+  name: string;
+  displayName: string;
 };
 
 const AlertFilters = ({ data, onFilter }: AlertFiltersProps) => {
-    const { clusterName } = useContext(AppContext);
-    const [serviceFilter, setServiceFilter] = useState<string>('');
-    const [alertNameFilter, setAlertNameFilter] = useState<string>('');
-    const [statusFilter, setStatusFilter] = useState<string>('');
-    const [responseFilter, setResponseFilter] = useState<string>('');
-    const [services, setServices] = useState<string[]>([]);
+  const { allServiceModels } = useContext(ServiceContext);
+  const [serviceFilter, setServiceFilter] = useState("");
+  const [alertNameFilter, setAlertNameFilter] = useState("");
+  const [statusFilter, setStatusFilter] = useState("");
+  const [responseFilter, setResponseFilter] = useState("");
 
-    const uniqueStatuses = Object.values(AlertStatus).map(status => status.toUpperCase());
+  const services = useMemo<ServiceOption[]>(() => {
+    const options = new Map<string, string>();
+    Object.values(allServiceModels || {}).forEach((service: any) => {
+      const name = String(service?.serviceName || "").toUpperCase();
+      if (name) {
+        options.set(name, service.displayName || name.replaceAll("_", " "));
+      }
+    });
+    data.forEach((alert) => {
+      const name = alert.serviceName || alert.serviceDisplayName;
+      if (name) {
+        options.set(name, alert.serviceDisplayName || name.replaceAll("_", " "));
+      }
+    });
+    return [...options].map(([name, displayName]) => ({ name, displayName }));
+  }, [allServiceModels, data]);
 
-    useEffect(() => {
-        const fetchServices = async () => {
-            try {
-                const response = await ServiceApi.getAllServices(clusterName);
-                const serviceNames = response.items.map(item => item.ServiceInfo.service_name);
-                setServices(['All', ...serviceNames]);
-            } catch (error) {
-                console.error('Error fetching services:', error);
-                setServices(['All']);
-            }
-        };
-        fetchServices();
-    }, [clusterName]);
-
-    const filteredData = useMemo(() => {
-        return data.filter((item: AlertItem) => {
-            const matchesService = serviceFilter === '' || item.serviceDisplayName === serviceFilter;
-            const matchesAlertName = item.label?.toLowerCase().includes(alertNameFilter.toLowerCase()) || false;
-            const matchesStatus = statusFilter === '' || item.statuses.some(status => status.status.toUpperCase() === statusFilter);
-            const matchesResponse = !responseFilter || (item.latest_text?.toLowerCase() || '').includes(responseFilter.toLowerCase());
-            return matchesService && matchesAlertName && matchesStatus && matchesResponse;
-        });
-    }, [serviceFilter, alertNameFilter, statusFilter, responseFilter, data]);
-
-    useEffect(() => {
-        onFilter(filteredData);
-    }, [filteredData, onFilter]);
-
-    return (
-        <Form className="filter-container mb-3">
-            <Row>
-                <Col>
-                    <Form.Group controlId="serviceFilter">
-                        <Form.Label>Service</Form.Label>
-                        <Dropdown>
-                            <Dropdown.Toggle variant="default" id="dropdown-basic">
-                                {serviceFilter ? formatServiceName(serviceFilter) : "All"}
-                            </Dropdown.Toggle>
-
-                            <Dropdown.Menu>
-                                {services.map((service, index) => (
-                                    <Dropdown.Item 
-                                        key={index} 
-                                        onClick={() => setServiceFilter(service === 'All' ? '' : service)}
-                                    >
-                                        {service === 'All' ? service : formatServiceName(service)}
-                                    </Dropdown.Item>
-                                ))}
-                            </Dropdown.Menu>
-                        </Dropdown>
-                    </Form.Group>
-                </Col>
-                <Col>
-                    <Form.Group controlId="alertNameFilter">
-                        <Form.Label>Alert Definition Name</Form.Label>
-                        <Form.Control
-                            type="text"
-                            placeholder="Any"
-                            value={alertNameFilter}
-                            onChange={(e) => setAlertNameFilter(e.target.value)}
-                        />
-                    </Form.Group>
-                </Col>
-                <Col>
-                    <Form.Group controlId="statusFilter">
-                        <Form.Label>Status</Form.Label>
-                        <Dropdown>
-                            <Dropdown.Toggle variant="default" id="dropdown-basic">
-                                {statusFilter || "All"}
-                            </Dropdown.Toggle>
-
-                            <Dropdown.Menu>
-                                <Dropdown.Item onClick={() => setStatusFilter('')}>All</Dropdown.Item>
-                                {uniqueStatuses.map((status, index) => (
-                                    <Dropdown.Item key={index} onClick={() => setStatusFilter(status)}>
-                                        {status}
-                                    </Dropdown.Item>
-                                ))}
-                            </Dropdown.Menu>
-                        </Dropdown>
-                    </Form.Group>
-                </Col>
-                <Col>
-                    <Form.Group controlId="responseFilter">
-                        <Form.Label>Response</Form.Label>
-                        <Form.Control
-                            type="text"
-                            placeholder="Any"
-                            value={responseFilter}
-                            onChange={(e) => setResponseFilter(e.target.value)}
-                        />
-                    </Form.Group>
-                </Col>
-            </Row>
-        </Form>
+  const filteredData = useMemo(() => data.filter((item) => {
+    const serviceName = item.serviceName || item.serviceDisplayName;
+    const matchesService = !serviceFilter || serviceName === serviceFilter;
+    const matchesAlertName = item.label?.toLowerCase().includes(alertNameFilter.toLowerCase()) || false;
+    const matchesStatus = !statusFilter || item.statuses.some(
+      (status) => status.status.toUpperCase() === statusFilter,
     );
+    const matchesResponse = !responseFilter || (item.latest_text || "")
+      .toLowerCase()
+      .includes(responseFilter.toLowerCase());
+    return matchesService && matchesAlertName && matchesStatus && matchesResponse;
+  }), [alertNameFilter, data, responseFilter, serviceFilter, statusFilter]);
+
+  useEffect(() => {
+    onFilter(filteredData);
+  }, [filteredData, onFilter]);
+
+  return (
+    <Form className="filter-container mb-3">
+      <Row>
+        <Col>
+          <Form.Group controlId="hostAlertServiceFilter">
+            <Form.Label>Service</Form.Label>
+            <Form.Select
+              value={serviceFilter}
+              onChange={(event) => setServiceFilter(event.target.value)}
+            >
+              <option value="">All</option>
+              {services.map((service) => (
+                <option key={service.name} value={service.name}>{service.displayName}</option>
+              ))}
+            </Form.Select>
+          </Form.Group>
+        </Col>
+        <Col>
+          <Form.Group controlId="hostAlertNameFilter">
+            <Form.Label>Alert Definition Name</Form.Label>
+            <Form.Control
+              type="text"
+              placeholder="Any"
+              value={alertNameFilter}
+              onChange={(event) => setAlertNameFilter(event.target.value)}
+            />
+          </Form.Group>
+        </Col>
+        <Col>
+          <Form.Group controlId="hostAlertStatusFilter">
+            <Form.Label>Status</Form.Label>
+            <Form.Select
+              value={statusFilter}
+              onChange={(event) => setStatusFilter(event.target.value)}
+            >
+              <option value="">All</option>
+              {Object.values(AlertStatus).map((status) => (
+                <option key={status} value={status.toUpperCase()}>{status.toUpperCase()}</option>
+              ))}
+            </Form.Select>
+          </Form.Group>
+        </Col>
+        <Col>
+          <Form.Group controlId="hostAlertResponseFilter">
+            <Form.Label>Response</Form.Label>
+            <Form.Control
+              type="text"
+              placeholder="Any"
+              value={responseFilter}
+              onChange={(event) => setResponseFilter(event.target.value)}
+            />
+          </Form.Group>
+        </Col>
+      </Row>
+    </Form>
+  );
 };
 
 export default AlertFilters;

--- a/ambari-web/latest/src/screens/Alerts/HostAlerts.test.tsx
+++ b/ambari-web/latest/src/screens/Alerts/HostAlerts.test.tsx
@@ -1,0 +1,140 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { MemoryRouter } from "react-router-dom";
+import { AppContext } from "../../store/context";
+import { ServiceContext } from "../../store/ServiceContext";
+
+const mocks = vi.hoisted(() => ({ getHostAlertInstances: vi.fn() }));
+vi.mock("../../api/alertsApi", () => ({
+  AlertsApi: { getHostAlertInstances: mocks.getHostAlertInstances },
+}));
+vi.mock("../../components/Paginator", () => ({ default: () => <div>Pagination</div> }));
+vi.mock("../../components/Spinner", () => ({ default: () => <div>Loading alerts</div> }));
+vi.mock("../../components/Table", () => ({
+  default: ({ columns, data }: { columns: any[]; data: any[] }) => (
+    <div>
+      {data.map((item) => (
+        <div key={item.alert_definition_id}>
+          {columns.map((column, index) => (
+            <span key={`${column.accessorKey || index}-${item.alert_definition_id}`}>
+              {column.cell
+                ? column.cell({ row: { original: item } })
+                : item[column.accessorKey]}
+            </span>
+          ))}
+        </div>
+      ))}
+    </div>
+  ),
+}));
+
+import HostAlerts from "./HostAlerts";
+
+const alertResponse = {
+  items: [
+    {
+      Alert: {
+        definition_id: 11,
+        label: "DataNode process",
+        latest_timestamp: 123,
+        maintenance_state: "ON",
+        service_name: "HDFS",
+        state: "CRITICAL",
+        text: "A complete response that must not be truncated by the host alerts table.",
+      },
+    },
+    {
+      Alert: {
+        definition_id: 12,
+        label: "Agent heartbeat",
+        latest_timestamp: 124,
+        maintenance_state: "OFF",
+        service_name: "AMBARI",
+        state: "OK",
+        text: "Agent is healthy",
+      },
+    },
+  ],
+};
+
+function renderAlerts() {
+  return render(
+    <MemoryRouter>
+      <AppContext.Provider value={{ clusterName: "c1" } as any}>
+        <ServiceContext.Provider value={{
+          allServiceModels: {
+            hdfs: { displayName: "HDFS Display", serviceName: "hdfs" },
+          },
+        } as any}>
+          <HostAlerts hostname="host1" />
+        </ServiceContext.Provider>
+      </AppContext.Provider>
+    </MemoryRouter>,
+  );
+}
+
+describe("Host Alerts", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.getHostAlertInstances.mockResolvedValue(alertResponse);
+  });
+
+  afterEach(() => cleanup());
+
+  it("loads once, preserves maintenance alerts, and links by backend identifiers", async () => {
+    renderAlerts();
+
+    const serviceLink = await screen.findByRole("link", { name: "HDFS Display" });
+    expect(serviceLink.getAttribute("href")).toBe("/main/services/HDFS/summary");
+    expect(screen.getByRole("link", { name: "DataNode process" }).getAttribute("href"))
+      .toBe("/main/alerts/11");
+    expect(screen.getByTitle("Maintenance mode")).toBeTruthy();
+    expect(screen.getByText(
+      "A complete response that must not be truncated by the host alerts table.",
+    )).toBeTruthy();
+    expect(screen.queryByRole("link", { name: "AMBARI" })).toBeNull();
+    expect(mocks.getHostAlertInstances).toHaveBeenCalledTimes(1);
+    expect(mocks.getHostAlertInstances).toHaveBeenCalledWith("c1", "host1");
+  });
+
+  it("applies definition filtering without being reset by sorting", async () => {
+    renderAlerts();
+    await screen.findByRole("link", { name: "DataNode process" });
+
+    fireEvent.change(screen.getByLabelText("Alert Definition Name"), {
+      target: { value: "heartbeat" },
+    });
+    await waitFor(() => expect(screen.queryByText("DataNode process")).toBeNull());
+    expect(screen.getByText("Agent heartbeat")).toBeTruthy();
+  });
+
+  it("shows a recoverable server failure", async () => {
+    mocks.getHostAlertInstances
+      .mockRejectedValueOnce({ response: { data: { message: "Alert service unavailable" } } })
+      .mockResolvedValueOnce(alertResponse);
+    renderAlerts();
+
+    expect(await screen.findByText("Alert service unavailable")).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: "Retry" }));
+    await waitFor(() => expect(mocks.getHostAlertInstances).toHaveBeenCalledTimes(2));
+    expect(await screen.findByRole("link", { name: "DataNode process" })).toBeTruthy();
+  });
+});

--- a/ambari-web/latest/src/screens/Alerts/HostAlerts.tsx
+++ b/ambari-web/latest/src/screens/Alerts/HostAlerts.tsx
@@ -16,36 +16,106 @@
  * limitations under the License.
  */
 
-import { useEffect, useState, useContext } from "react";
-import { AlertsApi } from "../../api/alertsApi";
-import { MergedAlert } from "./types";
-import { Container, Button } from "react-bootstrap";
-import { Link } from "react-router-dom";
-import { AppContext } from "../../store/context";
-import Table from "../../components/Table";
-import Paginator from "../../components/Paginator";
-import usePagination from "../../hooks/usePagination";
-import Spinner from "../../components/Spinner";
-import AlertFilters from "./AlertFilters";
-import { ColumnDef } from "@tanstack/react-table";
-import { AlertStatus, AlertStatusDisplay } from "./alertStatus";
-import { sortAlerts } from "./alertUtils";
+import { useContext, useState } from "react";
+import { Alert, Button, Container } from "react-bootstrap";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faMedkit } from "@fortawesome/free-solid-svg-icons";
+import { ColumnDef, SortingState } from "@tanstack/react-table";
+import { Link } from "react-router-dom";
+import { AlertsApi } from "../../api/alertsApi";
+import Paginator from "../../components/Paginator";
+import Spinner from "../../components/Spinner";
+import Table from "../../components/Table";
+import usePagination from "../../hooks/usePagination";
 import usePolling from "../../hooks/usePolling";
+import { AppContext } from "../../store/context";
+import { ServiceContext } from "../../store/ServiceContext";
+import AlertFilters from "./AlertFilters";
+import { AlertStatus, AlertStatusDisplay } from "./alertStatus";
+import { sortAlerts } from "./alertUtils";
+import { MergedAlert } from "./types";
 
 interface HostAlertsProps {
   hostname?: string;
 }
 
+const statusClassMap: { [key in AlertStatus]: string } = {
+  [AlertStatus.CRITICAL]: "status-critical",
+  [AlertStatus.WARNING]: "status-warning",
+  [AlertStatus.OK]: "status-ok",
+  [AlertStatus.UNKNOWN]: "status-unknown",
+  [AlertStatus.NONE]: "status-none",
+};
+
 const HostAlerts = ({ hostname }: HostAlertsProps) => {
   const { clusterName } = useContext(AppContext);
+  const { allServiceModels } = useContext(ServiceContext);
   const [alerts, setAlerts] = useState<MergedAlert[]>([]);
   const [filteredAlerts, setFilteredAlerts] = useState<MergedAlert[]>([]);
-  const [isLoading, setIsLoading] = useState<boolean>(true);
-  const [sorting, setSorting] = useState<{ id: string; desc: boolean }[]>([
+  const [isLoading, setIsLoading] = useState(true);
+  const [loadError, setLoadError] = useState("");
+  const [sorting, setSorting] = useState<SortingState>([
     { id: "statuses", desc: true },
   ]);
+
+  const serviceDisplayName = (serviceName: string) => {
+    const service = Object.values(allServiceModels || {}).find(
+      (model: any) => String(model?.serviceName).toUpperCase() === serviceName,
+    ) as any;
+    return service?.displayName || serviceName.replaceAll("_", " ");
+  };
+
+  const fetchData = async () => {
+    if (!clusterName || !hostname) {
+      setIsLoading(false);
+      return;
+    }
+
+    try {
+      setLoadError("");
+      const response = await AlertsApi.getHostAlertInstances(clusterName, hostname);
+      const mappedAlerts = (response.items || [])
+        .filter((item: any) => item.Alert)
+        .map((item: any) => {
+          const serviceName = item.Alert.service_name || "";
+          return {
+            serviceName,
+            serviceDisplayName: serviceDisplayName(serviceName),
+            latest_text: item.Alert.text || "",
+            label: item.Alert.label,
+            statuses: [{
+              status: item.Alert.state,
+              count: 1,
+              last_status_changed: item.Alert.latest_timestamp,
+              latest_text: item.Alert.text || "",
+            }],
+            last_status_changed: item.Alert.latest_timestamp,
+            alert_definition_id: item.Alert.definition_id,
+            maintenance_state: item.Alert.maintenance_state,
+          } as MergedAlert;
+        });
+      setAlerts(mappedAlerts);
+    } catch (error: any) {
+      setLoadError(
+        error?.response?.data?.message || "Ambari could not load alerts for this host.",
+      );
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  usePolling(fetchData, 10000);
+
+  let sortedAlerts = filteredAlerts;
+  if (sorting.length) {
+    const { id, desc } = sorting[0];
+    const fieldMap: Record<string, string> = {
+      statuses: "status",
+      serviceDisplayName: "service_name",
+      label: "name",
+    };
+    sortedAlerts = sortAlerts(filteredAlerts, fieldMap[id] || id, id === "statuses" ? desc : !desc);
+  }
 
   const {
     currentItems,
@@ -54,88 +124,23 @@ const HostAlerts = ({ hostname }: HostAlertsProps) => {
     maxPage,
     itemsPerPage,
     setItemsPerPage,
-  } = usePagination(filteredAlerts);
-
-  const fetchData = async () => {
-    if (clusterName && hostname) {
-      try {
-        const currTime = Date.now();
-        const alertsResponse = await AlertsApi.getAlertsList(
-          clusterName,
-          currTime,
-          hostname
-        );
-        const mappedAlerts = alertsResponse.items
-          .filter((item: { Alert: any }) => item.Alert)
-          .filter((item: any) => item.Alert.maintenance_state !== "ON") // Filter out alerts from components in maintenance mode
-          .map((item: any) => ({
-            serviceDisplayName: item.Alert.service_name,
-            latest_text: item.Alert.text || item.Alert.latest_text || "",
-            label: item.Alert.label,
-            statuses: [
-              {
-                status: item.Alert.state,
-                count: item.Alert.occurrences,
-                last_status_changed: item.Alert.latest_timestamp,
-              },
-            ],
-            last_status_changed: item.Alert.latest_timestamp,
-            alert_definition_id: item.Alert.definition_id,
-            maintenance_state: item.Alert.maintenance_state,
-          }));
-        setAlerts(mappedAlerts);
-        setFilteredAlerts(mappedAlerts);
-      } catch (error) {
-        console.error("Error fetching data:", error);
-      } finally {
-        setIsLoading(false);
-      }
-    }
-  };
-
-  usePolling(fetchData, 10000);
-
-  useEffect(()=>{
-   fetchData(); 
-  },[])
-
-  const truncateText = (text: string, maxLength: number = 60) => {
-    if (!text) return "";
-    return text.length > maxLength
-      ? text.substring(0, maxLength) + "..."
-      : text;
-  };
-
-  useEffect(() => {
-    if (sorting.length > 0) {
-      const { id, desc } = sorting[0];
-      const fieldMap: { [key: string]: string } = {
-        statuses: "status",
-        serviceDisplayName: "service_name",
-      };
-      const sortField = fieldMap[id] || id;
-      const sortedData = sortAlerts(alerts, sortField, desc);
-      setFilteredAlerts(sortedData);
-    } else {
-      setFilteredAlerts(alerts);
-    }
-  }, [sorting, alerts]);
+  } = usePagination(sortedAlerts);
 
   const columns: ColumnDef<MergedAlert, any>[] = [
     {
       header: "Service",
       accessorKey: "serviceDisplayName",
-      cell: (info) => {
-        const serviceName = info.row.original.serviceDisplayName || "";
-        if (serviceName.toLowerCase() === "ambari") {
-          return <span>{serviceName}</span>;
+      cell: ({ row }) => {
+        const serviceName = row.original.serviceName || "";
+        if (serviceName === "AMBARI") {
+          return <span>{row.original.serviceDisplayName}</span>;
         }
         return (
           <Link
-            to={`/main/services/${serviceName}/summary`}
+            to={`/main/services/${encodeURIComponent(serviceName)}/summary`}
             className="custom-link"
           >
-            {serviceName}
+            {row.original.serviceDisplayName}
           </Link>
         );
       },
@@ -143,90 +148,64 @@ const HostAlerts = ({ hostname }: HostAlertsProps) => {
     {
       header: "Alert Definition Name",
       accessorKey: "label",
-      cell: (info) => (
+      cell: ({ row }) => (
         <Link
-          to={`/main/alerts/${info.row.original.alert_definition_id}`}
+          to={`/main/alerts/${row.original.alert_definition_id}`}
           className="custom-link"
         >
-          {info.row.original.label || ""}
+          {row.original.label || ""}
         </Link>
       ),
     },
     {
       header: "Status",
       accessorKey: "statuses",
-      cell: (info) => {
-        const isInMaintenance = info.row.original.maintenance_state === "ON";
-        const statuses = info.row.original.statuses || [];
-        const statusClassMap: { [key in AlertStatus]: string } = {
-          [AlertStatus.CRITICAL]: "status-critical",
-          [AlertStatus.WARNING]: "status-warning",
-          [AlertStatus.OK]: "status-ok",
-          [AlertStatus.UNKNOWN]: "status-unknown",
-          [AlertStatus.NONE]: "status-none",
-        };
-        const getStatusClass = (status: string | undefined) =>
-          status
-            ? statusClassMap[status.toLowerCase() as AlertStatus] ||
-              "status-none"
-            : "status-none";
-
+      cell: ({ row }) => {
+        const isInMaintenance = row.original.maintenance_state === "ON";
+        const status = row.original.statuses[0]?.status || AlertStatus.NONE;
+        const normalizedStatus = status.toLowerCase() as AlertStatus;
         return (
-          <div className="status-container">
-            {statuses.length > 0 ? (
-              statuses.map(
-                (
-                  statusItem: { status: string; count: number },
-                  index: number
-                ) => (
-                  <div key={statusItem.status} className="status-row">
-                    <Button
-                      key={statusItem.status}
-                      className={`alert-item alert-status-box ${getStatusClass(
-                        statusItem.status
-                      )} ${index > 0 ? "mt-1" : ""} ${
-                        isInMaintenance ? "bg-light" : ""
-                      }`}
-                    >
-                      {isInMaintenance && (
-                        <FontAwesomeIcon
-                          className="text-dark fs-12 me-1"
-                          icon={faMedkit}
-                        />
-                      )}
-                      {AlertStatusDisplay[statusItem.status.toLowerCase()] ||
-                        statusItem.status.toUpperCase()}
-                    </Button>
-                  </div>
-                )
-              )
-            ) : (
-              <Button className="alert-item alert-status-box status-none">
-                {AlertStatusDisplay[AlertStatus.NONE]}
-              </Button>
-            )}
-          </div>
+          <span className={`alert-item alert-status-box ${
+            isInMaintenance ? "bg-light text-dark" : statusClassMap[normalizedStatus] || "status-none"
+          }`}>
+            {isInMaintenance ? (
+              <FontAwesomeIcon className="me-1" icon={faMedkit} title="Maintenance mode" />
+            ) : null}
+            {AlertStatusDisplay[normalizedStatus] || status.toUpperCase()}
+          </span>
         );
       },
     },
     {
       header: "Response",
       accessorKey: "latest_text",
-      cell: (info) => {
-        const { latest_text } = info.row.original;
-        return (
-          <span className="text-truncate">
-            {truncateText(latest_text || "")}
-          </span>
-        );
-      },
+      cell: ({ row }) => (
+        <span className="text-truncate" title={row.original.latest_text}>
+          {row.original.latest_text || ""}
+        </span>
+      ),
     },
   ];
 
   return (
     <div className="mx-5">
       <Container className="p-4 bg-white">
-        <h2 className="table-title col-sm-1">Alerts</h2>
+        <h2 className="table-title">Alerts</h2>
+        {loadError ? (
+          <Alert variant="danger">
+            {loadError}{" "}
+            <Button
+              size="sm"
+              variant="outline-danger"
+              onClick={() => {
+                setIsLoading(alerts.length === 0);
+                void fetchData();
+              }}
+            >
+              Retry
+            </Button>
+          </Alert>
+        ) : null}
         {isLoading ? (
           <Spinner />
         ) : (
@@ -240,14 +219,16 @@ const HostAlerts = ({ hostname }: HostAlertsProps) => {
               sorting={sorting}
               onSortingChange={setSorting}
             />
-            <Paginator
-              currentPage={currentPage}
-              maxPage={maxPage}
-              changePage={changePage}
-              itemsPerPage={itemsPerPage}
-              setItemsPerPage={setItemsPerPage}
-              totalItems={filteredAlerts.length}
-            />
+            {sortedAlerts.length ? (
+              <Paginator
+                currentPage={currentPage}
+                maxPage={maxPage}
+                changePage={changePage}
+                itemsPerPage={itemsPerPage}
+                setItemsPerPage={setItemsPerPage}
+                totalItems={sortedAlerts.length}
+              />
+            ) : null}
           </div>
         )}
       </Container>

--- a/ambari-web/latest/src/screens/Alerts/HostStackVersions.test.tsx
+++ b/ambari-web/latest/src/screens/Alerts/HostStackVersions.test.tsx
@@ -1,0 +1,172 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import IHost from "../../models/host";
+import HostStackVersion from "../../models/hostStackVersion";
+import { AppContext } from "../../store/context";
+
+const mocks = vi.hoisted(() => ({
+  hasAuthorization: vi.fn(),
+  installHostStackVersion: vi.fn(),
+}));
+
+vi.mock("../../api/versionsApi", () => ({
+  default: { installHostStackVersion: mocks.installHostStackVersion },
+}));
+vi.mock("../../hooks/useAuth", () => ({
+  useAuth: () => ({ hasAuthorization: mocks.hasAuthorization }),
+}));
+vi.mock("../../Utils/Utility", () => ({
+  translateWithVariables: (_key: string, replacements: Record<string, string>) => (
+    `Install ${replacements["0"]} on this host?`
+  ),
+}));
+vi.mock("../../components/Paginator", () => ({ default: () => <div>Pagination</div> }));
+vi.mock("../../components/ConfirmationModal", () => ({
+  default: ({ isOpen, modalBody, successCallback, okButtonText, isOkDisabled }: any) => isOpen ? (
+    <div>
+      {modalBody}
+      <button disabled={isOkDisabled} onClick={successCallback}>
+        Confirm {okButtonText}
+      </button>
+    </div>
+  ) : null,
+}));
+vi.mock("../BackgroundOperations", () => ({
+  default: ({ requestId }: { requestId: string | number }) => <div>Request {requestId}</div>,
+}));
+vi.mock("../../components/Table", () => ({
+  default: ({ columns, data }: { columns: any[]; data: any[] }) => (
+    <div>
+      {data.map((item) => (
+        <div key={item.key}>
+          {columns.map((column, index) => (
+            <span key={`${column.id || column.accessorKey || index}-${item.key}`}>
+              {column.cell
+                ? column.cell({ row: { original: item } })
+                : column.accessorFn
+                  ? column.accessorFn(item)
+                  : item[column.accessorKey]}
+            </span>
+          ))}
+        </div>
+      ))}
+    </div>
+  ),
+}));
+
+import HostStackVersions from "./HostStackVersions";
+
+function stackVersion(
+  status: string,
+  displayName: string,
+  isVisible = true,
+) {
+  return new HostStackVersion({
+    displayName,
+    hostName: "host1",
+    isVisible,
+    repoVersion: `${displayName}-repo`,
+    stack: "HDP-3.1",
+    status,
+    version: "3.1.5",
+  } as any);
+}
+
+function renderVersions(isNonWizardUser = false) {
+  const host = {
+    hostName: "host1",
+    stackVersions: [
+      stackVersion("CURRENT", "Current version"),
+      stackVersion("OUT_OF_SYNC", "Candidate version"),
+      stackVersion("INSTALL_FAILED", "Hidden version", false),
+    ],
+  } as IHost;
+  return render(
+    <AppContext.Provider value={{
+      backgroundOperations: [],
+      clusterName: "c1",
+      isNonWizardUser,
+    } as any}>
+      <HostStackVersions host={host} />
+    </AppContext.Provider>,
+  );
+}
+
+describe("Host Stack Versions", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.hasAuthorization.mockReturnValue(true);
+    mocks.installHostStackVersion.mockResolvedValue({ Requests: { id: 17 } });
+  });
+
+  afterEach(() => cleanup());
+
+  it("shows only visible host versions and hides installation without permission", () => {
+    mocks.hasAuthorization.mockReturnValue(false);
+    renderVersions();
+
+    expect(screen.getAllByText("Current version").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Candidate version").length).toBeGreaterThan(0);
+    expect(screen.queryByText("Hidden version")).toBeNull();
+    expect(screen.queryByRole("button", { name: "Install" })).toBeNull();
+  });
+
+  it("submits an eligible version and opens its request progress", async () => {
+    renderVersions();
+    const installButton = screen.getAllByRole("button", { name: "Install" })
+      .find((button) => !button.hasAttribute("disabled"));
+    fireEvent.click(installButton!);
+    fireEvent.click(screen.getByRole("button", { name: "Confirm Install" }));
+
+    await waitFor(() => expect(mocks.installHostStackVersion).toHaveBeenCalledWith(
+      "c1",
+      "host1",
+      expect.objectContaining({
+        displayName: "Candidate version",
+        repoVersion: "Candidate version-repo",
+      }),
+    ));
+    expect(await screen.findByText("Request 17")).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Installing" })).toBeTruthy();
+  });
+
+  it("keeps confirmation open and retries a failed installation", async () => {
+    mocks.installHostStackVersion
+      .mockRejectedValueOnce({ response: { data: { message: "Repository unavailable" } } })
+      .mockResolvedValueOnce({ Requests: { id: 18 } });
+    renderVersions();
+    const installButton = screen.getAllByRole("button", { name: "Install" })
+      .find((button) => !button.hasAttribute("disabled"));
+    fireEvent.click(installButton!);
+    fireEvent.click(screen.getByRole("button", { name: "Confirm Install" }));
+
+    expect(await screen.findByText("Repository unavailable")).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: "Confirm Retry" }));
+    await waitFor(() => expect(mocks.installHostStackVersion).toHaveBeenCalledTimes(2));
+    expect(await screen.findByText("Request 18")).toBeTruthy();
+  });
+
+  it("disables installation while another user owns the wizard", () => {
+    renderVersions(true);
+    const eligibleButton = screen.getAllByRole("button", { name: "Install" })[1];
+    expect(eligibleButton.hasAttribute("disabled")).toBe(true);
+  });
+});

--- a/ambari-web/latest/src/screens/Alerts/HostStackVersions.tsx
+++ b/ambari-web/latest/src/screens/Alerts/HostStackVersions.tsx
@@ -16,210 +16,288 @@
  * limitations under the License.
  */
 
-import { useState, useEffect, useContext, useMemo } from 'react';
-import { useParams } from 'react-router-dom';
-import { Container, Form, Row, Col, Button, Dropdown } from 'react-bootstrap';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faPowerOff } from '@fortawesome/free-solid-svg-icons';
-import { AppContext } from '../../store/context';
-import VersionsApi from '../../api/versionsApi';
-import Spinner from '../../components/Spinner';
-import Table from '../../components/Table';
-import { ColumnDef } from '@tanstack/react-table';
+import { useContext, useState } from "react";
+import { Alert, Badge, Button, Col, Container, Form, Row } from "react-bootstrap";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faCog, faPowerOff, faQuestionCircle } from "@fortawesome/free-solid-svg-icons";
+import { ColumnDef, SortingState } from "@tanstack/react-table";
+import { get } from "lodash";
+import VersionsApi from "../../api/versionsApi";
+import ConfirmationModal from "../../components/ConfirmationModal";
+import Paginator from "../../components/Paginator";
+import Table from "../../components/Table";
+import usePagination from "../../hooks/usePagination";
+import { useAuth } from "../../hooks/useAuth";
+import IHost from "../../models/host";
+import HostStackVersion, { IHostStackVersion } from "../../models/hostStackVersion";
+import { AppContext } from "../../store/context";
+import BackgroundOperations from "../BackgroundOperations";
+import { translateWithVariables } from "../../Utils/Utility";
+import { messages } from "../messages";
 
-interface RepositoryVersion {
-    RepositoryVersions: {
-        display_name: string;
-    };
+type HostStackVersionsProps = {
+  host?: IHost;
+};
+
+type VersionRow = {
+  key: string;
+  version: IHostStackVersion;
+  status: string;
+};
+
+type VersionColumn = ColumnDef<VersionRow, any> & { width?: string };
+
+function versionKey(version: IHostStackVersion): string {
+  return `${version.stack}:${version.version}:${version.repoVersion}`;
 }
 
-interface StackVersion {
-    ClusterStackVersions: {
-        stack: string;
-        state: string;
-    };
-    repository_versions: RepositoryVersion[];
+function requestIdFrom(response: any): string | number | null {
+  return get(response, "Requests.id", get(response, "data.Requests.id", null));
 }
 
-interface SortingState {
-    id: string;
-    desc: boolean;
-}
+const HostStackVersions = ({ host }: HostStackVersionsProps) => {
+  const {
+    backgroundOperations,
+    clusterName,
+    isNonWizardUser,
+  } = useContext(AppContext);
+  const { hasAuthorization } = useAuth();
+  const [stackFilter, setStackFilter] = useState("");
+  const [nameFilter, setNameFilter] = useState("");
+  const [statusFilter, setStatusFilter] = useState("");
+  const [sorting, setSorting] = useState<SortingState>([]);
+  const [versionToInstall, setVersionToInstall] = useState<IHostStackVersion | null>(null);
+  const [installingVersionKey, setInstallingVersionKey] = useState<string | null>(null);
+  const [installError, setInstallError] = useState("");
+  const [submittedRequestId, setSubmittedRequestId] = useState<string | number | null>(null);
+  const [showProgress, setShowProgress] = useState(false);
+  const [optimisticInstalling, setOptimisticInstalling] = useState<Set<string>>(new Set());
 
-const HostStackVersions = () => {
-    const { hostName } = useParams<{ hostName: string }>();
-    const { clusterName } = useContext(AppContext);
-    const [stackVersions, setStackVersions] = useState<StackVersion[]>([]);
-    const [filteredStackVersions, setFilteredStackVersions] = useState<StackVersion[]>([]);
-    const [isLoading, setIsLoading] = useState(true);
-    const [stackFilter, setStackFilter] = useState('');
-    const [nameFilter, setNameFilter] = useState('');
-    const [statusFilter, setStatusFilter] = useState('');
-    const [sorting, setSorting] = useState<SortingState[]>([]);
+  const canManageStackVersions = hasAuthorization("AMBARI.MANAGE_STACK_VERSIONS");
+  const visibleVersions = (host?.stackVersions || []).filter(
+    (version) => version.isVisible !== false,
+  );
+  const rows: VersionRow[] = visibleVersions.map((version) => ({
+    key: versionKey(version),
+    version,
+    status: optimisticInstalling.has(versionKey(version)) ? "INSTALLING" : version.status,
+  }));
+  const filteredRows = rows.filter((row) => (
+    (!stackFilter || row.version.stack === stackFilter)
+    && (!nameFilter || row.version.displayName === nameFilter)
+    && (!statusFilter || row.status === statusFilter)
+  ));
+  const uniqueStacks = [...new Set(rows.map((row) => row.version.stack))];
+  const uniqueNames = [...new Set(rows.map((row) => row.version.displayName))];
+  const {
+    currentItems,
+    changePage,
+    currentPage,
+    maxPage,
+    itemsPerPage,
+    setItemsPerPage,
+  } = usePagination(filteredRows);
 
-    const uniqueStacks = useMemo(() => [...new Set(stackVersions.map(item => item.ClusterStackVersions.stack))], [stackVersions]);
-    const uniqueNames = useMemo(() => [...new Set(stackVersions.map(item => item.repository_versions[0].RepositoryVersions.display_name))], [stackVersions]);
-    const uniqueStatuses = useMemo(() => ['Installed', 'Installing', 'Install Failed', 'Out of Sync', 'Current', 'Upgrading', 'Upgrade Failed'].map(status => status.toUpperCase()), []);
-    const fetchData = async () => {
-        try {
-            const response = await VersionsApi.getServices(clusterName);
-            const filteredItems = response.items.filter((item: StackVersion) => {
-                return item.ClusterStackVersions.state !== 'NOT_REQUIRED';
-            });
-            setStackVersions(filteredItems);
-            setFilteredStackVersions(filteredItems);
-        } catch (error) {
-            console.error('Error fetching data:', error);
-        } finally {
-            setIsLoading(false);
+  const lastInstallRequestId = submittedRequestId || get(
+    backgroundOperations.find((request: any) => (
+      get(request, "Requests.request_context", "").startsWith("Install version")
+    )),
+    "Requests.id",
+    null,
+  );
+
+  const installVersion = async () => {
+    if (!versionToInstall || !host || installingVersionKey) {
+      return;
+    }
+
+    const key = versionKey(versionToInstall);
+    setInstallingVersionKey(key);
+    setInstallError("");
+    try {
+      const response = await VersionsApi.installHostStackVersion(
+        clusterName,
+        host.hostName,
+        versionToInstall,
+      );
+      const requestId = requestIdFrom(response);
+      setOptimisticInstalling((current) => new Set(current).add(key));
+      setSubmittedRequestId(requestId);
+      setVersionToInstall(null);
+      setShowProgress(requestId !== null);
+    } catch (error: any) {
+      setInstallError(
+        error?.response?.data?.message || "Ambari could not start the version installation.",
+      );
+    } finally {
+      setInstallingVersionKey(null);
+    }
+  };
+
+  const columns: VersionColumn[] = [
+    {
+      header: "Stack",
+      accessorFn: (row) => row.version.stack,
+      id: "stack",
+      width: "25%",
+    },
+    {
+      header: "Name",
+      accessorFn: (row) => row.version.displayName,
+      id: "displayName",
+      width: "25%",
+    },
+    {
+      header: "Status",
+      accessorKey: "status",
+      width: "25%",
+      cell: ({ row }) => {
+        const { status } = row.original;
+        if (status === "CURRENT") {
+          return <Badge bg="success">Current</Badge>;
         }
-    };
-
-    useEffect(() => {
-        fetchData();
-    }, [hostName, clusterName]);
-
-    useEffect(() => {
-        const filteredData = stackVersions.filter(item => {
-            const matchesStack = stackFilter === '' || item.ClusterStackVersions.stack === stackFilter;
-            const matchesName = nameFilter === '' || item.repository_versions[0].RepositoryVersions.display_name === nameFilter;
-            const matchesStatus = statusFilter === '' || item.ClusterStackVersions.state === statusFilter;
-            return matchesStack && matchesName && matchesStatus;
-        });
-        setFilteredStackVersions(filteredData);
-    }, [stackFilter, nameFilter, statusFilter, stackVersions]);
-
-    const columns: any[] = [
-        {
-            header: 'Stack',
-            accessorKey: 'ClusterStackVersions.stack',
-            width: "25%",
-            cell: ({ row }: any) => row.original.ClusterStackVersions.stack,
-        },
-        {
-            header: 'Name',
-            accessorKey: 'repository_versions.0.RepositoryVersions.display_name',
-            width: "25%",
-            cell: ({ row }: any) => row.original.repository_versions[0].RepositoryVersions.display_name,
-        },
-        {
-            header: 'Status',
-            accessorKey: 'ClusterStackVersions.state',
-            width: "25%",
-            cell: ({ row }: any) => {
-                const stackVersion = row.original;
-                return stackVersion.ClusterStackVersions.state === 'CURRENT' ? (
-                    <Button variant="success" disabled>
-                        {stackVersion.ClusterStackVersions.state}
-                    </Button>
-                ) : (
-                    stackVersion.ClusterStackVersions.state
-                );
-            },
-        },
-        {
-            header: '',
-            accessorKey: 'install',
-            cell: ({ }) => (
-                <Button variant="secondary" disabled>
-                    <FontAwesomeIcon className={'mx-1'} icon={faPowerOff} />
-                    Install
-                </Button>
-            ),
-        },
-    ];
-
-    return (
-      <div className="mx-5">
-        <Container className="p-4 bg-white">
-          <h2 className="table-title pb-2">Versions</h2>
-          {isLoading ? (
-            <Spinner />
-          ) : (
-            <>
-              <Form className="filter-container mb-3">
-                <Row className="border-top border-bottom py-2 mx-1">
-                  <Col xs={3}>
-                    <Form.Group controlId="stackFilter">
-                      <Dropdown>
-                        <Dropdown.Toggle variant="default" id="dropdown-basic">
-                          {stackFilter || "All"}
-                        </Dropdown.Toggle>
-                        <Dropdown.Menu>
-                          <Dropdown.Item onClick={() => setStackFilter("")}>
-                            All
-                          </Dropdown.Item>
-                          {uniqueStacks.map((stack, index) => (
-                            <Dropdown.Item
-                              key={index}
-                              onClick={() => setStackFilter(stack)}
-                            >
-                              {stack}
-                            </Dropdown.Item>
-                          ))}
-                        </Dropdown.Menu>
-                      </Dropdown>
-                    </Form.Group>
-                  </Col>
-                  <Col xs={3}>
-                    <Form.Group controlId="nameFilter">
-                      <Dropdown>
-                        <Dropdown.Toggle variant="default" id="dropdown-basic">
-                          {nameFilter || "All"}
-                        </Dropdown.Toggle>
-                        <Dropdown.Menu>
-                          <Dropdown.Item onClick={() => setNameFilter("")}>
-                            All
-                          </Dropdown.Item>
-                          {uniqueNames.map((name, index) => (
-                            <Dropdown.Item
-                              key={index}
-                              onClick={() => setNameFilter(name)}
-                            >
-                              {name}
-                            </Dropdown.Item>
-                          ))}
-                        </Dropdown.Menu>
-                      </Dropdown>
-                    </Form.Group>
-                  </Col>
-                  <Col xs={3}>
-                    <Form.Group controlId="statusFilter">
-                      <Dropdown>
-                        <Dropdown.Toggle variant="default" id="dropdown-basic">
-                          {statusFilter || "All"}
-                        </Dropdown.Toggle>
-                        <Dropdown.Menu>
-                          <Dropdown.Item onClick={() => setStatusFilter("")}>
-                            All
-                          </Dropdown.Item>
-                          {uniqueStatuses.map((status, index) => (
-                            <Dropdown.Item
-                              key={index}
-                              onClick={() => setStatusFilter(status)}
-                            >
-                              {status}
-                            </Dropdown.Item>
-                          ))}
-                        </Dropdown.Menu>
-                      </Dropdown>
-                    </Form.Group>
-                  </Col>
-                </Row>
-              </Form>
-              <Table
-                columns={columns as ColumnDef<unknown, unknown>[]}
-                data={filteredStackVersions}
-                hover
-                entityName="stack versions"
-                sorting={sorting}
-                onSortingChange={setSorting}
+        if (status === "INSTALLING") {
+          return (
+            <Button
+              variant="link"
+              className="p-0"
+              disabled={!lastInstallRequestId}
+              onClick={() => setShowProgress(true)}
+            >
+              <FontAwesomeIcon className="me-1" icon={faCog} spin />
+              {HostStackVersion.formatStatus(status)}
+            </Button>
+          );
+        }
+        return (
+          <>
+            {HostStackVersion.formatStatus(status)}
+            {status === "OUT_OF_SYNC" ? (
+              <FontAwesomeIcon
+                className="ms-2"
+                icon={faQuestionCircle}
+                title={get(messages, "hosts.host.stackVersions.outOfSync.tooltip", "")}
               />
-            </>
-          )}
-        </Container>
-      </div>
-    );
+            ) : null}
+          </>
+        );
+      },
+    },
+    {
+      header: "",
+      id: "install",
+      enableSorting: false,
+      cell: ({ row }) => canManageStackVersions ? (
+        <Button
+          variant="secondary"
+          disabled={
+            !["OUT_OF_SYNC", "INSTALL_FAILED"].includes(row.original.status)
+            || installingVersionKey !== null
+            || isNonWizardUser
+          }
+          onClick={() => {
+            setInstallError("");
+            setVersionToInstall(row.original.version);
+          }}
+        >
+          <FontAwesomeIcon className="me-1" icon={faPowerOff} />
+          Install
+        </Button>
+      ) : null,
+    },
+  ];
+
+  return (
+    <div className="mx-5">
+      <Container className="p-4 bg-white">
+        <h2 className="table-title pb-2">Versions</h2>
+        <Form className="filter-container mb-3">
+          <Row className="border-top border-bottom py-2 mx-1">
+            <Col xs={4}>
+              <Form.Select
+                aria-label="Filter versions by stack"
+                value={stackFilter}
+                onChange={(event) => setStackFilter(event.target.value)}
+              >
+                <option value="">All Versions</option>
+                {uniqueStacks.map((stack) => <option key={stack}>{stack}</option>)}
+              </Form.Select>
+            </Col>
+            <Col xs={4}>
+              <Form.Select
+                aria-label="Filter versions by name"
+                value={nameFilter}
+                onChange={(event) => setNameFilter(event.target.value)}
+              >
+                <option value="">All Names</option>
+                {uniqueNames.map((name) => <option key={name}>{name}</option>)}
+              </Form.Select>
+            </Col>
+            <Col xs={4}>
+              <Form.Select
+                aria-label="Filter versions by status"
+                value={statusFilter}
+                onChange={(event) => setStatusFilter(event.target.value)}
+              >
+                <option value="">All Statuses</option>
+                {HostStackVersion.statusDefinition.map((status) => (
+                  <option key={status} value={status}>{HostStackVersion.formatStatus(status)}</option>
+                ))}
+              </Form.Select>
+            </Col>
+          </Row>
+        </Form>
+        <Table
+          columns={columns as ColumnDef<unknown, unknown>[]}
+          data={currentItems}
+          hover
+          entityName="stack versions"
+          sorting={sorting}
+          onSortingChange={setSorting}
+        />
+        {filteredRows.length ? (
+          <Paginator
+            currentPage={currentPage}
+            maxPage={maxPage}
+            changePage={changePage}
+            itemsPerPage={itemsPerPage}
+            setItemsPerPage={setItemsPerPage}
+            totalItems={filteredRows.length}
+          />
+        ) : null}
+      </Container>
+      <ConfirmationModal
+        isOpen={versionToInstall !== null}
+        onClose={() => {
+          if (!installingVersionKey) {
+            setVersionToInstall(null);
+            setInstallError("");
+          }
+        }}
+        modalTitle="Confirm Installation"
+        modalBody={(
+          <>
+            {versionToInstall ? translateWithVariables(
+              "hosts.host.stackVersions.install.confirmation",
+              { "0": versionToInstall.displayName },
+            ) : null}
+            {installError ? <Alert className="mt-3 mb-0" variant="danger">{installError}</Alert> : null}
+          </>
+        )}
+        successCallback={() => void installVersion()}
+        okButtonText={installError ? "Retry" : "Install"}
+        isOkDisabled={installingVersionKey !== null}
+      />
+      {showProgress && lastInstallRequestId ? (
+        <BackgroundOperations
+          isOpen
+          isExplicitClick
+          requestId={lastInstallRequestId}
+          onClose={() => setShowProgress(false)}
+        />
+      ) : null}
+    </div>
+  );
 };
 
 export default HostStackVersions;

--- a/ambari-web/latest/src/screens/Alerts/types.ts
+++ b/ambari-web/latest/src/screens/Alerts/types.ts
@@ -122,6 +122,7 @@ export interface MergedAlert {
     name: string;
     label: string;
     description: string;
+    serviceName?: string;
     serviceDisplayName: string;
     component_name: string;
     alert_definition_id: number;

--- a/ambari-web/latest/src/screens/ClusterWizard/Step2.tsx
+++ b/ambari-web/latest/src/screens/ClusterWizard/Step2.tsx
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-import { Button, Card, Form } from "react-bootstrap";
+import { Alert, Button, Card, Form } from "react-bootstrap";
 import DefaultButton from "../../components/DefaultButton";
 import { useContext, useEffect, useRef, useState } from "react";
 import Tooltip from "../../components/Tooltip";
@@ -29,6 +29,7 @@ import { ActionTypes } from "./clusterStore/types";
 import WizardFooter from "../../components/StepWizard/WizardFooter";
 import { getStepData } from "../../Utils/Utility";
 import { ContextWrapper } from ".";
+import { prepareHostInput } from "../../Utils/hostWizard";
 
 type FormFields = {
   targetHosts: string;
@@ -36,14 +37,22 @@ type FormFields = {
   sshKey: string;
   sshUserAccount: string;
   sshPortNumber: number;
+  agentUserAccount: string;
 };
 
 interface Step2Props {
   wizardName?: string;
   installedHosts?: string[];
+  customizeAgentUserAccount?: boolean;
+  isWindowsStack?: boolean;
 }
 
-export default function Step2({ installedHosts = [] }: Step2Props) {
+export default function Step2({
+  wizardName = "clusterCreation",
+  installedHosts = [],
+  customizeAgentUserAccount = false,
+  isWindowsStack = false,
+}: Step2Props) {
   const [showManualRegistrationWarning, setShowManualRegistrationWarning] =
     useState(false);
   const { Context } = useContext(ContextWrapper);
@@ -64,8 +73,10 @@ export default function Step2({ installedHosts = [] }: Step2Props) {
     formState: { errors },
   } = useForm<FormFields>({
     defaultValues: {
+      isSshRegistration: true,
       sshUserAccount: "root",
       sshPortNumber: 22,
+      agentUserAccount: "root",
     },
   });
   const [formData, setFormData] = useState<FormFields>();
@@ -95,17 +106,22 @@ export default function Step2({ installedHosts = [] }: Step2Props) {
   }, [isSshRegistration]);
 
   useEffect(() => {
-    const stepData = getStepData(state, currentStep.name, "");
-    if (stepData) {
-      // setValue("isSshRegistration", stepData?.isSshRegistration);
-      // setValue("sshKey", stepData?.sshKey!);
-      // setValue("targetHosts", stepData?.targetHosts?.join("\n"));
-      // setValue("sshUserAccount", stepData?.sshUserAccount);
-      // setValue("sshPortNumber", stepData?.sshPortNumber);
-      // installedHosts= stepData?.installedHosts || [];
-      // setHostNameArr(stepData?.targetHosts || []);
+    const stepData = getStepData(
+      state,
+      currentStep.name,
+      "",
+      `${wizardName}Steps`,
+    );
+    if (stepData && Object.keys(stepData).length) {
+      setValue("isSshRegistration", stepData.isSshRegistration ?? true);
+      setValue("sshKey", stepData.sshKey || "");
+      setValue("targetHosts", (stepData.targetHosts || []).join("\n"));
+      setValue("sshUserAccount", stepData.sshUserAccount || "root");
+      setValue("sshPortNumber", stepData.sshPortNumber || 22);
+      setValue("agentUserAccount", stepData.agentUserAccount || "root");
+      setHostNameArr(stepData.targetHosts || []);
     }
-  }, []);
+  }, [currentStep.name, setValue, state, wizardName]);
 
   const handleFileChange = (e: any) => {
     const file = e.target.files[0];
@@ -142,99 +158,58 @@ export default function Step2({ installedHosts = [] }: Step2Props) {
     return true;
   };
 
-  const parseHostNamesAsPatternExpression = (hostNames: string[]) => {
-    let tempArr: string[] = [];
-    let isPatternExpressionPresent = false;
-    hostNames.forEach((hostName) => {
-      const patternMatch = hostName.match(/(.*)\[(\d+)-(\d+)\](.*)/);
-
-      if (patternMatch) {
-        const [_, prefix, start, end, suffix] = patternMatch;
-        let hnlen = tempArr.length;
-        for (let i = parseInt(start); i <= parseInt(end); i++) {
-          isPatternExpressionPresent = true;
-          tempArr.push(`${prefix}${i}${suffix}`);
-        }
-        if (hnlen === tempArr.length) {
-          tempArr.push(hostName);
-        }
-      } else {
-        tempArr.push(hostName);
-      }
-    });
-
-    tempArr = Array.from(new Set(tempArr));
-
-    setHostNameArr(tempArr);
-    return isPatternExpressionPresent;
-  };
-
-  const updateHostNameArr = (targetHostsData: string) => {
-    let targetHosts = targetHostsData
-      .split(new RegExp("\\s+", "g"))
-      .filter((host) => host.trim() !== "");
-    let isPatternExpressionPresent =
-      parseHostNamesAsPatternExpression(targetHosts);
-
-    setHostNameArr((prevHostNameArr) => {
-      let tempNotInstalledHostNameArr: string[] = [];
-      let tempInputtedAgainHostNameArr: string[] = [];
-      prevHostNameArr.forEach((hostName) => {
-        if (installedHosts.includes(hostName)) {
-          tempInputtedAgainHostNameArr.push(hostName);
-        } else {
-          tempNotInstalledHostNameArr.push(hostName);
-        }
-      });
-
-      setInputtedAgainHostNames(tempInputtedAgainHostNameArr);
-
-      if (!tempNotInstalledHostNameArr.length) {
-        setError("targetHosts", {
-          message: "All these hosts are already part of the cluster",
-        });
-        return prevHostNameArr;
-      }
-
-      if (isPatternExpressionPresent) {
-        setShowPatternExpressionModal(true);
-      } else {
-        if (tempInputtedAgainHostNameArr.length) {
-          setShowInstalledHostnameWarning(true);
-        } else {
-          if (isAllHostNamesValid(tempNotInstalledHostNameArr)) {
-            if (!isSshRegistration) {
-              setShowBeforeProceedModal(true);
-            }
-          } else {
-            setShowInvalidHostnameWarning(true);
-          }
-        }
-      }
-
-      return tempNotInstalledHostNameArr;
-    });
-  };
-
   const onSubmit: SubmitHandler<FormFields> = (data) => {
-    setFormData(data);
-    const apiData = updateHostNameArr(data.targetHosts);
-    console.log("API Data: ", apiData);
+    const prepared = prepareHostInput(data.targetHosts, installedHosts);
+    const submission = {
+      ...data,
+      agentUserAccount: customizeAgentUserAccount
+        ? data.agentUserAccount
+        : "root",
+      isSshRegistration: isWindowsStack || data.isSshRegistration,
+      sshKey: isWindowsStack ? "" : data.sshKey,
+      sshUserAccount: isWindowsStack ? "" : data.sshUserAccount,
+      sshPortNumber: isWindowsStack ? 0 : data.sshPortNumber,
+    };
+    clearErrors("targetHosts");
+    setFormData(submission);
+    setHostNameArr(prepared.hosts);
+    setInputtedAgainHostNames(prepared.alreadyInstalled);
+    if (!prepared.hosts.length) {
+      setError("targetHosts", {
+        message: "All these hosts are already part of the cluster",
+      });
+    } else if (prepared.hadPattern) {
+      setShowPatternExpressionModal(true);
+    } else if (prepared.alreadyInstalled.length) {
+      setShowInstalledHostnameWarning(true);
+    } else if (!isAllHostNamesValid(prepared.hosts)) {
+      setShowInvalidHostnameWarning(true);
+    } else if (!submission.isSshRegistration) {
+      setShowBeforeProceedModal(true);
+    } else {
+      moveToNextStep(submission, prepared.hosts);
+    }
   };
 
-  useEffect(() => {
-    if (registerRef.current) enableNext();
-  }, [registerRef.current]);
+  useEffect(() => enableNext(), []);
 
-  const moveToNextStep = () => {
+  const moveToNextStep = (
+    submission: FormFields | undefined = formData,
+    hosts: string[] = hostNameArr,
+  ) => {
+    if (!submission || hosts.length === 0) {
+      return;
+    }
     dispatch({
       type: ActionTypes.STORE_INFORMATION,
       payload: {
         step: currentStep.name,
         data: {
-          ...formData,
-          targetHosts: hostNameArr,
+          ...submission,
+          targetHosts: hosts,
           installedHosts: installedHosts,
+          useSsh: !isWindowsStack && submission.isSshRegistration,
+          customizeAgentUserAccount,
         },
       },
     });
@@ -395,7 +370,7 @@ export default function Step2({ installedHosts = [] }: Step2Props) {
             </div>
             <div>
               <h2 className="mb-3">Host Registration Information</h2>
-              <div className="d-flex justify-content-between w-75 mb-3">
+              {!isWindowsStack && <div className="d-flex justify-content-between w-75 mb-3">
                 <div className="d-flex make-all-grey">
                   <Form.Check
                     type="radio"
@@ -441,8 +416,13 @@ export default function Step2({ installedHosts = [] }: Step2Props) {
                     on hosts and do not use SSH
                   </Form.Label>
                 </div>
-              </div>
-              <div className="d-flex mb-2">
+              </div>}
+              {isWindowsStack && (
+                <Alert variant="info">
+                  Windows hosts use PowerShell Remoting; SSH settings are not required.
+                </Alert>
+              )}
+              {!isWindowsStack && <><div className="d-flex mb-2">
                 <DefaultButton
                   onClick={handleChooseFileClick}
                   disabled={!isSshRegistration}
@@ -545,6 +525,26 @@ export default function Step2({ installedHosts = [] }: Step2Props) {
                   )}
                 </div>
               </div>
+              {customizeAgentUserAccount && (
+                <div className="d-flex w-100 mt-3">
+                  <div className="d-flex justify-content-between w-75">
+                    <Form.Label className="pt-2">Ambari Agent User Account</Form.Label>
+                    <Form.Control
+                      {...register("agentUserAccount", {
+                        required: isSshRegistration ? "Agent user name is required" : false,
+                      })}
+                      type="text"
+                      className={errors.agentUserAccount ? "w-50 border-danger" : "w-50"}
+                      disabled={!isSshRegistration}
+                    />
+                  </div>
+                  {errors.agentUserAccount && (
+                    <div className="text-danger mt-3 ms-3">
+                      <FontAwesomeIcon icon={faCircleXmark} /> {errors.agentUserAccount.message}
+                    </div>
+                  )}
+                </div>
+              )}</>}
             </div>
             <div className="mt-4">
               <Button

--- a/ambari-web/latest/src/screens/ClusterWizard/Step3.test.tsx
+++ b/ambari-web/latest/src/screens/ClusterWizard/Step3.test.tsx
@@ -1,0 +1,124 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { act, cleanup, render } from "@testing-library/react";
+import { createContext } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ContextWrapper } from ".";
+
+const mocks = vi.hoisted(() => ({
+  isHostsRegistered: vi.fn(),
+  loadAmbariProperties: vi.fn(),
+  startHostCheck: vi.fn(),
+}));
+
+vi.mock("../../api/clusterApi", () => ({
+  default: { loadAmbariProperties: mocks.loadAmbariProperties },
+}));
+vi.mock("../../api/wizardApi", () => ({
+  default: { isHostsRegistered: mocks.isHostsRegistered },
+}));
+vi.mock("../../hooks/useHostChecks", () => ({
+  useHostChecks: () => ({
+    hostCheckResult: [],
+    isHostCheckRunning: false,
+    startHostCheck: mocks.startHostCheck,
+  }),
+}));
+vi.mock("../Hosts/HostChecks", () => ({
+  default: () => null,
+  getHostWithIssues: () => [],
+}));
+vi.mock("../../components/Table", () => ({ default: () => null }));
+vi.mock("../../components/Paginator", () => ({ default: () => null }));
+vi.mock("../../components/Spinner", () => ({ default: () => null }));
+vi.mock("../../components/StepWizard/WizardFooter", () => ({
+  default: () => null,
+}));
+
+import Step3 from "./Step3";
+
+describe("Confirm Hosts registration polling", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    mocks.loadAmbariProperties.mockResolvedValue({});
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.useRealTimers();
+  });
+
+  it("schedules the next registration poll only after the current request settles", async () => {
+    let completeFirstPoll: (response: unknown) => void = () => undefined;
+    mocks.isHostsRegistered
+      .mockReturnValueOnce(new Promise((resolve) => {
+        completeFirstPoll = resolve;
+      }))
+      .mockResolvedValue({ items: [] });
+    const contextValue = {
+      dispatch: vi.fn(),
+      flushStateToDb: vi.fn(),
+      state: {
+        addHostSteps: {
+          HOSTS: {
+            data: {
+              installedHosts: [],
+              isSshRegistration: false,
+              targetHosts: ["host1"],
+            },
+          },
+        },
+      },
+      stepWizardUtilities: {
+        currentStep: { name: "HOST_STATUS" },
+        handleBackImperitive: vi.fn(),
+        handleNextImperitive: vi.fn(),
+      },
+    };
+    const WizardContext = createContext(contextValue);
+
+    render(
+      <ContextWrapper.Provider value={{ Context: WizardContext }}>
+        <WizardContext.Provider value={contextValue}>
+          <Step3 wizardName="addHost" />
+        </WizardContext.Provider>
+      </ContextWrapper.Provider>,
+    );
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(mocks.isHostsRegistered).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(3000);
+    });
+    expect(mocks.isHostsRegistered).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      completeFirstPoll({ items: [] });
+      await Promise.resolve();
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(3000);
+    });
+    expect(mocks.isHostsRegistered).toHaveBeenCalledTimes(2);
+  });
+});

--- a/ambari-web/latest/src/screens/ClusterWizard/Step3.tsx
+++ b/ambari-web/latest/src/screens/ClusterWizard/Step3.tsx
@@ -43,6 +43,10 @@ import { useHostChecks } from "../../hooks/useHostChecks";
 import { messages } from "../messages";
 import { ContextWrapper } from ".";
 import modalManager from "../../store/ModalManager";
+import {
+  addHostRegistrationTimeoutSecs,
+  buildBootstrapPayload,
+} from "../../Utils/hostWizard";
 
 interface Host {
   name: string;
@@ -123,6 +127,10 @@ export default function Step3({ wizardName = "clusterCreation" }: Step3Props) {
   };
 
   const registrationStartedAt = useRef<any>(null);
+  const registrationTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const bootstrapTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const bootstrapStarted = useRef(false);
+  const isMounted = useRef(true);
   //TODO: Remove this hack
   const serviceCheckStarted = useRef(false);
   const hostsRef = useRef<Host[]>([]);
@@ -136,7 +144,6 @@ export default function Step3({ wizardName = "clusterCreation" }: Step3Props) {
     setItemsPerPage,
   } = usePagination(hostsToBeDisplayed);
 
-  const registrationTimeoutSecs = 15;
   const bootStatusFilterMapping = {
     [ShowOptions.ALL]: [
       BootStatus.PENDING,
@@ -167,32 +174,26 @@ export default function Step3({ wizardName = "clusterCreation" }: Step3Props) {
   useEffect(() => {
     hostsRef.current = hosts;
     if (hostsRef.current.length) {
-      if (!registrationStartedAt.current) {
+      const installOptions = get(
+        state,
+        `${wizardName}Steps.${wizardSteps[2].name}.data`,
+        {},
+      );
+      if (installOptions.isSshRegistration) {
+        if (!bootstrapStarted.current && hostsRef.current.some(
+          (host) => host.bootStatus === BootStatus.PENDING,
+        )) {
+          void startAutomaticBootstrap(installOptions);
+        } else if (
+          !registrationStartedAt.current
+          && hostsRef.current.some((host) => host.bootStatus === BootStatus.DONE)
+        ) {
+          startRegistration();
+        }
+      } else if (!registrationStartedAt.current) {
         startRegistration();
       }
 
-      if (isRegistrationInProgress()) {
-        if (
-          hostsRef.current.some(
-            (_host) => _host.bootStatus === BootStatus.RUNNING
-          ) ||
-          Date.now() - registrationStartedAt.current <
-            registrationTimeoutSecs * 1000
-        ) {
-          setTimeout(isHostsRegistered, 3000);
-        } else {
-          let updatedHosts = hostsRef.current.map((_host) => {
-            if (_host.bootStatus === BootStatus.REGISTERING) {
-              _host.bootStatus = BootStatus.FAILED;
-              _host.bootLog =
-                (_host.bootLog || "") +
-                "Registration with the server failed.\n\n";
-            }
-            return _host;
-          });
-          setHosts(updatedHosts);
-        }
-      }
     }
     let showOptionsTemp = [...showOptions];
     showOptionsTemp.forEach((option) => {
@@ -206,6 +207,16 @@ export default function Step3({ wizardName = "clusterCreation" }: Step3Props) {
     setHostsToBeDisplayed(hosts);
     applyFilters();
   }, [hosts]);
+
+  useEffect(() => () => {
+    isMounted.current = false;
+    if (registrationTimer.current) {
+      clearTimeout(registrationTimer.current);
+    }
+    if (bootstrapTimer.current) {
+      clearTimeout(bootstrapTimer.current);
+    }
+  }, []);
 
   useEffect(() => {
     applyFilters();
@@ -250,10 +261,138 @@ export default function Step3({ wizardName = "clusterCreation" }: Step3Props) {
     }
   };
 
+  const failRegistrationHosts = () => {
+    setHosts((current) => current.map((host) =>
+      host.bootStatus === BootStatus.REGISTERING
+        ? {
+            ...host,
+            bootStatus: BootStatus.FAILED,
+            bootLog: `${host.bootLog || ""}Registration with the server failed.\n\n`,
+          }
+        : host,
+    ));
+  };
+
+  const scheduleRegistrationPoll = (installOptions: any) => {
+    const timeoutSecs = addHostRegistrationTimeoutSecs(
+      Boolean(installOptions.isSshRegistration),
+    );
+    const bootstrapStillRunning = hostsRef.current.some(
+      (host) => host.bootStatus === BootStatus.RUNNING,
+    );
+    const withinTimeout = registrationStartedAt.current !== null
+      && Date.now() - registrationStartedAt.current < timeoutSecs * 1000;
+    if (bootstrapStillRunning || withinTimeout) {
+      if (registrationTimer.current) {
+        clearTimeout(registrationTimer.current);
+      }
+      registrationTimer.current = setTimeout(() => void isHostsRegistered(), 3000);
+    } else {
+      failRegistrationHosts();
+    }
+  };
+
+  const failBootstrapHosts = (message: string) => {
+    if (!isMounted.current) {
+      return;
+    }
+    setHosts((current) => current.map((host) =>
+      [BootStatus.PENDING, BootStatus.RUNNING].includes(host.bootStatus as BootStatus)
+        ? { ...host, bootStatus: BootStatus.FAILED, bootLog: message }
+        : host,
+    ));
+  };
+
+  const pollBootstrap = async (requestId: string) => {
+    try {
+      const response = await WizardApi.getBootstrapStatus(requestId);
+      if (!isMounted.current) {
+        return;
+      }
+      const statuses = Array.isArray(response.hostsStatus)
+        ? response.hostsStatus
+        : response.hostsStatus
+          ? [response.hostsStatus]
+          : [];
+      setHosts((current) => current.map((host) => {
+        const update = statuses.find((item: any) => item.hostName === host.name);
+        if (!update) {
+          return response.status === "ERROR" && host.bootStatus !== BootStatus.REGISTERED
+            ? { ...host, bootStatus: BootStatus.FAILED, bootLog: response.log || "Bootstrap failed." }
+            : host;
+        }
+        const status = [BootStatus.DONE, BootStatus.FAILED, BootStatus.RUNNING]
+          .includes(update.status)
+          ? update.status
+          : host.bootStatus;
+        return {
+          ...host,
+          bootStatus: status,
+          bootLog: update.log || host.bootLog,
+        };
+      }));
+      const terminal = response.status === "ERROR"
+        || (statuses.length > 0 && statuses.every((item: any) =>
+          [BootStatus.DONE, BootStatus.FAILED].includes(item.status),
+        ));
+      if (!terminal) {
+        bootstrapTimer.current = setTimeout(() => void pollBootstrap(requestId), 3000);
+      }
+    } catch (error: any) {
+      bootstrapStarted.current = false;
+      failBootstrapHosts(
+        error?.response?.data?.message || "Ambari could not bootstrap the selected hosts.",
+      );
+    }
+  };
+
+  const startAutomaticBootstrap = async (installOptions: any) => {
+    bootstrapStarted.current = true;
+    setHosts((current) => current.map((host) =>
+      host.bootStatus === BootStatus.PENDING
+        ? { ...host, bootStatus: BootStatus.RUNNING, bootLog: "Setting up Ambari Agent...\n\n" }
+        : host,
+    ));
+    try {
+      const response = await WizardApi.launchBootstrap(buildBootstrapPayload({
+        agentUserAccount: installOptions.agentUserAccount,
+        customizeAgentUserAccount: Boolean(installOptions.customizeAgentUserAccount),
+        hosts: installOptions.targetHosts || [],
+        sshKey: installOptions.sshKey,
+        sshPortNumber: installOptions.sshPortNumber,
+        sshUserAccount: installOptions.sshUserAccount,
+      }));
+      const requestId = String(response.requestId ?? "");
+      if (!requestId || response.status === "ERROR") {
+        bootstrapStarted.current = false;
+        failBootstrapHosts(response.log || "Ambari could not start host bootstrap.");
+        return;
+      }
+      await pollBootstrap(requestId);
+    } catch (error: any) {
+      bootstrapStarted.current = false;
+      failBootstrapHosts(
+        error?.response?.data?.message || "Ambari could not start host bootstrap.",
+      );
+    }
+  };
+
   const isHostsRegistered = async () => {
-    const response = await WizardApi.isHostsRegistered();
-    if (response) {
-      isHostsRegisteredSuccessCallback(response);
+    try {
+      const response = await WizardApi.isHostsRegistered();
+      if (response && isMounted.current) {
+        isHostsRegisteredSuccessCallback(response);
+      }
+    } catch {
+      if (!isMounted.current || !isRegistrationInProgress()) {
+        return;
+      }
+      const installOptions = get(
+        state,
+        `${wizardName}Steps.${wizardSteps[2].name}.data`,
+        {},
+      );
+      scheduleRegistrationPoll(installOptions);
     }
   };
 
@@ -297,7 +436,16 @@ export default function Step3({ wizardName = "clusterCreation" }: Step3Props) {
       return updatedHost;
     });
 
+    hostsRef.current = updatedHosts;
     setHosts(updatedHosts);
+    if (isRegistrationInProgress()) {
+      const installOptions = get(
+        state,
+        `${wizardName}Steps.${wizardSteps[2].name}.data`,
+        {},
+      );
+      scheduleRegistrationPoll(installOptions);
+    }
   };
 
   const loadHosts = () => {
@@ -314,7 +462,7 @@ export default function Step3({ wizardName = "clusterCreation" }: Step3Props) {
     )
       ? "PENDING"
       : "DONE";
-    hostInfo.forEach((host: string[]) => {
+    hostInfo.forEach((host: string) => {
       allHosts.push({
         name: host,
         bootStatus: bootStatus,
@@ -329,13 +477,19 @@ export default function Step3({ wizardName = "clusterCreation" }: Step3Props) {
     let updatedHosts = hostsRef.current.map((_host) => {
       let updatedHost = { ..._host };
       if (updatedHost.bootStatus === BootStatus.FAILED) {
-        updatedHost.bootStatus = BootStatus.DONE;
+        const automatic = get(
+          state,
+          `${wizardName}Steps.${wizardSteps[2].name}.data.isSshRegistration`,
+          true,
+        );
+        updatedHost.bootStatus = automatic ? BootStatus.PENDING : BootStatus.DONE;
         updatedHost.bootLog = "Retrying ...\n\n";
       }
       return updatedHost;
     });
     setHosts(updatedHosts);
     registrationStartedAt.current = null;
+    bootstrapStarted.current = false;
   };
 
   const startHostCheckLocal = (hostsList: Host[]) => {

--- a/ambari-web/latest/src/screens/CommonConfigs/AdvancedConfigs.tsx
+++ b/ambari-web/latest/src/screens/CommonConfigs/AdvancedConfigs.tsx
@@ -812,7 +812,11 @@ function AdvancedConfigs({
                                                 {renderInput(
                                                   {
                                                     ...currentConfigPropertyValue,
-                                                    isEditable: configGroup === "Default" && currentConfigPropertyValue.isEditable
+                                                    isEditable:
+                                                      !hostConfigs &&
+                                                      canEditConfigs &&
+                                                      configGroup === "Default" &&
+                                                      currentConfigPropertyValue.isEditable
                                                   },
                                                   function (
                                                     e: any,
@@ -954,7 +958,8 @@ function AdvancedConfigs({
                                             </Tooltip>
                                           )}
 
-                                      {config.includes("Custom") &&
+                                      {!hostConfigs &&
+                                        config.includes("Custom") &&
                                         canEditConfigs && (
                                           <Tooltip
                                             message="Remove this custom property"
@@ -985,7 +990,8 @@ function AdvancedConfigs({
                                           </Tooltip>
                                         )}
 
-                                      {displayUndoRedo &&
+                                      {!hostConfigs &&
+                                      displayUndoRedo &&
                                       canEditConfigs &&
                                       currentConfigPropertyValue.value !==
                                         currentConfigPropertyValue.previousValue &&
@@ -1006,7 +1012,7 @@ function AdvancedConfigs({
                                         />
                                         </Tooltip>
                                       ) : null}
-                                      {displayUndoRedo && canEditConfigs && configGroup === "Default" && (
+                                      {!hostConfigs && displayUndoRedo && canEditConfigs && configGroup === "Default" && (
                                         <Tooltip
                                           message="Reset to default value"
                                           placement="top"
@@ -1057,6 +1063,8 @@ function AdvancedConfigs({
                                                   propertyValue:
                                                     overrideValue.previousValue,
                                                   isEditable:
+                                                    !hostConfigs &&
+                                                    canEditConfigs &&
                                                     configGroup !== "Default",
                                                 },
                                                 function (
@@ -1080,7 +1088,7 @@ function AdvancedConfigs({
                                             </Stack>
                                           </Col>
                                           <Col md={2}>
-                                            {configGroup === "Default" ? (
+                                            {!hostConfigs && (configGroup === "Default" ? (
                                               <h4
                                                 className="text-info"
                                                 onClick={() => {
@@ -1124,7 +1132,7 @@ function AdvancedConfigs({
                                                   />
                                                 </Tooltip>
                                               </Stack>
-                                            )}
+                                            ))}
                                           </Col>
                                         </Row>
                                       );
@@ -1137,7 +1145,7 @@ function AdvancedConfigs({
                         return null;
                       }
                     )}
-                    {config.includes("Custom") ? (
+                    {!hostConfigs && canEditConfigs && config.includes("Custom") ? (
                       <h4
                         className="text-info ms-2 mt-2"
                         onClick={() => {

--- a/ambari-web/latest/src/screens/CommonConfigs/Config.tsx
+++ b/ambari-web/latest/src/screens/CommonConfigs/Config.tsx
@@ -852,7 +852,7 @@ export default function Config({
                 />
               </div>
             )}
-            {canEditConfigs && (
+            {!hostConfigs && canEditConfigs && (
               <Tooltip
                 message={
                   isTextMode
@@ -955,7 +955,7 @@ export default function Config({
                 />
               </div>
             )}
-            {allowSwitchToTextBox && canEditConfigs && (
+            {!hostConfigs && allowSwitchToTextBox && canEditConfigs && (
               <Tooltip
                 message={
                   isComboTextMode
@@ -1122,22 +1122,24 @@ export default function Config({
                 </div>
               </div>
             )}
-            <Tooltip
-              message={
-                isTimeTextMode
-                  ? "Switch back to time interval mode"
-                  : "Switch to text input mode"
-              }
-              placement="top"
-            >
-              <FontAwesomeIcon
-                icon={faPen}
-                className={`ms-4 ${isTimeTextMode ? "text-primary" : ""} ${
-                  property.isEditable ? "pointer" : ""
-                }`}
-                onClick={property.isEditable ? toggleTimeMode : undefined}
-              />
-            </Tooltip>
+            {!hostConfigs && canEditConfigs && (
+              <Tooltip
+                message={
+                  isTimeTextMode
+                    ? "Switch back to time interval mode"
+                    : "Switch to text input mode"
+                }
+                placement="top"
+              >
+                <FontAwesomeIcon
+                  icon={faPen}
+                  className={`ms-4 ${isTimeTextMode ? "text-primary" : ""} ${
+                    property.isEditable ? "pointer" : ""
+                  }`}
+                  onClick={property.isEditable ? toggleTimeMode : undefined}
+                />
+              </Tooltip>
+            )}
           </div>
         );
 
@@ -1191,22 +1193,24 @@ export default function Config({
                 </Form>
               </div>
             )}
-            <Tooltip
-              message={
-                isToggleTextMode
-                  ? "Switch back to toggle mode"
-                  : "Switch to text input mode"
-              }
-              placement="top"
-            >
-              <FontAwesomeIcon
-                icon={faPen}
-                className={`ms-4 ${isToggleTextMode ? "text-primary" : ""} ${
-                  property.isEditable ? "pointer" : ""
-                }`}
-                onClick={property.isEditable ? toggleToggleMode : undefined}
-              />
-            </Tooltip>
+            {!hostConfigs && canEditConfigs && (
+              <Tooltip
+                message={
+                  isToggleTextMode
+                    ? "Switch back to toggle mode"
+                    : "Switch to text input mode"
+                }
+                placement="top"
+              >
+                <FontAwesomeIcon
+                  icon={faPen}
+                  className={`ms-4 ${isToggleTextMode ? "text-primary" : ""} ${
+                    property.isEditable ? "pointer" : ""
+                  }`}
+                  onClick={property.isEditable ? toggleToggleMode : undefined}
+                />
+              </Tooltip>
+            )}
           </div>
         );
 
@@ -2578,6 +2582,8 @@ export default function Config({
                                                                                           {
                                                                                             ...property,
                                                                                             isEditable:
+                                                                                              !hostConfigs &&
+                                                                                              canEditConfigs &&
                                                                                               currentConfigGroup ===
                                                                                                 "Default" &&
                                                                                               property.isEditable,
@@ -2709,6 +2715,7 @@ export default function Config({
                                                                                       }
                                                                                     >
                                                                                       {!hostConfigs &&
+                                                                                        canEditConfigs &&
                                                                                         property?.supportsFinal && (
                                                                                           <Tooltip
                                                                                             message={
@@ -2838,7 +2845,8 @@ export default function Config({
                                                                                               />
                                                                                             </Tooltip>
                                                                                           )}
-                                                                                      {displayUndoRedo &&
+                                                                                      {!hostConfigs &&
+                                                                                      displayUndoRedo &&
                                                                                       property.value !==
                                                                                         property.previousValue &&
                                                                                       canEditConfigs &&
@@ -2857,7 +2865,8 @@ export default function Config({
                                                                                           }
                                                                                         />
                                                                                       ) : null}
-                                                                                      {displayUndoRedo &&
+                                                                                      {!hostConfigs &&
+                                                                                        displayUndoRedo &&
                                                                                         canEditConfigs &&
                                                                                         currentConfigGroup ===
                                                                                           "Default" && (
@@ -2925,6 +2934,8 @@ export default function Config({
                                                                                                   value:
                                                                                                     overrideValue.value,
                                                                                                   isEditable:
+                                                                                                    !hostConfigs &&
+                                                                                                    canEditConfigs &&
                                                                                                     currentConfigGroup !==
                                                                                                     "Default",
                                                                                                 },
@@ -2962,7 +2973,7 @@ export default function Config({
                                                                                                 1
                                                                                               }
                                                                                             >
-                                                                                              {currentConfigGroup ===
+                                                                                              {!hostConfigs && (currentConfigGroup ===
                                                                                               "Default" ? (
                                                                                                 <h4
                                                                                                   className="text-info"
@@ -3031,7 +3042,7 @@ export default function Config({
                                                                                                     }}
                                                                                                   />
                                                                                                 </Stack>
-                                                                                              )}
+                                                                                              ))}
                                                                                             </Col>
                                                                                           </Row>
                                                                                         );

--- a/ambari-web/latest/src/screens/Hosts/AddHostWizard/AddHostConfigurations.tsx
+++ b/ambari-web/latest/src/screens/Hosts/AddHostWizard/AddHostConfigurations.tsx
@@ -16,19 +16,24 @@
  * limitations under the License.
  */
 
-import { useContext, useEffect, useState } from "react";
+import { useContext, useEffect, useMemo, useRef, useState } from "react";
 import { AppContext } from "../../../store/context";
 import ConfigGroupApi from "../../../api/configGroupApi";
-import { cloneDeep, forEach, get, isEmpty, set } from "lodash";
+import { cloneDeep, get, isEmpty, set } from "lodash";
 import Table from "../../../components/Table";
-import { Form } from "react-bootstrap";
+import { Alert, Button, Form } from "react-bootstrap";
 import WizardFooter from "../../../components/StepWizard/WizardFooter";
 import { ContextWrapper } from "../../ClusterWizard";
 import { ActionTypes } from "./wizardDataStore/types";
 import { translate } from "../../../Utils/Utility";
+import Spinner from "../../../components/Spinner";
+import {
+  buildAddHostConfigGroups,
+  selectedAddHostServices,
+} from "../../../Utils/hostWizard";
 
 export default function AddHostConfigurations() {
-  const { clusterName, services } = useContext(AppContext);
+  const { clusterName } = useContext(AppContext);
   const { Context } = useContext(ContextWrapper);
   const {
     dispatch,
@@ -50,49 +55,61 @@ export default function AddHostConfigurations() {
 
   const [configGroups, setConfigGroups] = useState({});
   const [formData, setFormData] = useState(initialConfigs);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [retryCount, setRetryCount] = useState(0);
+  const skipped = useRef(false);
+  const selectedServices = useMemo(() => selectedAddHostServices(
+    get(state, "addHostSteps.SLAVES_AND_CLIENTS.data.serviceComponents", []),
+    get(state, "addHostSteps.SLAVES_AND_CLIENTS.data.allServiceComponentsList", []),
+  ), [state]);
 
   useEffect(() => {
-    getConfigGroups();
-  }, []);
+    if (!clusterName) {
+      return;
+    }
+    if (selectedServices.length === 0) {
+      if (!skipped.current) {
+        skipped.current = true;
+        dispatch({
+          type: ActionTypes.STORE_INFORMATION,
+          payload: { step: currentStep.name, data: { configurations: [] } },
+        });
+        void Promise.resolve(flushStateToDb("next")).then(handleNextImperitive);
+      }
+      setLoading(false);
+      return;
+    }
+    void getConfigGroups();
+  }, [clusterName, retryCount, selectedServices.join(",")]);
 
   useEffect(() => {
     if (!isEmpty(configGroups)) {
-      let data: any = [];
-      forEach(services, (service: any) => {
-        const serviceName = get(service, "ServiceInfo.service_name");
-        data.push({
-          serviceName: serviceName,
-          configGroups: get(configGroups, "items", [])
-            .filter(
-              (configGroup: any) =>
-                serviceName === get(configGroup, "ConfigGroup.tag")
-            )
-            .map((configGroup: any) => {
-              return {
-                ...get(configGroup, "ConfigGroup"),
-                isSelected: false,
-              };
-            }),
-        });
-      });
-      forEach(data, (service) => {
-        service?.configGroups.unshift({
-          cluster_name: clusterName,
-          description: "",
-          desired_configs: [],
-          group_name: "Default",
-          hosts: [],
-          tag: service?.serviceName,
-          isSelected: true,
-        });
-      });
-      setFormData(data);
+      setFormData(buildAddHostConfigGroups(
+        selectedServices,
+        configGroups,
+        clusterName,
+        initialConfigs,
+      ));
     }
-  }, [configGroups]);
+  }, [configGroups, clusterName, selectedServices.join(",")]);
 
   const getConfigGroups = async () => {
-    const response = await ConfigGroupApi.getConfigGroups(clusterName, "*");
-    setConfigGroups(response);
+    setLoading(true);
+    setError(null);
+    try {
+      const response = await ConfigGroupApi.getConfigGroupsForServices(
+        clusterName,
+        selectedServices,
+      );
+      setConfigGroups(response);
+    } catch (requestError: any) {
+      setError(
+        requestError?.response?.data?.message || "Ambari could not load configuration groups.",
+      );
+    } finally {
+      setLoading(false);
+    }
   };
 
   const getSelectedConfigGroupName = (configGroups: any[]) => {
@@ -176,9 +193,17 @@ export default function AddHostConfigurations() {
       <p className="make-all-grey step-description">
         {translate("addHost.step4.title")}
       </p>
-      <Table data={formData} columns={columnInTable} />
+      {error && (
+        <Alert variant="danger">
+          {error}{" "}
+          <Button size="sm" variant="outline-danger" onClick={() => setRetryCount((value) => value + 1)}>
+            Retry
+          </Button>
+        </Alert>
+      )}
+      {loading ? <Spinner /> : <Table data={formData} columns={columnInTable} />}
       <WizardFooter
-        isNextEnabled={true}
+        isNextEnabled={!loading && !error}
         step={currentStep}
         onNext={() => {
           moveToNextStep();

--- a/ambari-web/latest/src/screens/Hosts/AddHostWizard/AddHostInstall.tsx
+++ b/ambari-web/latest/src/screens/Hosts/AddHostWizard/AddHostInstall.tsx
@@ -1,0 +1,551 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useContext, useEffect, useRef, useState } from "react";
+import { Alert, Button, ProgressBar, Spinner, Table } from "react-bootstrap";
+import { get } from "lodash";
+import { AppContext } from "../../../store/context";
+import { ContextWrapper } from "../../ClusterWizard";
+import WizardFooter from "../../../components/StepWizard/WizardFooter";
+import BackgroundOperations from "../../BackgroundOperations";
+import { ViewLevel } from "../../../constants";
+import { RequestApi } from "../../../api/requestApi";
+import { HostsApi } from "../../../api/hostsApi";
+import {
+  buildAddHostComponentAssignments,
+  AddHostComponentMetadata,
+} from "../../../Utils/hostWizard";
+import { ActionTypes } from "./wizardDataStore/types";
+
+type DeploymentPhase = "INSTALL" | "KEYTABS" | "START" | "COMPLETE";
+
+const terminalRequestStatuses = new Set([
+  "ABORTED",
+  "COMPLETED",
+  "FAILED",
+  "TIMEDOUT",
+]);
+const failedRequestStatuses = new Set(["ABORTED", "FAILED", "TIMEDOUT"]);
+const terminalTaskStatuses = new Set(["ABORTED", "COMPLETED", "FAILED", "TIMEDOUT"]);
+const failedTaskStatuses = new Set(["ABORTED", "FAILED", "TIMEDOUT"]);
+
+function requestIdFrom(response: any): string | number | undefined {
+  return response?.Requests?.id ?? response?.data?.Requests?.id ?? response?.id;
+}
+
+function requestError(error: any) {
+  return error?.response?.data?.message
+    || error?.response?.data
+    || error?.message
+    || "Ambari could not continue the Add Host deployment.";
+}
+
+function mergeTasks(existing: any[], incoming: any[]) {
+  const tasks = new Map(existing.map((task) => [
+    `${task.Tasks?.request_id || ""}:${task.Tasks?.id}`,
+    task,
+  ]));
+  incoming.forEach((task) => {
+    tasks.set(`${task.Tasks?.request_id || ""}:${task.Tasks?.id}`, task);
+  });
+  return [...tasks.values()];
+}
+
+function phaseLabel(phase: DeploymentPhase) {
+  switch (phase) {
+    case "INSTALL": return "Installing components";
+    case "KEYTABS": return "Regenerating Kerberos keytabs";
+    case "START": return "Starting components";
+    default: return "Deployment complete";
+  }
+}
+
+export default function AddHostInstall() {
+  const { clusterName: contextClusterName, isKerberosEnabled } = useContext(AppContext);
+  const { Context } = useContext(ContextWrapper);
+  const {
+    dispatch,
+    flushStateToDb,
+    state,
+    stepWizardUtilities: { currentStep, handleNextImperitive },
+  }: any = useContext(Context);
+
+  const clusterName = get(
+    state,
+    "addHostSteps.NAME.data.clusterName",
+    contextClusterName,
+  );
+  const reviewStatus = get(state, "addHostSteps.REVIEW.data.clusterStatus", {});
+  const restoredInstall = get(state, "addHostSteps.INSTALL_START_TEST.data", {});
+  const initialStatus = restoredInstall.clusterStatus || reviewStatus;
+  const registeredHosts = get(
+    state,
+    "addHostSteps.HOST_STATUS.data.hosts",
+    [],
+  ).filter((host: any) => host.bootStatus === "REGISTERED");
+  const assignments = get(
+    state,
+    "addHostSteps.SLAVES_AND_CLIENTS.data.serviceComponents",
+    [],
+  );
+  const componentMetadata: AddHostComponentMetadata[] = get(
+    state,
+    "addHostSteps.SLAVES_AND_CLIENTS.data.allServiceComponentsList",
+    [],
+  );
+  const componentAssignments = buildAddHostComponentAssignments(
+    assignments,
+    componentMetadata,
+  );
+  const metadataByComponent = Object.fromEntries(componentMetadata.map((component) => [
+    component.component_name || "",
+    component,
+  ]));
+  const startableComponents = Object.keys(componentAssignments).filter((componentName) => {
+    const metadata = metadataByComponent[componentName];
+    return metadata && metadata.is_client !== true && metadata.component_category !== "CLIENT";
+  });
+
+  const initialTerminal = ["STARTED", "INSTALL FAILED", "START FAILED"].includes(
+    initialStatus.status,
+  );
+  const initialHosts = restoredInstall.hostInfo?.length
+    ? restoredInstall.hostInfo
+    : registeredHosts.map((host: any) => ({
+      name: host.name,
+      status: initialStatus.status === "STARTED" ? "success" : "pending",
+      progress: initialStatus.status === "STARTED" ? 100 : 0,
+      message: initialStatus.status === "STARTED" ? "Install and start completed" : "Waiting",
+      logTasks: [],
+    }));
+
+  const [hosts, setHosts] = useState<any[]>(initialHosts);
+  const [clusterStatus, setClusterStatus] = useState<any>(initialStatus);
+  const [phase, setPhase] = useState<DeploymentPhase>(initialStatus.phase || "INSTALL");
+  const [working, setWorking] = useState(!initialTerminal);
+  const [terminal, setTerminal] = useState(initialTerminal);
+  const [pollError, setPollError] = useState("");
+  const [operationError, setOperationError] = useState(initialStatus.operationError || "");
+  const [selectedHost, setSelectedHost] = useState("");
+  const [selectedRequestId, setSelectedRequestId] = useState<string | number | null>(null);
+
+  const active = useRef(false);
+  const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const requestInFlight = useRef(false);
+  const hostsRef = useRef<any[]>(initialHosts);
+  const clusterStatusRef = useRef<any>(initialStatus);
+  const phaseRef = useRef<DeploymentPhase>(initialStatus.phase || "INSTALL");
+  const requestIdRef = useRef<string | number | undefined>(initialStatus.requestId);
+
+  const persist = (
+    nextHosts: any[],
+    nextStatus: any,
+    nextPhase: DeploymentPhase,
+  ) => {
+    dispatch({
+      type: ActionTypes.STORE_INFORMATION,
+      payload: {
+        step: "INSTALL_START_TEST",
+        data: {
+          hostInfo: nextHosts,
+          clusterStatus: nextStatus,
+          phase: nextPhase,
+        },
+      },
+    });
+  };
+
+  const updateDeploymentState = (
+    nextStatus: any,
+    nextPhase: DeploymentPhase,
+    nextHosts = hostsRef.current,
+  ) => {
+    hostsRef.current = nextHosts;
+    clusterStatusRef.current = nextStatus;
+    phaseRef.current = nextPhase;
+    requestIdRef.current = nextStatus.requestId;
+    setHosts(nextHosts);
+    setClusterStatus(nextStatus);
+    setPhase(nextPhase);
+    persist(nextHosts, nextStatus, nextPhase);
+  };
+
+  const schedulePoll = (delay = 0) => {
+    if (timer.current) clearTimeout(timer.current);
+    timer.current = setTimeout(() => void pollCurrentRequest(), delay);
+  };
+
+  const setRequest = (
+    requestId: string | number,
+    nextPhase: DeploymentPhase,
+    status: string,
+  ) => {
+    const nextStatus = {
+      ...clusterStatusRef.current,
+      status,
+      requestId,
+      oldRequestsId: Array.from(new Set([
+        ...(clusterStatusRef.current.oldRequestsId || []),
+        requestId,
+      ])),
+      isCompleted: false,
+      operationError: "",
+      phase: nextPhase,
+    };
+    setOperationError("");
+    setPollError("");
+    setTerminal(false);
+    setWorking(true);
+    updateDeploymentState(nextStatus, nextPhase);
+    schedulePoll();
+  };
+
+  const completeSuccess = () => {
+    const completedHosts = hostsRef.current.map((host) => ({
+      ...host,
+      status: host.status === "failed" ? "warning" : "success",
+      progress: 100,
+      message: host.status === "failed"
+        ? "Deployment completed with warnings"
+        : "Install and start completed",
+    }));
+    const nextStatus = {
+      ...clusterStatusRef.current,
+      status: "STARTED",
+      isCompleted: true,
+      phase: "COMPLETE",
+      operationError: "",
+    };
+    updateDeploymentState(nextStatus, "COMPLETE", completedHosts);
+    setWorking(false);
+    setTerminal(true);
+  };
+
+  const completeFailure = (failedPhase: DeploymentPhase, message = "") => {
+    const nextStatus = {
+      ...clusterStatusRef.current,
+      status: failedPhase === "INSTALL" ? "INSTALL FAILED" : "START FAILED",
+      isCompleted: true,
+      failedPhase,
+      phase: failedPhase,
+      operationError: message,
+    };
+    updateDeploymentState(nextStatus, failedPhase);
+    setOperationError(message);
+    setWorking(false);
+    setTerminal(true);
+  };
+
+  const launchKeytabRegeneration = async () => {
+    try {
+      const response = await RequestApi.regenerateKeytabs(
+        clusterName,
+        { Clusters: { security_type: "KERBEROS" } },
+        "regenerate_keytabs=all",
+      );
+      if (!active.current) return;
+      const requestId = requestIdFrom(response);
+      if (requestId == null) {
+        throw new Error("Ambari did not return a keytab request ID.");
+      }
+      setRequest(requestId, "KEYTABS", "INSTALLED");
+    } catch (error: any) {
+      if (active.current) completeFailure("KEYTABS", String(requestError(error)));
+    }
+  };
+
+  const launchStart = async () => {
+    if (!startableComponents.length) {
+      completeSuccess();
+      return;
+    }
+    try {
+      const response = await HostsApi.updateHostComponents(clusterName, "", {
+        context: "Start Host Components",
+        HostRoles: { state: "STARTED" },
+        level: "HOST_COMPONENT",
+        query: `HostRoles/component_name.in(${startableComponents.join(",")})`
+          + `&HostRoles/state=INSTALLED&HostRoles/host_name.in(${registeredHosts
+            .map((host: any) => host.name)
+            .join(",")})`,
+      });
+      if (!active.current) return;
+      const requestId = requestIdFrom(response);
+      if (requestId == null) {
+        completeSuccess();
+        return;
+      }
+      setRequest(requestId, "START", "INSTALLED");
+    } catch (error: any) {
+      if (active.current) completeFailure("START", String(requestError(error)));
+    }
+  };
+
+  const advanceAfterSuccess = async (completedPhase: DeploymentPhase) => {
+    if (completedPhase === "INSTALL") {
+      if (isKerberosEnabled) {
+        await launchKeytabRegeneration();
+      } else {
+        await launchStart();
+      }
+    } else if (completedPhase === "KEYTABS") {
+      await launchStart();
+    } else if (completedPhase === "START") {
+      completeSuccess();
+    }
+  };
+
+  const updateHostsFromTasks = (
+    tasks: any[],
+    currentPhase: DeploymentPhase,
+    currentRequestId: string | number,
+  ) => {
+    const baseProgress = currentPhase === "INSTALL" ? 0 : 50;
+    const phaseWeight = currentPhase === "INSTALL" ? 50 : currentPhase === "START" ? 50 : 0;
+    const nextHosts = hostsRef.current.map((host) => {
+      const hostTasks = tasks.filter((task) => task.Tasks?.host_name === host.name);
+      const mergedHostTasks = mergeTasks(host.logTasks || [], hostTasks);
+      if (!hostTasks.length) {
+        return {
+          ...host,
+          progress: currentPhase === "KEYTABS" ? 50 : host.progress,
+          message: currentPhase === "KEYTABS" ? phaseLabel(currentPhase) : host.message,
+          logTasks: mergedHostTasks,
+        };
+      }
+      const completed = hostTasks.filter((task) =>
+        terminalTaskStatuses.has(task.Tasks?.status),
+      ).length;
+      const failed = hostTasks.some((task) => failedTaskStatuses.has(task.Tasks?.status));
+      const requestComplete = completed === hostTasks.length;
+      return {
+        ...host,
+        lastRequestId: currentRequestId,
+        logTasks: mergedHostTasks,
+        progress: Math.round(baseProgress + phaseWeight * (completed / hostTasks.length)),
+        status: failed ? "failed" : requestComplete ? "success" : "in_progress",
+        message: failed
+          ? `${phaseLabel(currentPhase)} failed`
+          : requestComplete
+            ? `${phaseLabel(currentPhase)} completed`
+            : phaseLabel(currentPhase),
+      };
+    });
+    hostsRef.current = nextHosts;
+    setHosts(nextHosts);
+    persist(nextHosts, clusterStatusRef.current, currentPhase);
+  };
+
+  async function pollCurrentRequest() {
+    const currentRequestId = requestIdRef.current;
+    if (!active.current || requestInFlight.current || currentRequestId == null) return;
+    requestInFlight.current = true;
+    setWorking(true);
+    setPollError("");
+    try {
+      const response = await RequestApi.getRequestStatus(
+        clusterName,
+        String(currentRequestId),
+      );
+      if (!active.current) return;
+      const currentPhase = phaseRef.current;
+      const tasks = (response.tasks || []).map((task: any) => ({
+        ...task,
+        Tasks: { ...task.Tasks, request_id: currentRequestId },
+      }));
+      updateHostsFromTasks(tasks, currentPhase, currentRequestId);
+      const requestStatus = response.Requests?.request_status;
+      const finished = terminalRequestStatuses.has(requestStatus)
+        || (tasks.length > 0 && tasks.every((task: any) =>
+          terminalTaskStatuses.has(task.Tasks?.status),
+        ));
+      if (!finished) {
+        schedulePoll(3000);
+        return;
+      }
+      const failed = failedRequestStatuses.has(requestStatus)
+        || tasks.some((task: any) => failedTaskStatuses.has(task.Tasks?.status));
+      if (failed) {
+        completeFailure(currentPhase);
+      } else {
+        await advanceAfterSuccess(currentPhase);
+      }
+    } catch (error: any) {
+      if (active.current) {
+        setPollError(String(requestError(error)));
+        setWorking(false);
+      }
+    } finally {
+      requestInFlight.current = false;
+    }
+  }
+
+  const retryFailedOperation = async () => {
+    const failedPhase: DeploymentPhase = clusterStatusRef.current.failedPhase
+      || phaseRef.current;
+    setTerminal(false);
+    setWorking(true);
+    setOperationError("");
+    if (failedPhase === "INSTALL") {
+      try {
+        const response = await HostsApi.updateHostComponents(
+          clusterName,
+          "HostRoles/desired_state=INSTALLED&HostRoles/state!=INSTALLED",
+          {
+            context: "Retry Install Components",
+            HostRoles: { state: "INSTALLED" },
+            level: "HOST_COMPONENT",
+            query: `HostRoles/host_name.in(${registeredHosts
+              .map((host: any) => host.name)
+              .join(",")})`,
+          },
+        );
+        const requestId = requestIdFrom(response);
+        if (requestId == null) throw new Error("Ambari did not return a retry request ID.");
+        setRequest(requestId, "INSTALL", "PENDING");
+      } catch (error: any) {
+        completeFailure("INSTALL", String(requestError(error)));
+      }
+    } else if (failedPhase === "KEYTABS") {
+      await launchKeytabRegeneration();
+    } else {
+      await launchStart();
+    }
+  };
+
+  useEffect(() => {
+    active.current = true;
+    if (!initialTerminal && requestIdRef.current != null) {
+      schedulePoll();
+    } else if (!initialTerminal) {
+      setPollError("The installation request ID is missing. Return to Review and deploy again.");
+      setWorking(false);
+    }
+    return () => {
+      active.current = false;
+      if (timer.current) clearTimeout(timer.current);
+    };
+  }, []);
+
+  const overallProgress = hosts.length
+    ? Math.round(hosts.reduce((sum, host) => sum + Number(host.progress || 0), 0) / hosts.length)
+    : terminal ? 100 : 0;
+
+  return (
+    <>
+      {selectedRequestId != null ? (
+        <BackgroundOperations
+          isExplicitClick
+          rootLevel={ViewLevel.TASKS_LIST}
+          clusterName={clusterName}
+          requestId={selectedRequestId}
+          host={selectedHost}
+          isOpen
+          onClose={() => setSelectedRequestId(null)}
+        />
+      ) : null}
+
+      <div className="step-title">Install, Start and Test</div>
+      <p className="step-description mt-2">
+        Ambari is installing and starting components on the new hosts.
+      </p>
+
+      {pollError ? (
+        <Alert variant="danger">
+          {pollError}{" "}
+          <Button size="sm" variant="outline-danger" onClick={() => schedulePoll()}>
+            Retry Poll
+          </Button>
+        </Alert>
+      ) : null}
+      {operationError ? <Alert variant="danger">{operationError}</Alert> : null}
+
+      <div className="d-flex align-items-center gap-3 mt-3">
+        <ProgressBar
+          className="flex-grow-1"
+          now={overallProgress}
+          variant={clusterStatus.status?.includes("FAILED") ? "danger" : terminal ? "success" : "info"}
+        />
+        <span>{overallProgress}% overall</span>
+      </div>
+      <div className="mt-2 text-muted d-flex align-items-center gap-2">
+        {working ? <Spinner animation="border" size="sm" /> : null}
+        {phaseLabel(phase)}
+      </div>
+
+      <Table responsive hover className="mt-3 mb-5">
+        <thead>
+          <tr>
+            <th>Host</th>
+            <th>Status</th>
+            <th>Progress</th>
+            <th>Tasks</th>
+          </tr>
+        </thead>
+        <tbody>
+          {hosts.map((host) => (
+            <tr key={host.name}>
+              <td>{host.name}</td>
+              <td>{host.message}</td>
+              <td>{host.progress}%</td>
+              <td>
+                <div>{(host.logTasks || []).length} task(s)</div>
+                {host.lastRequestId != null ? (
+                  <Button
+                    size="sm"
+                    variant="link"
+                    className="p-0"
+                    onClick={() => {
+                      setSelectedHost(host.name);
+                      setSelectedRequestId(host.lastRequestId);
+                    }}
+                  >
+                    View task logs
+                  </Button>
+                ) : null}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </Table>
+
+      <WizardFooter
+        isNextEnabled={terminal}
+        isBackEnabled={false}
+        lifted
+        step={currentStep}
+        sideItems={clusterStatus.status?.includes("FAILED") ? (
+          <Button
+            variant="outline-primary"
+            className="me-3"
+            disabled={working}
+            onClick={() => void retryFailedOperation()}
+          >
+            RETRY
+          </Button>
+        ) : null}
+        onNext={async () => {
+          persist(hostsRef.current, clusterStatusRef.current, phaseRef.current);
+          await Promise.resolve(flushStateToDb("next"));
+          handleNextImperitive();
+        }}
+        onCancel={() => void flushStateToDb("cancel")}
+        onBack={() => {}}
+      />
+    </>
+  );
+}

--- a/ambari-web/latest/src/screens/Hosts/AddHostWizard/AddHostReview.tsx
+++ b/ambari-web/latest/src/screens/Hosts/AddHostWizard/AddHostReview.tsx
@@ -1,0 +1,329 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useContext, useRef, useState } from "react";
+import { Alert, Badge, Button, Card, ListGroup, Spinner, Stack } from "react-bootstrap";
+import { get } from "lodash";
+import { AppContext } from "../../../store/context";
+import { ContextWrapper } from "../../ClusterWizard";
+import WizardFooter from "../../../components/StepWizard/WizardFooter";
+import { HostsApi } from "../../../api/hostsApi";
+import ConfigGroupApi from "../../../api/configGroupApi";
+import useKDCSessionState from "../../../hooks/useKDCSessionState";
+import {
+  buildAddHostComponentAssignments,
+  buildAddHostConfigGroupUpdates,
+} from "../../../Utils/hostWizard";
+import { ActionTypes } from "./wizardDataStore/types";
+
+function requestIdFrom(response: any): string | number | undefined {
+  return response?.Requests?.id ?? response?.data?.Requests?.id ?? response?.id;
+}
+
+function errorMessage(error: any) {
+  return error?.response?.data?.message
+    || error?.response?.data
+    || error?.message
+    || "Ambari could not prepare the selected hosts for installation.";
+}
+
+export default function AddHostReview() {
+  const { clusterName: contextClusterName } = useContext(AppContext);
+  const { Context } = useContext(ContextWrapper);
+  const {
+    dispatch,
+    flushStateToDb,
+    state,
+    stepWizardUtilities: {
+      currentStep,
+      handleBackImperitive,
+      handleNextImperitive,
+    },
+  }: any = useContext(Context);
+  const { getKDCSessionState } = useKDCSessionState(() => {});
+
+  const clusterName = get(
+    state,
+    "addHostSteps.NAME.data.clusterName",
+    contextClusterName,
+  );
+  const registeredHosts = get(
+    state,
+    "addHostSteps.HOST_STATUS.data.hosts",
+    [],
+  ).filter((host: any) => host.bootStatus === "REGISTERED");
+  const assignments = get(
+    state,
+    "addHostSteps.SLAVES_AND_CLIENTS.data.serviceComponents",
+    [],
+  );
+  const componentMetadata = get(
+    state,
+    "addHostSteps.SLAVES_AND_CLIENTS.data.allServiceComponentsList",
+    [],
+  );
+  const configurations = get(
+    state,
+    "addHostSteps.CONFIGURATIONS.data.configurations",
+    [],
+  );
+  const restoredReview = get(state, "addHostSteps.REVIEW.data", {});
+  const componentAssignments = buildAddHostComponentAssignments(
+    assignments,
+    componentMetadata,
+  );
+  const configGroupUpdates = buildAddHostConfigGroupUpdates(
+    configurations,
+    assignments,
+    componentMetadata,
+  );
+
+  const hostsRegistered = useRef(Boolean(restoredReview.hostsRegistered));
+  const completedComponents = useRef(new Set<string>(
+    restoredReview.completedComponents || [],
+  ));
+  const completedConfigGroups = useRef(new Set<string>(
+    restoredReview.completedConfigGroups || [],
+  ));
+  const deployLocked = useRef(false);
+  const [deploying, setDeploying] = useState(false);
+  const [deployError, setDeployError] = useState("");
+  const [deploymentStage, setDeploymentStage] = useState(
+    restoredReview.deploymentStage || "Ready to deploy",
+  );
+  const deploymentStageRef = useRef(
+    restoredReview.deploymentStage || "Ready to deploy",
+  );
+
+  const updateDeploymentStage = (stage: string) => {
+    deploymentStageRef.current = stage;
+    setDeploymentStage(stage);
+  };
+
+  const saveReviewState = (data: Record<string, any>) => {
+    dispatch({
+      type: ActionTypes.STORE_INFORMATION,
+      payload: {
+        step: "REVIEW",
+        data: {
+          ...restoredReview,
+          hostsRegistered: hostsRegistered.current,
+          completedComponents: [...completedComponents.current],
+          completedConfigGroups: [...completedConfigGroups.current],
+          deploymentStage: deploymentStageRef.current,
+          ...data,
+        },
+      },
+    });
+  };
+
+  const waitForKDCSession = () => new Promise<void>((resolve, reject) => {
+    void getKDCSessionState(resolve, reject).catch(reject);
+  });
+
+  const deploy = async () => {
+    if (deployLocked.current || deploying) return;
+    deployLocked.current = true;
+    setDeploying(true);
+    setDeployError("");
+
+    try {
+      await waitForKDCSession();
+
+      if (!hostsRegistered.current) {
+        updateDeploymentStage("Adding hosts to the cluster");
+        await HostsApi.registerHostToComponent(
+          clusterName,
+          registeredHosts.map((host: any) => ({
+            Hosts: { host_name: host.name },
+          })),
+        );
+        hostsRegistered.current = true;
+        saveReviewState({
+          hostsRegistered: true,
+          deploymentStage: "Hosts added to the cluster",
+        });
+      }
+
+      for (const [componentName, hostNames] of Object.entries(componentAssignments)) {
+        if (completedComponents.current.has(componentName)) continue;
+        updateDeploymentStage(`Assigning ${componentName}`);
+        await HostsApi.registerHostToComponent(clusterName, {
+          RequestInfo: {
+            query: hostNames.map((hostName) => `Hosts/host_name=${hostName}`).join("|"),
+          },
+          Body: {
+            host_components: [{
+              HostRoles: { component_name: componentName },
+            }],
+          },
+        });
+        completedComponents.current.add(componentName);
+        saveReviewState({
+          completedComponents: [...completedComponents.current],
+          deploymentStage: `${componentName} assigned`,
+        });
+      }
+
+      for (const update of configGroupUpdates) {
+        if (completedConfigGroups.current.has(update.groupId)) continue;
+        updateDeploymentStage(`Applying the ${update.serviceName} configuration group`);
+        await ConfigGroupApi.updateConfigGroup(
+          clusterName,
+          update.groupId,
+          update.payload,
+        );
+        completedConfigGroups.current.add(update.groupId);
+        saveReviewState({
+          completedConfigGroups: [...completedConfigGroups.current],
+          deploymentStage: `${update.serviceName} configuration group applied`,
+        });
+      }
+
+      let clusterStatus: Record<string, any>;
+      if (Object.keys(componentAssignments).length === 0) {
+        clusterStatus = {
+          status: "STARTED",
+          isCompleted: true,
+          oldRequestsId: [],
+          phase: "COMPLETE",
+        };
+      } else {
+        updateDeploymentStage("Launching component installation");
+        const installResponse = await HostsApi.updateHostComponents(
+          clusterName,
+          "",
+          {
+            context: "Install Components",
+            HostRoles: { state: "INSTALLED" },
+            level: "HOST_COMPONENT",
+            query: `HostRoles/host_name.in(${registeredHosts
+              .map((host: any) => host.name)
+              .join(",")})`,
+          },
+        );
+        const requestId = requestIdFrom(installResponse);
+        if (requestId == null) {
+          throw new Error("Ambari did not return an installation request ID.");
+        }
+        clusterStatus = {
+          status: "PENDING",
+          requestId,
+          oldRequestsId: [requestId],
+          isInstallError: false,
+          isCompleted: false,
+          installStartTime: Date.now(),
+          phase: "INSTALL",
+        };
+      }
+
+      saveReviewState({
+        clusterStatus,
+        deploymentStage: "Installation request launched",
+      });
+      await Promise.resolve(flushStateToDb("next"));
+      handleNextImperitive();
+    } catch (error: any) {
+      setDeployError(String(errorMessage(error)));
+      saveReviewState({
+        deploymentStage: deploymentStageRef.current,
+        deploymentError: String(errorMessage(error)),
+      });
+      deployLocked.current = false;
+    } finally {
+      setDeploying(false);
+    }
+  };
+
+  return (
+    <>
+      <div className="step-title">Review</div>
+      <p className="step-description mt-2">
+        Review the new hosts, component assignments, and configuration groups before deployment.
+      </p>
+
+      {deployError ? (
+        <Alert variant="danger" className="mt-3">
+          {deployError}{" "}
+          <Button size="sm" variant="outline-danger" onClick={() => void deploy()}>
+            Retry
+          </Button>
+        </Alert>
+      ) : null}
+      {deploying ? (
+        <Alert variant="info" className="mt-3 d-flex align-items-center gap-2">
+          <Spinner animation="border" size="sm" />
+          {deploymentStage}
+        </Alert>
+      ) : null}
+
+      <Card className="mt-3">
+        <Card.Header>Hosts</Card.Header>
+        <ListGroup variant="flush">
+          {registeredHosts.map((host: any) => (
+            <ListGroup.Item key={host.name}>{host.name}</ListGroup.Item>
+          ))}
+        </ListGroup>
+      </Card>
+
+      <Card className="mt-3">
+        <Card.Header>Component Assignments</Card.Header>
+        <ListGroup variant="flush">
+          {Object.entries(componentAssignments).map(([componentName, hostNames]) => (
+            <ListGroup.Item key={componentName}>
+              <Stack direction="horizontal" className="justify-content-between">
+                <span>{componentName}</span>
+                <Badge bg="secondary">{hostNames.join(", ")}</Badge>
+              </Stack>
+            </ListGroup.Item>
+          ))}
+        </ListGroup>
+      </Card>
+
+      <Card className="mt-3 mb-5">
+        <Card.Header>Configuration Groups</Card.Header>
+        <ListGroup variant="flush">
+          {configurations.length ? configurations.map((configuration: any) => {
+            const selected = (configuration.configGroups || []).find(
+              (group: any) => group.isSelected,
+            );
+            return (
+              <ListGroup.Item key={configuration.serviceName}>
+                <b>{configuration.serviceName}</b>: {selected?.group_name || "Default"}
+              </ListGroup.Item>
+            );
+          }) : (
+            <ListGroup.Item>No configuration-group changes are required.</ListGroup.Item>
+          )}
+        </ListGroup>
+      </Card>
+
+      <WizardFooter
+        isNextEnabled={!deploying}
+        lifted
+        step={{ ...currentStep, nextLabel: "DEPLOY" }}
+        onNext={() => void deploy()}
+        onCancel={() => void flushStateToDb("cancel")}
+        onBack={() => {
+          void flushStateToDb("back");
+          handleBackImperitive();
+        }}
+      />
+    </>
+  );
+}

--- a/ambari-web/latest/src/screens/Hosts/AddHostWizard/AddHostSummary.tsx
+++ b/ambari-web/latest/src/screens/Hosts/AddHostWizard/AddHostSummary.tsx
@@ -1,0 +1,125 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useContext, useRef, useState } from "react";
+import { Alert, Card, ListGroup } from "react-bootstrap";
+import { get } from "lodash";
+import { ContextWrapper } from "../../ClusterWizard";
+import WizardFooter from "../../../components/StepWizard/WizardFooter";
+
+const failedTaskStatuses = new Set(["ABORTED", "FAILED", "TIMEDOUT"]);
+
+export default function AddHostSummary() {
+  const { Context } = useContext(ContextWrapper);
+  const {
+    flushStateToDb,
+    state,
+    stepWizardUtilities: { currentStep },
+  }: any = useContext(Context);
+  const hosts = get(
+    state,
+    "addHostSteps.INSTALL_START_TEST.data.hostInfo",
+    [],
+  );
+  const clusterStatus = get(
+    state,
+    "addHostSteps.INSTALL_START_TEST.data.clusterStatus",
+    {},
+  );
+  const [finishError, setFinishError] = useState("");
+  const finishing = useRef(false);
+
+  const successfulHosts = hosts.filter((host: any) => host.status === "success");
+  const warningHosts = hosts.filter((host: any) => host.status === "warning");
+  const failedHosts = hosts.filter((host: any) => host.status === "failed");
+  const failedTasks = hosts.flatMap((host: any) => (host.logTasks || [])
+    .filter((task: any) => failedTaskStatuses.has(task.Tasks?.status))
+    .map((task: any) => ({
+      hostName: host.name,
+      role: task.Tasks?.role || "Unknown task",
+      status: task.Tasks?.status,
+    })));
+
+  const finish = async () => {
+    if (finishing.current) return;
+    finishing.current = true;
+    setFinishError("");
+    try {
+      await Promise.resolve(flushStateToDb("cancel"));
+    } catch (error: any) {
+      setFinishError(
+        error?.response?.data?.message
+          || error?.message
+          || "Ambari could not clear the Add Host wizard state.",
+      );
+      finishing.current = false;
+    }
+  };
+
+  return (
+    <>
+      <div className="step-title">Summary</div>
+      <p className="step-description mt-2">
+        Here is the result of adding the selected hosts.
+      </p>
+
+      {finishError ? <Alert variant="danger">{finishError}</Alert> : null}
+      <Alert variant={clusterStatus.status === "STARTED" ? "success" : "warning"}>
+        Deployment status: <b>{clusterStatus.status || "Unknown"}</b>
+      </Alert>
+
+      <Card className="mt-3">
+        <Card.Header>Host Results</Card.Header>
+        <ListGroup variant="flush">
+          <ListGroup.Item className="text-success">
+            {successfulHosts.length} host(s) completed successfully
+          </ListGroup.Item>
+          <ListGroup.Item className="text-warning">
+            {warningHosts.length} host(s) completed with warnings
+          </ListGroup.Item>
+          <ListGroup.Item className="text-danger">
+            {failedHosts.length} host(s) failed
+          </ListGroup.Item>
+        </ListGroup>
+      </Card>
+
+      {failedTasks.length ? (
+        <Card className="mt-3 mb-5">
+          <Card.Header>Failed Tasks</Card.Header>
+          <ListGroup variant="flush">
+            {failedTasks.map((task: any, index: number) => (
+              <ListGroup.Item key={`${task.hostName}-${task.role}-${index}`}>
+                <b>{task.hostName}</b>: {task.role} ({task.status})
+              </ListGroup.Item>
+            ))}
+          </ListGroup>
+        </Card>
+      ) : null}
+
+      <WizardFooter
+        isNextEnabled={!finishing.current}
+        isBackEnabled={false}
+        lifted
+        step={{ ...currentStep, nextLabel: "COMPLETE" }}
+        onNext={() => void finish()}
+        onCancel={() => void finish()}
+        onBack={() => {}}
+      />
+    </>
+  );
+}

--- a/ambari-web/latest/src/screens/Hosts/AddHostWizard/AddHostWizard.test.tsx
+++ b/ambari-web/latest/src/screens/Hosts/AddHostWizard/AddHostWizard.test.tsx
@@ -1,0 +1,259 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React, { createContext } from "react";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { AppContext } from "../../../store/context";
+import { ContextWrapper } from "../../ClusterWizard";
+
+const mocks = vi.hoisted(() => ({
+  flushStateToDb: vi.fn(),
+  getKDCSessionState: vi.fn((callback: Function) => callback()),
+  getRequestStatus: vi.fn(),
+  handleBackImperitive: vi.fn(),
+  handleNextImperitive: vi.fn(),
+  registerHostToComponent: vi.fn(),
+  regenerateKeytabs: vi.fn(),
+  updateConfigGroup: vi.fn(),
+  updateHostComponents: vi.fn(),
+}));
+
+vi.mock("../../../api/hostsApi", () => ({
+  HostsApi: {
+    registerHostToComponent: mocks.registerHostToComponent,
+    updateHostComponents: mocks.updateHostComponents,
+  },
+}));
+vi.mock("../../../api/configGroupApi", () => ({
+  default: { updateConfigGroup: mocks.updateConfigGroup },
+}));
+vi.mock("../../../api/requestApi", () => ({
+  RequestApi: {
+    getRequestStatus: mocks.getRequestStatus,
+    regenerateKeytabs: mocks.regenerateKeytabs,
+  },
+}));
+vi.mock("../../../hooks/useKDCSessionState", () => ({
+  default: () => ({ isLoaded: true, getKDCSessionState: mocks.getKDCSessionState }),
+}));
+vi.mock("../../BackgroundOperations", () => ({
+  default: ({ requestId, host }: any) => <div>Logs {requestId} {host}</div>,
+}));
+vi.mock("../../../components/StepWizard/WizardFooter", () => ({
+  default: ({ isNextEnabled, onNext, sideItems, step }: any) => (
+    <div>
+      {sideItems}
+      <button disabled={!isNextEnabled} onClick={onNext}>
+        {step.nextLabel || "NEXT"}
+      </button>
+    </div>
+  ),
+}));
+
+import AddHostInstall from "./AddHostInstall";
+import AddHostReview from "./AddHostReview";
+import AddHostSummary from "./AddHostSummary";
+
+const assignments = [{
+  hostname: "host1",
+  checkboxes: [{ checked: true, label: "DATANODE" }],
+}];
+const componentMetadata = [{
+  component_category: "SLAVE",
+  component_name: "DATANODE",
+  is_client: false,
+  service_name: "HDFS",
+}];
+
+function baseState(reviewData: Record<string, any> = {}): any {
+  return {
+    addHostSteps: {
+      NAME: { data: { clusterName: "cluster1" } },
+      HOST_STATUS: {
+        data: { hosts: [{ name: "host1", bootStatus: "REGISTERED" }] },
+      },
+      SLAVES_AND_CLIENTS: {
+        data: {
+          serviceComponents: assignments,
+          allServiceComponentsList: componentMetadata,
+        },
+      },
+      CONFIGURATIONS: {
+        data: {
+          configurations: [{
+            serviceName: "HDFS",
+            configGroups: [{
+              id: 7,
+              group_name: "workers",
+              tag: "HDFS",
+              service_name: "HDFS",
+              hosts: [],
+              desired_configs: [],
+              isSelected: true,
+            }],
+          }],
+        },
+      },
+      REVIEW: { data: reviewData },
+    },
+  };
+}
+
+function renderWithWizard(
+  component: React.ReactNode,
+  state: any,
+  appContext: Record<string, any> = {},
+  strict = false,
+) {
+  const WizardContext = createContext<any>({});
+  const content = (
+    <AppContext.Provider value={{
+      clusterName: "cluster1",
+      isKerberosEnabled: false,
+      ...appContext,
+    } as any}>
+      <ContextWrapper.Provider value={{ Context: WizardContext }}>
+        <WizardContext.Provider value={{
+          state,
+          dispatch: vi.fn(),
+          flushStateToDb: mocks.flushStateToDb,
+          stepWizardUtilities: {
+            currentStep: { name: "REVIEW", canGoBack: true },
+            handleBackImperitive: mocks.handleBackImperitive,
+            handleNextImperitive: mocks.handleNextImperitive,
+          },
+        }}>
+          {component}
+        </WizardContext.Provider>
+      </ContextWrapper.Provider>
+    </AppContext.Provider>
+  );
+  return render(strict ? <React.StrictMode>{content}</React.StrictMode> : content);
+}
+
+describe("Add Host Review and deployment", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.flushStateToDb.mockResolvedValue(undefined);
+    mocks.registerHostToComponent.mockResolvedValue({ data: {} });
+    mocks.updateConfigGroup.mockResolvedValue({});
+    mocks.updateHostComponents.mockResolvedValue({ Requests: { id: 10 } });
+  });
+
+  afterEach(() => cleanup());
+
+  it("blocks installation on config-group failure and resumes completed stages", async () => {
+    mocks.updateConfigGroup
+      .mockRejectedValueOnce({ response: { data: { message: "Config group update failed" } } })
+      .mockResolvedValueOnce({});
+    renderWithWizard(<AddHostReview />, baseState());
+
+    fireEvent.click(screen.getByRole("button", { name: "DEPLOY" }));
+    expect(await screen.findByText("Config group update failed")).toBeTruthy();
+    expect(mocks.updateHostComponents).not.toHaveBeenCalled();
+    expect(mocks.registerHostToComponent).toHaveBeenCalledTimes(2);
+
+    fireEvent.click(screen.getByRole("button", { name: "Retry" }));
+    await waitFor(() => expect(mocks.updateHostComponents).toHaveBeenCalledTimes(1));
+    expect(mocks.registerHostToComponent).toHaveBeenCalledTimes(2);
+    expect(mocks.updateConfigGroup).toHaveBeenLastCalledWith(
+      "cluster1",
+      "7",
+      [expect.objectContaining({
+        ConfigGroup: expect.objectContaining({
+          hosts: [{ host_name: "host1" }],
+        }),
+      })],
+    );
+    expect(mocks.handleNextImperitive).toHaveBeenCalledTimes(1);
+  });
+
+  it("polls install and start requests once under Strict Mode", async () => {
+    mocks.getRequestStatus.mockImplementation(async (_cluster: string, requestId: string) => ({
+      Requests: { request_status: "COMPLETED" },
+      tasks: [{
+        Tasks: {
+          id: Number(requestId),
+          host_name: "host1",
+          role: "DATANODE",
+          status: "COMPLETED",
+          command: requestId === "10" ? "INSTALL" : "START",
+        },
+      }],
+    }));
+    mocks.updateHostComponents.mockResolvedValue({ Requests: { id: 11 } });
+    renderWithWizard(
+      <AddHostInstall />,
+      baseState({
+        clusterStatus: {
+          status: "PENDING",
+          phase: "INSTALL",
+          requestId: 10,
+          oldRequestsId: [10],
+        },
+      }),
+      {},
+      true,
+    );
+
+    await waitFor(() => expect(screen.getByText("Install and start completed")).toBeTruthy());
+    expect(mocks.updateHostComponents).toHaveBeenCalledTimes(1);
+    expect(mocks.getRequestStatus).toHaveBeenCalledWith("cluster1", "10");
+    expect(mocks.getRequestStatus).toHaveBeenCalledWith("cluster1", "11");
+    expect(screen.getByRole("button", { name: "View task logs" })).toBeTruthy();
+  });
+
+  it("does not launch the next phase after unmount", async () => {
+    let resolveRequest: (value: any) => void = () => undefined;
+    mocks.getRequestStatus.mockReturnValue(new Promise((resolve) => {
+      resolveRequest = resolve;
+    }));
+    const rendered = renderWithWizard(
+      <AddHostInstall />,
+      baseState({
+        clusterStatus: {
+          status: "PENDING",
+          phase: "INSTALL",
+          requestId: 10,
+          oldRequestsId: [10],
+        },
+      }),
+    );
+    await waitFor(() => expect(mocks.getRequestStatus).toHaveBeenCalledTimes(1));
+    rendered.unmount();
+    resolveRequest({ Requests: { request_status: "COMPLETED" }, tasks: [] });
+    await Promise.resolve();
+
+    expect(mocks.updateHostComponents).not.toHaveBeenCalled();
+  });
+
+  it("finishes by clearing Add Host state without a provisioning update", async () => {
+    const state = baseState();
+    state.addHostSteps.INSTALL_START_TEST = {
+      data: {
+        clusterStatus: { status: "STARTED" },
+        hostInfo: [{ name: "host1", status: "success", logTasks: [] }],
+      },
+    };
+    renderWithWizard(<AddHostSummary />, state);
+
+    fireEvent.click(screen.getByRole("button", { name: "COMPLETE" }));
+    await waitFor(() => expect(mocks.flushStateToDb).toHaveBeenCalledWith("cancel"));
+  });
+});

--- a/ambari-web/latest/src/screens/Hosts/AddHostWizard/Step2Wrapper.tsx
+++ b/ambari-web/latest/src/screens/Hosts/AddHostWizard/Step2Wrapper.tsx
@@ -19,9 +19,19 @@
 import { useContext } from "react";
 import Step2 from "../../ClusterWizard/Step2";
 import { AddHostContext } from "./wizardDataStore/context";
+import { AppContext } from "../../../store/context";
 
 export default function Step2Wrapper() {
   const { installedHosts } = useContext(AddHostContext);
+  const { cluster, supports } = useContext(AppContext);
+  const stackName = cluster?.stack || String(cluster?.version || "").split("-")[0];
 
-  return <Step2 wizardName={"addHost"} installedHosts={installedHosts} />;
+  return (
+    <Step2
+      wizardName="addHost"
+      installedHosts={installedHosts}
+      customizeAgentUserAccount={Boolean(supports.customizeAgentUserAccount)}
+      isWindowsStack={stackName === "HDPWIN"}
+    />
+  );
 }

--- a/ambari-web/latest/src/screens/Hosts/AddHostWizard/addHostWizardSteps.tsx
+++ b/ambari-web/latest/src/screens/Hosts/AddHostWizard/addHostWizardSteps.tsx
@@ -16,11 +16,11 @@
  * limitations under the License.
  */
 
-import Step10 from "../../ClusterWizard/Step10";
 import Step3 from "../../ClusterWizard/Step3";
-import Step8 from "../../ClusterWizard/Step8";
-import Step9 from "../../ClusterWizard/Step9";
 import AddHostConfigurations from "./AddHostConfigurations";
+import AddHostInstall from "./AddHostInstall";
+import AddHostReview from "./AddHostReview";
+import AddHostSummary from "./AddHostSummary";
 import Step2Wrapper from "./Step2Wrapper";
 import Step6 from "../../ClusterWizard/Step6";
 import { translate } from "../../../Utils/Utility";
@@ -81,7 +81,7 @@ export default {
   5: {
     label: translate("common.review"),
     completed: false,
-    Component: <Step8 wizardName="addHost" />,
+    Component: <AddHostReview />,
     canGoBack: true,
     nextLabel: String(translate("common.deploy")).toUpperCase(),
     isNextEnabled: false,
@@ -91,7 +91,7 @@ export default {
   6: {
     label: translate("installer.step9.header"),
     completed: false,
-    Component: <Step9 wizardName="addHost" />,
+    Component: <AddHostInstall />,
     canGoBack: false,
     isNextEnabled: false,
     name: "INSTALL_START_TEST",
@@ -100,7 +100,7 @@ export default {
   7: {
     label: translate("installer.step10.header"),
     completed: false,
-    Component: <Step10 wizardName="addHost" />,
+    Component: <AddHostSummary />,
     canGoBack: false,
     isNextEnabled: false,
     keyToRemove: [],

--- a/ambari-web/latest/src/screens/Hosts/AddHostWizard/wizardDataStore/context.test.tsx
+++ b/ambari-web/latest/src/screens/Hosts/AddHostWizard/wizardDataStore/context.test.tsx
@@ -1,0 +1,142 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { useContext } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { AppContext } from "../../../../store/context";
+
+const mocks = vi.hoisted(() => ({
+  getPersistData: vi.fn(),
+  postPersistData: vi.fn(),
+}));
+
+vi.mock("../../../../api/clusterApi", () => ({
+  default: {
+    getPersistData: mocks.getPersistData,
+    postPersistData: mocks.postPersistData,
+  },
+}));
+
+import { AddHostContext, AddHostProvider } from "./context";
+import { ActionTypes } from "./types";
+
+const wizardUtilities = {
+  currentStep: { name: "INSTALL_OPTIONS" },
+  jumpToStep: vi.fn(),
+  wizardSteps: {
+    1: { name: "INSTALL_OPTIONS" },
+    2: { name: "HOST_STATUS" },
+  },
+};
+
+function PersistenceProbe() {
+  const { dispatch, flushStateToDb } = useContext(AddHostContext);
+  return (
+    <>
+      <button onClick={() => void flushStateToDb("default")}>Persist</button>
+      <button onClick={() => {
+        dispatch({
+          type: ActionTypes.STORE_INFORMATION,
+          payload: { step: "REVIEW", data: { completed: true } },
+        });
+        void flushStateToDb("next");
+      }}>
+        Persist next
+      </button>
+    </>
+  );
+}
+
+function renderProvider() {
+  return render(
+    <AppContext.Provider value={{
+      clusterName: "",
+      serviceComponentInfo: [],
+      services: [],
+    } as any}>
+      <AddHostProvider stepWizardUtilities={wizardUtilities}>
+        <PersistenceProbe />
+      </AddHostProvider>
+    </AppContext.Provider>,
+  );
+}
+
+describe("Add Host persistence", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.postPersistData.mockResolvedValue({});
+  });
+
+  afterEach(() => cleanup());
+
+  it("does not overwrite persisted state when hydration fails", async () => {
+    mocks.getPersistData
+      .mockRejectedValueOnce({ response: { data: { message: "Restore failed" } } })
+      .mockResolvedValueOnce({});
+    renderProvider();
+
+    expect(await screen.findByText("Restore failed")).toBeTruthy();
+    expect(mocks.postPersistData).not.toHaveBeenCalled();
+    fireEvent.click(screen.getByRole("button", { name: "Retry" }));
+
+    expect(await screen.findByRole("button", { name: "Persist" })).toBeTruthy();
+    expect(mocks.getPersistData).toHaveBeenCalledTimes(2);
+  });
+
+  it("serializes persistence requests", async () => {
+    let completeFirstWrite: () => void = () => undefined;
+    mocks.getPersistData.mockResolvedValue({});
+    mocks.postPersistData
+      .mockReturnValueOnce(new Promise<void>((resolve) => {
+        completeFirstWrite = resolve;
+      }))
+      .mockResolvedValueOnce({});
+    renderProvider();
+
+    const persist = await screen.findByRole("button", { name: "Persist" });
+    fireEvent.click(persist);
+    fireEvent.click(persist);
+    await waitFor(() => expect(mocks.postPersistData).toHaveBeenCalledTimes(1));
+
+    completeFirstWrite();
+    await waitFor(() => expect(mocks.postPersistData).toHaveBeenCalledTimes(2));
+  });
+
+  it("persists same-event checkpoints with the destination step before resolving", async () => {
+    mocks.getPersistData.mockResolvedValue({});
+    renderProvider();
+
+    fireEvent.click(await screen.findByRole("button", { name: "Persist next" }));
+    await waitFor(() => expect(mocks.postPersistData).toHaveBeenCalled());
+    const snapshots = mocks.postPersistData.mock.calls.map(([payload]) => {
+      const outer = JSON.parse(payload);
+      return JSON.parse(outer.ADD_HOST);
+    });
+
+    expect(snapshots).toContainEqual(expect.objectContaining({
+      activeStep: "HOST_STATUS",
+      addHostSteps: expect.objectContaining({
+        REVIEW: {
+          step: "REVIEW",
+          data: { completed: true },
+        },
+      }),
+    }));
+  });
+});

--- a/ambari-web/latest/src/screens/Hosts/AddHostWizard/wizardDataStore/context.tsx
+++ b/ambari-web/latest/src/screens/Hosts/AddHostWizard/wizardDataStore/context.tsx
@@ -35,6 +35,7 @@ import VersionsApi from "../../../../api/versionsApi";
 import { HostsApi } from "../../../../api/hostsApi";
 import { getAllComponents } from "../../utils";
 import { ClusterProgressStatus } from "../../../../constants";
+import { Alert, Button } from "react-bootstrap";
 
 interface AddHostContextProps {
   state: State;
@@ -55,13 +56,32 @@ export const AddHostProvider: React.FC<{
   stepWizardUtilities: any;
   children: React.ReactNode;
 }> = ({ stepWizardUtilities, children }) => {
-  const [state, dispatch] = useReducer(reducer, initialState);
+  const [state, reducerDispatch] = useReducer(reducer, initialState);
   const [currStepData, setCurrStepData] = useState({});
   const [installedHosts, setInstalledHosts] = useState([]);
+  const [isHydrated, setIsHydrated] = useState(false);
+  const [initializationError, setInitializationError] = useState<string | null>(null);
+  const [retryCount, setRetryCount] = useState(0);
   const { clusterName, services, serviceComponentInfo } =
     useContext(AppContext);
 
   const isDataPersisted = useRef(false);
+  const persistenceQueue = useRef<Promise<void>>(Promise.resolve());
+  const stateRef = useRef<State>(initialState);
+  const currStepDataRef = useRef<Record<string, any>>({});
+
+  const dispatch: Dispatch<Action> = (action) => {
+    stateRef.current = reducer(stateRef.current, action);
+    reducerDispatch(action);
+  };
+
+  const queuePersistence = (operation: () => Promise<void>) => {
+    const nextOperation = persistenceQueue.current
+      .catch(() => undefined)
+      .then(operation);
+    persistenceQueue.current = nextOperation.catch(() => undefined);
+    return nextOperation;
+  };
 
   const getInstalledServices = () => {
     const serviceNames = services.map((service: any) =>
@@ -115,6 +135,9 @@ export const AddHostProvider: React.FC<{
       
       // Use the current stack if found, otherwise fallback to the first one
       const stackToUse = currentStack || response.items[0];
+      if (!stackToUse) {
+        throw new Error("No stack version is available for this cluster.");
+      }
       
       const repoVersionId = get(
         stackToUse,
@@ -177,58 +200,62 @@ export const AddHostProvider: React.FC<{
       });
     } catch (error) {
       console.error("Error setting stack and version:", error);
-      // Set fallback data to prevent undefined errors
-      const fallbackData = {
-        selectedVersion: {
-          id: "",
-          stack_name: "",
-          stack_version: "",
-        },
-        selectedStack: {
-          id: "",
-          stack_name: "",
-          stack_version: "",
-        },
-        operatingSystems: {},
-      };
-      dispatch({
-        type: ActionTypes.STORE_INFORMATION,
-        payload: {
-          step: "VERSION",
-          data: fallbackData,
-        },
-      });
+      throw error;
     }
   };
 
   useEffect(() => {
-    syncUserPersistedData();
-    getHostComponents();
-  }, []);
+    void syncUserPersistedData();
+  }, [retryCount]);
 
-  // Ensure cluster name, services, and stack/version are loaded when AppContext data becomes available
   useEffect(() => {
-    if (clusterName) {
+    if (isHydrated && clusterName && !state.addHostSteps?.NAME) {
       setClusterName();
-      
-      // Also load stack and version when we have all required data
-      if (!isEmpty(services) && !isEmpty(serviceComponentInfo)) {
-        setStackAndVersion();
-      }
     }
-  }, [clusterName, services, serviceComponentInfo]);
+  }, [clusterName, isHydrated, state.addHostSteps?.NAME]);
+
+  useEffect(() => {
+    if (
+      isHydrated
+      && !isEmpty(services)
+      && !isEmpty(serviceComponentInfo)
+      && !state.addHostSteps?.SERVICES
+    ) {
+      getInstalledServices();
+    }
+  }, [isHydrated, services, serviceComponentInfo, state.addHostSteps?.SERVICES]);
+
+  useEffect(() => {
+    if (
+      isHydrated
+      && clusterName
+      && !isEmpty(services)
+      && !isEmpty(serviceComponentInfo)
+      && !state.addHostSteps?.VERSION
+    ) {
+      void setStackAndVersion().catch((error: any) => {
+        setInitializationError(
+          error?.response?.data?.message || error?.message || "Ambari could not load the cluster stack version.",
+        );
+      });
+    }
+  }, [clusterName, isHydrated, services, serviceComponentInfo, state.addHostSteps?.VERSION]);
+
+  useEffect(() => {
+    if (isHydrated && clusterName && !isEmpty(serviceComponentInfo)) {
+      void getHostComponents().catch((error: any) => {
+        setInitializationError(
+          error?.response?.data?.message || "Ambari could not load installed hosts.",
+        );
+      });
+    }
+  }, [clusterName, isHydrated, serviceComponentInfo, retryCount]);
 
   useEffect(() => {
     if (isDataPersisted.current) {
-      flushCurrentData();
+      void queuePersistence(() => flushCurrentData(state, currStepData));
     }
   }, [state.addHostSteps, currStepData]);
-
-  useEffect(() => {
-    if (!isEmpty(services) && !isEmpty(serviceComponentInfo)) {
-      getInstalledServices();
-    }
-  }, [services, serviceComponentInfo]);
 
   const getHostComponents = async () => {
     const response = await HostsApi.getHostComponentsDetails(
@@ -279,6 +306,8 @@ export const AddHostProvider: React.FC<{
   };
 
   async function syncUserPersistedData() {
+    setInitializationError(null);
+    setIsHydrated(false);
     try {
       const persistedData = await ClusterApi.getPersistData("ADD_HOST");
       if (!isEmpty(get(persistedData, "addHostSteps", {}))) {
@@ -290,10 +319,12 @@ export const AddHostProvider: React.FC<{
       if (get(persistedData, "activeStep", "")) {
         try {
           const activeStepName = get(persistedData, "activeStep");
-          setCurrStepData({
+          const restoredStepData = {
             progressStatus: ClusterProgressStatus.ADDING_HOST,
             stepName: activeStepName,
-          });
+          };
+          currStepDataRef.current = restoredStepData;
+          setCurrStepData(restoredStepData);
           let activeStepNumber = Object.keys(
             stepWizardUtilities.wizardSteps
           ).find((stepName) => {
@@ -307,59 +338,69 @@ export const AddHostProvider: React.FC<{
           console.error("Error while jumping to step", err);
         }
       } else {
-        getInstalledServices();
-        setClusterName();
-        setStackAndVersion();
         stepWizardUtilities.jumpToStep(1, true);
       }
-    } finally {
       isDataPersisted.current = true;
+      setIsHydrated(true);
+    } catch (error: any) {
+      isDataPersisted.current = false;
+      setInitializationError(
+        error?.response?.data?.message || "Ambari could not restore the Add Host wizard.",
+      );
+      setIsHydrated(false);
     }
   }
 
-  async function flushCurrentData() {
+  async function flushCurrentData(
+    stateSnapshot: State = stateRef.current,
+    stepSnapshot: Record<string, any> = currStepDataRef.current,
+  ) {
     await ClusterApi.postPersistData(
       JSON.stringify({
         ADD_HOST: JSON.stringify({
-          ...state,
-          activeStep: get(currStepData, "stepName", ""),
+          ...stateSnapshot,
+          activeStep: get(stepSnapshot, "stepName", ""),
         }),
-        CLUSTER_STATE: JSON.stringify(currStepData),
+        CLUSTER_STATE: JSON.stringify(stepSnapshot),
       })
     );
   }
 
-  function flushOnCancel() {
-    ClusterApi.postPersistData(
+  async function flushOnCancel() {
+    await queuePersistence(() => ClusterApi.postPersistData(
       JSON.stringify({
         ADD_HOST: JSON.stringify(initialState),
         CLUSTER_STATE: JSON.stringify({}),
-      })
-    );
-    window.location.href = "/#/main/hosts";
+      }),
+    ));
+    window.location.assign("/main/hosts");
   }
 
   async function flushOnStepChange(nextStep: number) {
     if (nextStep >= 1) {
-      let nextStepDetails = stepWizardUtilities.wizardSteps?.[nextStep];
+      const nextStepDetails = stepWizardUtilities.wizardSteps?.[nextStep];
+      const nextAddHostSteps = { ...stateRef.current.addHostSteps };
       if (nextStepDetails?.keysToRemove) {
         nextStepDetails.keysToRemove.forEach((key: string) => {
-          if (state?.addHostSteps?.[key]) {
-            dispatch({
-              type: ActionTypes.REMOVE_KEY,
-              payload: { key },
-            });
-          }
+          delete nextAddHostSteps[key];
         });
       }
-      setCurrStepData({
+      const nextState = {
+        ...stateRef.current,
+        addHostSteps: nextAddHostSteps,
+      };
+      dispatch({ type: ActionTypes.SYNC_STATE, payload: nextState });
+      const nextStepData = {
         progressStatus: ClusterProgressStatus.ADDING_HOST,
         stepName: stepWizardUtilities?.wizardSteps?.[nextStep]?.name,
-      });
+      };
+      currStepDataRef.current = nextStepData;
+      setCurrStepData(nextStepData);
+      await queuePersistence(() => flushCurrentData(nextState, nextStepData));
     }
   }
 
-  function flushStateToDb(
+  async function flushStateToDb(
     operation: string = "default",
     jumpStep: number = -1
   ) {
@@ -373,19 +414,22 @@ export const AddHostProvider: React.FC<{
     );
     switch (operation) {
       case "cancel":
-        flushOnCancel();
+        await flushOnCancel();
         break;
       case "back":
-        flushOnStepChange(Number(activeStep) - 1);
+        await flushOnStepChange(Number(activeStep) - 1);
         break;
       case "next":
-        flushOnStepChange(Number(activeStep) + 1);
+        await flushOnStepChange(Number(activeStep) + 1);
         break;
       case "jump":
-        flushOnStepChange(jumpStep);
+        await flushOnStepChange(jumpStep);
         break;
       default:
-        flushCurrentData();
+        await queuePersistence(() => flushCurrentData(
+          stateRef.current,
+          currStepDataRef.current,
+        ));
     }
   }
 
@@ -399,7 +443,18 @@ export const AddHostProvider: React.FC<{
         installedHosts,
       }}
     >
-      {children}
+      {initializationError ? (
+        <Alert variant="danger" className="m-4">
+          {initializationError}{" "}
+          <Button
+            size="sm"
+            variant="outline-danger"
+            onClick={() => setRetryCount((value) => value + 1)}
+          >
+            Retry
+          </Button>
+        </Alert>
+      ) : children}
     </AddHostContext.Provider>
   );
 };

--- a/ambari-web/latest/src/screens/Hosts/HostConfigs.test.tsx
+++ b/ambari-web/latest/src/screens/Hosts/HostConfigs.test.tsx
@@ -1,0 +1,232 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { AppContext } from "../../store/context";
+import { ServiceContext } from "../../store/ServiceContext";
+
+const mocks = vi.hoisted(() => ({
+  getConfigGroupsForServices: vi.fn(),
+  getConfigValues: vi.fn(),
+  getHostData: vi.fn(),
+  getStackConfigurations: vi.fn(),
+  getStackThemes: vi.fn(),
+  hasAuthorization: vi.fn(),
+  updateConfigGroup: vi.fn(),
+}));
+
+vi.mock("../../api/configGroupApi", () => ({
+  default: {
+    getConfigGroupsForServices: mocks.getConfigGroupsForServices,
+    updateConfigGroup: mocks.updateConfigGroup,
+  },
+}));
+vi.mock("../../api/configsApi", () => ({
+  default: { getConfigValues: mocks.getConfigValues },
+}));
+vi.mock("../../api/hostsApi", () => ({
+  HostsApi: { getHostData: mocks.getHostData },
+}));
+vi.mock("../../api/wizardApi", () => ({
+  default: {
+    getStackConfigurations: mocks.getStackConfigurations,
+    getStackThemes: mocks.getStackThemes,
+  },
+}));
+vi.mock("../../hooks/useAuth", () => ({
+  useAuth: () => ({ hasAuthorization: mocks.hasAuthorization }),
+}));
+vi.mock("../../components/Spinner", () => ({
+  default: () => <div>Loading host configurations</div>,
+}));
+vi.mock("../../components/Modal", () => ({
+  default: ({ isOpen, modalBody, successCallback }: any) => isOpen ? (
+    <div>
+      {modalBody}
+      <button onClick={successCallback}>Confirm group change</button>
+    </div>
+  ) : null,
+}));
+vi.mock("../CommonConfigs/Config", () => ({
+  default: ({ configGroup, hostConfigs, onServiceChange, servicesList }: any) => (
+    <div>
+      <div data-testid="config-probe">
+        {hostConfigs ? "Read-only" : "Editable"} group: {configGroup}
+      </div>
+      {servicesList.map((serviceName: string) => (
+        <button key={serviceName} onClick={() => onServiceChange(serviceName)}>
+          Show {serviceName}
+        </button>
+      ))}
+    </div>
+  ),
+}));
+
+import HostConfigs from "./HostConfigs";
+
+const services = [
+  { ServiceInfo: { service_name: "HDFS" } },
+  { ServiceInfo: { service_name: "YARN" } },
+];
+
+const configGroups = {
+  items: [
+    {
+      ConfigGroup: {
+        id: 1,
+        group_name: "HDFS Blue",
+        service_name: "HDFS",
+        tag: "HDFS",
+        hosts: [{ host_name: "host1" }],
+        desired_configs: [],
+      },
+    },
+    {
+      ConfigGroup: {
+        id: 2,
+        group_name: "YARN Green",
+        service_name: "YARN",
+        tag: "YARN",
+        hosts: [{ host_name: "host2" }],
+        desired_configs: [],
+      },
+    },
+    {
+      ConfigGroup: {
+        id: 3,
+        group_name: "HDFS Green",
+        service_name: "HDFS",
+        tag: "HDFS",
+        hosts: [{ host_name: "host3" }],
+        desired_configs: [],
+      },
+    },
+  ],
+};
+
+function renderHostConfigs() {
+  return render(
+    <MemoryRouter initialEntries={["/hosts/host1/configs"]}>
+      <AppContext.Provider value={{
+        clusterName: "cluster1",
+        cluster: { stack: "HDP", versionNum: "3.1" },
+        services,
+      } as any}>
+        <ServiceContext.Provider value={{ allServiceModels: {} } as any}>
+          <Routes>
+            <Route path="/hosts/:hostname/configs" element={<HostConfigs />} />
+          </Routes>
+        </ServiceContext.Provider>
+      </AppContext.Provider>
+    </MemoryRouter>,
+  );
+}
+
+describe("Host Configs", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.hasAuthorization.mockReturnValue(true);
+    mocks.getHostData.mockResolvedValue({
+      host_components: [
+        { HostRoles: { service_name: "HDFS", component_name: "DATANODE" } },
+        { HostRoles: { service_name: "YARN", component_name: "NODEMANAGER" } },
+      ],
+    });
+    mocks.getStackConfigurations.mockResolvedValue({ items: [] });
+    mocks.getStackThemes.mockResolvedValue({ items: [] });
+    mocks.getConfigGroupsForServices.mockResolvedValue(configGroups);
+    mocks.getConfigValues.mockResolvedValue({ items: [] });
+  });
+
+  afterEach(() => cleanup());
+
+  it("bootstraps once and restores a service-specific assigned group", async () => {
+    renderHostConfigs();
+
+    expect(await screen.findByText("Read-only group: HDFS Blue")).toBeTruthy();
+    expect(mocks.getConfigGroupsForServices).toHaveBeenCalledWith(
+      "cluster1",
+      ["HDFS", "YARN"],
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Show YARN" }));
+    expect(await screen.findByText("Read-only group: Default")).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: "Change" }));
+    expect(screen.getByRole("option", { name: "YARN Green" })).toBeTruthy();
+  });
+
+  it("does not expose config-group reassignment without authorization", async () => {
+    mocks.hasAuthorization.mockReturnValue(false);
+    renderHostConfigs();
+
+    expect(await screen.findByText("Read-only group: HDFS Blue")).toBeTruthy();
+    expect(screen.queryByRole("button", { name: "Change" })).toBeNull();
+  });
+
+  it("recovers from a failed bootstrap request", async () => {
+    mocks.getHostData
+      .mockRejectedValueOnce({ response: { data: { message: "Host lookup failed" } } })
+      .mockResolvedValueOnce({
+        host_components: [
+          { HostRoles: { service_name: "HDFS", component_name: "DATANODE" } },
+          { HostRoles: { service_name: "YARN", component_name: "NODEMANAGER" } },
+        ],
+      });
+    renderHostConfigs();
+
+    expect(await screen.findByText("Host lookup failed")).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: "Retry" }));
+    await waitFor(() => expect(mocks.getHostData).toHaveBeenCalledTimes(2));
+    expect(await screen.findByText("Read-only group: HDFS Blue")).toBeTruthy();
+  });
+
+  it("serializes both writes when moving between non-default groups", async () => {
+    let completeSourceUpdate: () => void = () => undefined;
+    mocks.updateConfigGroup
+      .mockReturnValueOnce(new Promise<void>((resolve) => {
+        completeSourceUpdate = resolve;
+      }))
+      .mockResolvedValueOnce({});
+    renderHostConfigs();
+
+    expect(await screen.findByText("Read-only group: HDFS Blue")).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: "Change" }));
+    fireEvent.change(screen.getByRole("combobox", { name: "Group" }), {
+      target: { value: "HDFS Green" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Confirm group change" }));
+
+    await waitFor(() => expect(mocks.updateConfigGroup).toHaveBeenCalledTimes(1));
+    expect(mocks.updateConfigGroup).toHaveBeenNthCalledWith(
+      1,
+      "cluster1",
+      "1",
+      expect.any(Array),
+    );
+    completeSourceUpdate();
+    await waitFor(() => expect(mocks.updateConfigGroup).toHaveBeenCalledTimes(2));
+    expect(mocks.updateConfigGroup).toHaveBeenNthCalledWith(
+      2,
+      "cluster1",
+      "3",
+      expect.any(Array),
+    );
+    expect(await screen.findByText("Read-only group: HDFS Green")).toBeTruthy();
+  });
+});

--- a/ambari-web/latest/src/screens/Hosts/HostConfigs.tsx
+++ b/ambari-web/latest/src/screens/Hosts/HostConfigs.tsx
@@ -29,8 +29,8 @@ import { tez_properties } from "../../data/configs/services/tez_properties";
 import { yarn_properties } from "../../data/configs/services/yarn_properties";
 import { zookeeper_properties } from "../../data/configs/services/zookeeper_properties";
 import { kerberos_properties } from "../../data/configs/services/kerberos_properties";
-import { get, isEmpty, map, find } from "lodash";
-import { Card, Dropdown, Badge } from "react-bootstrap";
+import { cloneDeep, get, isEmpty, map } from "lodash";
+import { Alert, Badge, Button, Card, Form } from "react-bootstrap";
 import Config from "../CommonConfigs/Config";
 import {
   fetchComponentHostNamesByComponent,
@@ -45,8 +45,13 @@ import { HostsApi } from "../../api/hostsApi";
 import Spinner from "../../components/Spinner";
 import { ServiceContext } from "../../store/ServiceContext";
 import { serviceNameModelMapping } from "../../constants";
-import { translate } from "../../Utils/Utility";
 import Modal from "../../components/Modal";
+import { useAuth } from "../../hooks/useAuth";
+import { messages } from "../messages";
+import {
+  buildConfigGroupMembershipUpdates,
+  buildHostConfigGroupState,
+} from "../../Utils/hostConfigs";
 
 export default function Hostconfigs() {
   const params = useParams();
@@ -57,24 +62,27 @@ export default function Hostconfigs() {
   const [configs, setConfigs] = useState<any>({});
   const [configProperties, setConfigProperties] = useState({});
   const [propertyValues, setPropertyValues] = useState<any>({});
-  const [defaultVersionNumber, setDefaultVersionNumber] = useState<string>();
-  const [selectedVersion, setSelectedVersion] = useState<string>();
   const [showChangeConfigGroupModal, setShowChangeConfigGroupModal] = useState<boolean>(false);
   const [selectedConfigGroup, setSelectedConfigGroup] = useState<string>("Default");
   const [configGroup, setConfigGroup] = useState<string>("Default");
-  const [hostData, setHostData] = useState<any>(null);
-  const [hostConfigGroups, setHostConfigGroups] = useState<any[]>([]);
-  const [availableConfigGroups, setAvailableConfigGroups] = useState<string[]>(["Default"]);
-  const [serviceConfigGroups, setServiceConfigGroups] = useState<{ [key: string]: string[] }>({});
+  const [groupsByService, setGroupsByService] = useState<Record<string, any[]>>({});
+  const [assignedGroupByService, setAssignedGroupByService] = useState<Record<string, string>>({});
   const [currentService, setCurrentService] = useState<string>("");
   const [hostServices, setHostServices] = useState<string[]>([]);
+  const [loadError, setLoadError] = useState("");
+  const [groupChangeError, setGroupChangeError] = useState("");
+  const [isChangingGroup, setIsChangingGroup] = useState(false);
+  const [retryCount, setRetryCount] = useState(0);
 
   const { clusterName, services, cluster } = useContext(AppContext);
   const { allServiceModels } = useContext(ServiceContext);
+  const { hasAuthorization } = useAuth();
   const stackName = get(cluster, "stack");
   const stackVersion = get(cluster, "versionNum");
+  const canManageConfigGroups = hasAuthorization("SERVICE.MANAGE_CONFIG_GROUPS");
 
   const serviceInCluster = map(services, "ServiceInfo.service_name");
+  const serviceOrderKey = serviceInCluster.join(",");
 
   const propertiesFileMap: { [key: string]: any } = {
     HDFS: hdfs_properties,
@@ -90,19 +98,98 @@ export default function Hostconfigs() {
   };
 
   useEffect(() => {
-    if (serviceInCluster.length > 0 && hostName) {
-      getHostData();
+    let active = true;
+    if (!clusterName || !hostName || !stackName || !stackVersion) {
+      return () => {
+        active = false;
+      };
     }
-  }, [services, hostName]);
 
-  useEffect(() => {
-    if (hostData && hostServices.length > 0) {
-      getConfigurations();
-      getThemes();
-      getHostConfigGroups();
-      getPropertiesValues();
-    }
-  }, [hostData, hostServices]);
+    const loadHostConfigurations = async () => {
+      setLoading(true);
+      setLoadError("");
+      try {
+        const hostResponse = await HostsApi.getHostData(
+          clusterName,
+          hostName,
+          "host_components/HostRoles/service_name,host_components/HostRoles/component_name,host_components/HostRoles/display_name",
+        );
+        const componentServices = [...new Set(
+          get(hostResponse, "host_components", [])
+            .map((component: any) => get(component, "HostRoles.service_name"))
+            .filter(Boolean),
+        )] as string[];
+        const servicesOnHost = componentServices.sort((left, right) => {
+          const leftIndex = serviceInCluster.indexOf(left);
+          const rightIndex = serviceInCluster.indexOf(right);
+          return (leftIndex === -1 ? Number.MAX_SAFE_INTEGER : leftIndex)
+            - (rightIndex === -1 ? Number.MAX_SAFE_INTEGER : rightIndex);
+        });
+
+        if (!active) return;
+        setHostServices(servicesOnHost);
+        if (!servicesOnHost.length) {
+          setCurrentService("");
+          setConfigs({});
+          setThemes({});
+          setPropertyValues({});
+          setGroupsByService({});
+          setAssignedGroupByService({});
+          return;
+        }
+
+        const serviceNames = servicesOnHost.join(",");
+        const [configResponse, themeResponse, groupResponse, valueResponse] = await Promise.all([
+          WizardApi.getStackConfigurations(
+            stackName,
+            stackVersion,
+            serviceNames,
+            "configurations/*,configurations/dependencies/*,StackServices/config_types/*",
+          ),
+          WizardApi.getStackThemes(
+            stackName,
+            stackVersion,
+            serviceNames,
+            "themes/*",
+          ),
+          ConfigGroupApi.getConfigGroupsForServices(clusterName, servicesOnHost),
+          ConfigsApi.getConfigValues(clusterName, serviceNames),
+        ]);
+
+        if (!active) return;
+        const groupState = buildHostConfigGroupState(
+          groupResponse.items || [],
+          servicesOnHost,
+          hostName,
+        );
+        const firstService = servicesOnHost[0];
+        const firstGroup = groupState.assignedGroupByService[firstService] || "Default";
+        setThemes(themeResponse);
+        setPropertyValues(valueResponse);
+        setGroupsByService(groupState.groupsByService);
+        setAssignedGroupByService(groupState.assignedGroupByService);
+        setCurrentService(firstService);
+        setConfigGroup(firstGroup);
+        setSelectedConfigGroup(firstGroup);
+        setConfigs(configResponse);
+      } catch (error: any) {
+        if (active) {
+          setLoadError(
+            error?.response?.data?.message || "Ambari could not load host configurations.",
+          );
+        }
+      } finally {
+        if (active) {
+          setLoading(false);
+        }
+      }
+    };
+
+    void loadHostConfigurations();
+    return () => {
+      active = false;
+    };
+  }, [clusterName, hostName, serviceOrderKey, stackName, stackVersion, retryCount]);
 
   useEffect(() => {
     if (!isEmpty(configs)) {
@@ -110,182 +197,9 @@ export default function Hostconfigs() {
     }
   }, [configs, propertyValues, JSON.stringify(allServiceModels)]);
 
-  // Custom callback to handle service changes from Config component
   const onServiceChange = (selectedService: string) => {
     if (selectedService !== currentService && hostServices.includes(selectedService)) {
       handleServiceChange(selectedService);
-    }
-  };
-
-  const getThemes = async () => {
-    if (hostServices.length === 0) return;
-
-    setLoading(true);
-    try {
-      const response = await WizardApi.getStackThemes(
-        stackName,
-        stackVersion,
-        hostServices.join(","),
-        "themes/*"
-      );
-      setThemes(response);
-    } catch (error) {
-      console.error("Error fetching themes:", error);
-    } finally {
-      setLoading(false);
-    }
-  };
-
-  const getConfigurations = async () => {
-    if (hostServices.length === 0) return;
-
-    setLoading(true);
-    try {
-      const response = await WizardApi.getStackConfigurations(
-        stackName,
-        stackVersion,
-        hostServices.join(","),
-        "configurations/*,configurations/dependencies/*,StackServices/config_types/*"
-      );
-      setConfigs(response);
-    } catch (error) {
-      console.error("Error fetching configurations:", error);
-    } finally {
-      setLoading(false);
-    }
-  };
-
-  const getHostData = async () => {
-    if (!hostName) return;
-
-    setLoading(true);
-    try {
-      const response = await HostsApi.getHostData(
-        clusterName,
-        hostName,
-        "host_components/HostRoles/service_name,host_components/HostRoles/component_name,host_components/HostRoles/display_name"
-      );
-      setHostData(response);
-
-      // Extract services running on this host
-      const hostComponents = get(response, "host_components", []);
-      const servicesOnHost = [...new Set(hostComponents.map((comp: any) =>
-        get(comp, "HostRoles.service_name")
-      ))].filter(Boolean) as string[];
-
-      setHostServices(servicesOnHost);
-    } catch (error) {
-      console.error("Error fetching host data:", error);
-    } finally {
-      setLoading(false);
-    }
-  };
-
-  const getHostConfigGroups = async () => {
-    if (!hostName || hostServices.length === 0) return;
-
-    try {
-      const configGroups = [];
-      const serviceSpecificGroups: { [key: string]: string[] } = {};
-
-      // Initialize each service with Default group
-      hostServices.forEach(service => {
-        serviceSpecificGroups[service] = ["Default"];
-      });
-
-      // Get config groups for each service running on this host
-      for (const serviceName of hostServices) {
-        const response = await ConfigGroupApi.getConfigGroupInfo(
-          clusterName,
-          serviceName,
-          "ConfigGroup/group_name,ConfigGroup/hosts,ConfigGroup/tag"
-        );
-
-        if (response.items) {
-          // Filter config groups that include this host
-          const relevantGroups = response.items.filter((group: any) => {
-            const hosts = get(group, "ConfigGroup.hosts", []);
-            return hosts.some((host: any) => host.host_name === hostName);
-          });
-
-          // Store service-specific config groups
-          const serviceGroups = ["Default"];
-          relevantGroups.forEach((group: any) => {
-            const groupName = get(group, "ConfigGroup.group_name");
-            if (groupName && !serviceGroups.includes(groupName)) {
-              serviceGroups.push(groupName);
-            }
-          });
-          serviceSpecificGroups[serviceName] = serviceGroups;
-
-          configGroups.push(...relevantGroups.map((group: any) => ({
-            ...group,
-            serviceName: serviceName
-          })));
-        }
-      }
-
-      setHostConfigGroups(configGroups);
-      setServiceConfigGroups(serviceSpecificGroups);
-
-      // Set initial service and config groups
-      if (hostServices.length > 0) {
-        const firstService = hostServices[0];
-        setCurrentService(firstService);
-        setAvailableConfigGroups(serviceSpecificGroups[firstService] || ["Default"]);
-
-        // Set the config group for the first service
-        const serviceGroups = serviceSpecificGroups[firstService] || ["Default"];
-        const primaryGroup = serviceGroups.find(group => group !== "Default") || "Default";
-        setConfigGroup(primaryGroup);
-        setSelectedConfigGroup(primaryGroup);
-      }
-    } catch (error) {
-      console.error("Error fetching host config groups:", error);
-      // Fallback to Default if there's an error
-      setAvailableConfigGroups(["Default"]);
-      setConfigGroup("Default");
-      setSelectedConfigGroup("Default");
-    }
-  };
-
-  const getPropertiesValues = async () => {
-    if (hostServices.length === 0) return;
-
-    setLoading(true);
-    try {
-      // Fetch configs for services running on this host only
-      const response = await ConfigsApi.getConfigValues(
-        clusterName,
-        hostServices.join(",")
-      );
-      setPropertyValues(response);
-
-      // Handle config group specific values
-      response.items.map((item: any) => {
-        const groupName = get(item, "group_name", "Default");
-        if (groupName === "Default") {
-          const latestDefaultVersion = get(item, "service_config_version", "");
-          setDefaultVersionNumber(latestDefaultVersion);
-          setSelectedVersion(latestDefaultVersion);
-        }
-
-        // If this host belongs to a specific config group, prioritize that group's configs
-        if (hostConfigGroups.length > 0) {
-          const hostGroup = find(hostConfigGroups, (group) => {
-            const hosts = get(group, "ConfigGroup.hosts", []);
-            return hosts.some((host: any) => host.host_name === hostName);
-          });
-
-          if (hostGroup && groupName === get(hostGroup, "ConfigGroup.group_name")) {
-            setSelectedVersion(get(item, "service_config_version", ""));
-          }
-        }
-      });
-    } catch (error) {
-      console.error("Error fetching property values:", error);
-    } finally {
-      setLoading(false);
     }
   };
 
@@ -503,10 +417,8 @@ export default function Hostconfigs() {
                       final: "",
                       fileName: type + ".xml",
                       propertyType: [],
-                      type: type,
-                      isEditable:
-                        configGroup === "Default" &&
-                        selectedVersion === defaultVersionNumber,
+                    type: type,
+                    isEditable: false,
                     };
                   }
                 }
@@ -655,6 +567,14 @@ export default function Hostconfigs() {
       updatedConfigProperties
     );
 
+    Object.values(updatedConfigProperties).forEach((serviceConfigs) => {
+      Object.values(serviceConfigs).forEach((section) => {
+        Object.values(section.properties).forEach((property) => {
+          property.isEditable = false;
+        });
+      });
+    });
+
     setConfigProperties(updatedConfigProperties);
   };
 
@@ -688,26 +608,15 @@ export default function Hostconfigs() {
 
   const handleServiceChange = (selectedService: string) => {
     setCurrentService(selectedService);
-
-    // Update available config groups for the selected service
-    const serviceGroups = serviceConfigGroups[selectedService] || ["Default"];
-    setAvailableConfigGroups(serviceGroups);
-
-    // Reset to Default or first available group for the service
-    const defaultGroup = serviceGroups.includes("Default") ? "Default" : serviceGroups[0];
-    setConfigGroup(defaultGroup);
-    setSelectedConfigGroup(defaultGroup);
-
-    // Refresh config properties for the new service and group
-    if (!isEmpty(configs)) {
-      getConfigProperties();
-    }
+    const assignedGroup = assignedGroupByService[selectedService] || "Default";
+    setConfigGroup(assignedGroup);
+    setSelectedConfigGroup(assignedGroup);
   };
 
   const setVisibilityForKerberosProperties = (
     configProps: ConfigPropertiesType
   ) => {
-    const updatedConfigs = { ...configProps };
+    const updatedConfigs = cloneDeep(configProps);
 
     if (!serviceInCluster.includes("KERBEROS")) {
       return updatedConfigs;
@@ -733,19 +642,19 @@ export default function Hostconfigs() {
       });
     };
 
-    switch (kdcType.value.toLowerCase()) {
-      case translate("admin.kerberos.wizard.step1.option.manual"):
+    switch (String(kdcType.value).toLowerCase()) {
+      case messages["admin.kerberos.wizard.step1.option.manual"].toLowerCase():
         updatePropertyVisibility("kdc_hosts", false);
         updatePropertyVisibility("admin_server_host", false);
         updatePropertyVisibility("domains", false);
         break;
 
-      case translate("admin.kerberos.wizard.step1.option.ad"):
+      case messages["admin.kerberos.wizard.step1.option.ad"].toLowerCase():
         updatePropertyVisibility("container_dn", true);
         updatePropertyVisibility("ldap_url", true);
         break;
 
-      case translate("admin.kerberos.wizard.step1.option.ipa"):
+      case messages["admin.kerberos.wizard.step1.option.ipa"].toLowerCase():
         updatePropertyVisibility("group", true);
         Object.values(updatedConfigs["KERBEROS"]).forEach((section) => {
           const manageKrb5Conf = section.properties["manage_krb5_conf"];
@@ -763,6 +672,9 @@ export default function Hostconfigs() {
         break;
     }
 
+    if (!updatedConfigs["KERBEROS"]?.["KDC"]?.properties) {
+      return updatedConfigs;
+    }
     updatedConfigs["KERBEROS"]["KDC"].properties["Test.KDC.Connection"] = {
       propertyName: "Test.KDC.Connection",
       propertyDisplayname: " ",
@@ -775,38 +687,110 @@ export default function Hostconfigs() {
       previousValue: "TEST KDC CONNECTION",
       value: "TEST KDC CONNECTION",
       final: "false",
-      isEditable: true,
+      isEditable: false,
     };
 
     return updatedConfigs;
   };
 
-  const getChangeConfigGroupModalBody = () => {
-    return <div className="d-flex h-25">
-      <div className="mt-2 me-2">Groups: </div>
-      <Dropdown>
-        <Dropdown.Toggle variant="outline-secondary" size="sm">
-          {selectedConfigGroup}
-        </Dropdown.Toggle>
-        <Dropdown.Menu className="bring-to-front">
+  const availableConfigGroups = [
+    "Default",
+    ...(groupsByService[currentService] || []).map(
+      (group) => get(group, "ConfigGroup.group_name", ""),
+    ).filter(Boolean),
+  ];
+
+  const changeConfigGroup = async () => {
+    if (
+      !hostName
+      || !currentService
+      || selectedConfigGroup === configGroup
+      || isChangingGroup
+      || !canManageConfigGroups
+    ) {
+      return;
+    }
+
+    const updates = buildConfigGroupMembershipUpdates(
+      groupsByService[currentService] || [],
+      currentService,
+      configGroup,
+      selectedConfigGroup,
+      hostName,
+    );
+    setIsChangingGroup(true);
+    setGroupChangeError("");
+    try {
+      for (const update of updates) {
+        await ConfigGroupApi.updateConfigGroup(
+          clusterName,
+          update.groupId,
+          update.payload,
+        );
+      }
+      setGroupsByService((current) => ({
+        ...current,
+        [currentService]: current[currentService].map((group) => (
+          updates.find((update) => update.groupId === String(get(group, "ConfigGroup.id")))?.group
+          || group
+        )),
+      }));
+      setAssignedGroupByService((current) => ({
+        ...current,
+        [currentService]: selectedConfigGroup,
+      }));
+      setConfigGroup(selectedConfigGroup);
+      setShowChangeConfigGroupModal(false);
+    } catch (error: any) {
+      setGroupChangeError(
+        error?.response?.data?.message || "Ambari could not change this host's config group.",
+      );
+    } finally {
+      setIsChangingGroup(false);
+    }
+  };
+
+  const getChangeConfigGroupModalBody = () => (
+    <div>
+      <Form.Group controlId="hostConfigGroup">
+        <Form.Label>Group</Form.Label>
+        <Form.Select
+          value={selectedConfigGroup}
+          disabled={isChangingGroup}
+          onChange={(event) => setSelectedConfigGroup(event.target.value)}
+        >
           {availableConfigGroups.map((groupName) => (
-            <Dropdown.Item
-              key={groupName}
-              active={groupName === configGroup}
-              onClick={() => {
-                setSelectedConfigGroup(groupName);
-              }}
-            >
-              {groupName}
-            </Dropdown.Item>
+            <option key={groupName} value={groupName}>{groupName}</option>
           ))}
-        </Dropdown.Menu>
-      </Dropdown>
-    </div>;
-  }
+        </Form.Select>
+      </Form.Group>
+      {groupChangeError ? (
+        <Alert className="mt-3 mb-0" variant="danger">{groupChangeError}</Alert>
+      ) : null}
+    </div>
+  );
 
   if (loading) {
     return <Spinner />;
+  }
+
+  if (loadError) {
+    return (
+      <Alert variant="danger">
+        {loadError}{" "}
+        <Button
+          size="sm"
+          variant="outline-danger"
+          onClick={() => setRetryCount((value) => value + 1)}
+        >
+          Retry
+        </Button>
+      </Alert>
+    );
+  }
+
+  if (!hostServices.length) {
+    return <Alert variant="info">There are no configurable services on this host.</Alert>;
   }
 
   return (
@@ -814,22 +798,22 @@ export default function Hostconfigs() {
       {showChangeConfigGroupModal && (
         <Modal
           isOpen={showChangeConfigGroupModal}
-          onClose={() => setShowChangeConfigGroupModal(false)}
+          onClose={() => {
+            if (!isChangingGroup) {
+              setSelectedConfigGroup(configGroup);
+              setGroupChangeError("");
+              setShowChangeConfigGroupModal(false);
+            }
+          }}
           modalTitle="Change Group"
           modalBody={getChangeConfigGroupModalBody()}
-          successCallback={() => {
-            setConfigGroup(selectedConfigGroup);
-            if (!isEmpty(configs)) {
-              getConfigProperties();
-            }
-            setShowChangeConfigGroupModal(false);
-          }}
+          successCallback={() => void changeConfigGroup()}
           options={{
             cancelableViaBtn: true,
             cancelableViaIcon: true,
             buttonSize: "sm",
             okButtonVariant: "primary",
-            okButtonDisabled: configGroup === selectedConfigGroup,
+            okButtonDisabled: configGroup === selectedConfigGroup || isChangingGroup,
             modalBodyClassName: "h-150px"
           }}
         />
@@ -856,8 +840,18 @@ export default function Hostconfigs() {
                   >
                     {configGroup}
                   </Badge>
-                  {availableConfigGroups.length > 1 && (
-                    <div className="custom-link" onClick={() => setShowChangeConfigGroupModal(true)}>Change</div>
+                  {canManageConfigGroups && availableConfigGroups.length > 1 && (
+                    <Button
+                      className="p-0 align-baseline"
+                      variant="link"
+                      onClick={() => {
+                        setSelectedConfigGroup(configGroup);
+                        setGroupChangeError("");
+                        setShowChangeConfigGroupModal(true);
+                      }}
+                    >
+                      Change
+                    </Button>
                   )}
                 </div>
               </div>

--- a/ambari-web/latest/src/screens/Hosts/HostLogTailModal.test.tsx
+++ b/ambari-web/latest/src/screens/Hosts/HostLogTailModal.test.tsx
@@ -1,0 +1,78 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { act, cleanup, render } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { AppContext } from "../../store/context";
+
+const mocks = vi.hoisted(() => ({ fetchLogTail: vi.fn() }));
+vi.mock("../../api/hostLogsApi", () => ({
+  default: { fetchLogTail: mocks.fetchLogTail },
+}));
+vi.mock("../../components/Spinner", () => ({
+  default: () => <div>Loading log</div>,
+}));
+
+import HostLogTailModal from "./HostLogTailModal";
+
+describe("HostLogTailModal polling", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    mocks.fetchLogTail.mockResolvedValue({ logList: [] });
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.useRealTimers();
+  });
+
+  it("polls serially and stops after unmount", async () => {
+    const view = render(
+      <AppContext.Provider value={{ clusterName: "c1" } as any}>
+        <HostLogTailModal
+          componentName="hdfs_namenode"
+          filePath="/var/log/hdfs/namenode.log"
+          hostName="nn1"
+          onClose={() => {}}
+        />
+      </AppContext.Provider>,
+    );
+
+    await act(async () => {});
+    expect(mocks.fetchLogTail).toHaveBeenCalledTimes(1);
+    expect(mocks.fetchLogTail).toHaveBeenLastCalledWith(
+      "c1",
+      "hdfs_namenode",
+      "nn1",
+      50,
+      0,
+    );
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2000);
+    });
+    expect(mocks.fetchLogTail).toHaveBeenCalledTimes(2);
+
+    view.unmount();
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(4000);
+    });
+    expect(mocks.fetchLogTail).toHaveBeenCalledTimes(2);
+  });
+});

--- a/ambari-web/latest/src/screens/Hosts/HostLogTailModal.tsx
+++ b/ambari-web/latest/src/screens/Hosts/HostLogTailModal.tsx
@@ -1,0 +1,203 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useContext, useEffect, useState } from "react";
+import { Alert, Button, Form, Modal, Stack } from "react-bootstrap";
+import HostLogsApi from "../../api/hostLogsApi";
+import Spinner from "../../components/Spinner";
+import { AppContext } from "../../store/context";
+import {
+  HostLogEntry,
+  hostLogsToText,
+  mapHostLogEntries,
+  mergeHostLogEntries,
+  openTextInNewWindow,
+} from "../../Utils/hostLogs";
+
+type HostLogTailModalProps = {
+  componentName: string;
+  filePath: string;
+  hostName: string;
+  logSearchUrl?: string;
+  onClose: () => void;
+};
+
+const POLL_INTERVAL = 2000;
+
+export default function HostLogTailModal({
+  componentName,
+  filePath,
+  hostName,
+  logSearchUrl = "",
+  onClose,
+}: HostLogTailModalProps) {
+  const { clusterName } = useContext(AppContext);
+  const [rows, setRows] = useState<HostLogEntry[]>([]);
+  const [tailCount, setTailCount] = useState(50);
+  const [loading, setLoading] = useState(true);
+  const [loadingOlder, setLoadingOlder] = useState(false);
+  const [hasOlderRows, setHasOlderRows] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [retryCount, setRetryCount] = useState(0);
+  const [copyStatus, setCopyStatus] = useState("");
+
+  useEffect(() => {
+    let active = true;
+    let timeout: ReturnType<typeof setTimeout> | undefined;
+
+    const poll = async () => {
+      try {
+        const response = await HostLogsApi.fetchLogTail(
+          clusterName,
+          componentName,
+          hostName,
+          tailCount,
+          0,
+        );
+        if (!active) {
+          return;
+        }
+        setRows((current) => mergeHostLogEntries(current, mapHostLogEntries(response)));
+        setError(null);
+      } catch (requestError: any) {
+        if (active) {
+          setError(
+            requestError?.response?.data?.message || "Ambari could not load this log.",
+          );
+        }
+      } finally {
+        if (active) {
+          setLoading(false);
+          timeout = setTimeout(poll, POLL_INTERVAL);
+        }
+      }
+    };
+
+    setRows([]);
+    setLoading(true);
+    setHasOlderRows(true);
+    void poll();
+    return () => {
+      active = false;
+      if (timeout) {
+        clearTimeout(timeout);
+      }
+    };
+  }, [clusterName, componentName, hostName, retryCount, tailCount]);
+
+  const loadOlder = async () => {
+    setLoadingOlder(true);
+    try {
+      const response = await HostLogsApi.fetchLogTail(
+        clusterName,
+        componentName,
+        hostName,
+        tailCount,
+        rows.length,
+      );
+      const olderRows = mapHostLogEntries(response);
+      setRows((current) => mergeHostLogEntries(current, olderRows));
+      setHasOlderRows(olderRows.length > 0);
+      setError(null);
+    } catch (requestError: any) {
+      setError(
+        requestError?.response?.data?.message || "Ambari could not load older log entries.",
+      );
+    } finally {
+      setLoadingOlder(false);
+    }
+  };
+
+  const text = hostLogsToText(rows);
+  const copyLogs = async () => {
+    try {
+      await navigator.clipboard.writeText(text);
+      setCopyStatus("Copied");
+    } catch {
+      setCopyStatus("Copy failed");
+    }
+  };
+
+  return (
+    <Modal show onHide={onClose} size="xl" centered scrollable>
+      <Modal.Header closeButton>
+        <Modal.Title>{filePath.split("/").pop() || filePath}</Modal.Title>
+      </Modal.Header>
+      <Modal.Body>
+        <Stack direction="horizontal" gap={3} className="mb-3 flex-wrap">
+          <span><strong>File:</strong> {filePath}</span>
+          <Form.Select
+            aria-label="Tail count"
+            className="w-auto ms-auto"
+            value={tailCount}
+            onChange={(event) => setTailCount(Number(event.target.value))}
+          >
+            {[50, 100, 200].map((count) => (
+              <option key={count} value={count}>Tail {count}</option>
+            ))}
+          </Form.Select>
+          <Button variant="outline-secondary" onClick={() => void copyLogs()}>
+            Copy
+          </Button>
+          <Button variant="outline-secondary" onClick={() => openTextInNewWindow(text)}>
+            Open
+          </Button>
+          {logSearchUrl ? (
+            <Button
+              as="a"
+              href={logSearchUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              variant="outline-secondary"
+            >
+              Open in Log Search
+            </Button>
+          ) : null}
+          <span role="status" className="text-muted">{copyStatus}</span>
+        </Stack>
+        {error && (
+          <Alert variant="danger">
+            {error}{" "}
+            <Button size="sm" variant="outline-danger" onClick={() => setRetryCount((value) => value + 1)}>
+              Retry
+            </Button>
+          </Alert>
+        )}
+        {loading ? <Spinner /> : (
+          <>
+            <Button
+              size="sm"
+              variant="outline-secondary"
+              className="mb-2"
+              disabled={loadingOlder || !hasOlderRows}
+              onClick={() => void loadOlder()}
+            >
+              {loadingOlder ? "Loading..." : hasOlderRows ? "Load older" : "No older entries"}
+            </Button>
+            <pre className="bg-dark text-light p-3 overflow-auto" style={{ maxHeight: "60vh" }}>
+              {text || "No log entries were returned."}
+            </pre>
+          </>
+        )}
+      </Modal.Body>
+      <Modal.Footer>
+        <Button variant="success" onClick={onClose}>Dismiss</Button>
+      </Modal.Footer>
+    </Modal>
+  );
+}

--- a/ambari-web/latest/src/screens/Hosts/HostLogs.test.tsx
+++ b/ambari-web/latest/src/screens/Hosts/HostLogs.test.tsx
@@ -1,0 +1,103 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { AppContext } from "../../store/context";
+import { ServiceContext } from "../../store/ServiceContext";
+
+const mocks = vi.hoisted(() => ({ fetchHostLogs: vi.fn() }));
+vi.mock("../../api/hostLogsApi", () => ({
+  default: {
+    fetchHostLogs: mocks.fetchHostLogs,
+    fetchLogTail: vi.fn(),
+  },
+}));
+vi.mock("../../components/Paginator", () => ({ default: () => <div>Pagination</div> }));
+vi.mock("../../components/Spinner", () => ({ default: () => <div>Loading logs</div> }));
+vi.mock("../../hooks/useLazyQuicklinks", () => ({
+  useLazyQuicklinks: () => ({
+    loadQuicklinks: vi.fn(),
+    quicklinks: [{
+      links: [{ label: "Log Search UI", url: "https://logsearch.example:61888" }],
+    }],
+  }),
+}));
+vi.mock("./HostLogTailModal", () => ({
+  default: ({ filePath, logSearchUrl }: { filePath: string; logSearchUrl: string }) => (
+    <div data-testid="log-tail">Tail {filePath} {logSearchUrl}</div>
+  ),
+}));
+
+import HostLogs from "./HostLogs";
+
+const response = {
+  host_components: [{
+    HostRoles: {
+      component_name: "NAMENODE",
+      display_name: "NameNode",
+      service_name: "HDFS",
+    },
+    logging: {
+      name: "hdfs_namenode",
+      logs: [{ name: "/var/log/hdfs/namenode.log" }],
+    },
+  }],
+};
+
+function renderLogs() {
+  return render(
+    <AppContext.Provider value={{ clusterName: "c1" } as any}>
+      <ServiceContext.Provider value={{
+        allServiceModels: [{ serviceName: "HDFS", displayName: "HDFS" }],
+      } as any}>
+        <HostLogs hostName="host1" />
+      </ServiceContext.Provider>
+    </AppContext.Provider>,
+  );
+}
+
+describe("Host Logs", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.fetchHostLogs.mockResolvedValue(response);
+  });
+  afterEach(() => cleanup());
+
+  it("lists a host log and opens its tail", async () => {
+    renderLogs();
+    const logSearchLink = await screen.findByRole("link", { name: "Open in Log Search" });
+    expect(logSearchLink.getAttribute("href")).toContain("hosts=host1");
+    expect(logSearchLink.getAttribute("href")).toContain("components=hdfs_namenode");
+    fireEvent.click(await screen.findByRole("button", { name: "namenode.log" }));
+    expect(screen.getByTestId("log-tail").textContent).toContain(
+      "Tail /var/log/hdfs/namenode.log",
+    );
+  });
+
+  it("exposes a recoverable metadata failure", async () => {
+    mocks.fetchHostLogs
+      .mockRejectedValueOnce(new Error("offline"))
+      .mockResolvedValueOnce(response);
+    renderLogs();
+    expect(await screen.findByText("Ambari could not load host logs.")).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: "Retry" }));
+    await waitFor(() => expect(mocks.fetchHostLogs).toHaveBeenCalledTimes(2));
+    expect(await screen.findByRole("button", { name: "namenode.log" })).toBeTruthy();
+  });
+});

--- a/ambari-web/latest/src/screens/Hosts/HostLogs.tsx
+++ b/ambari-web/latest/src/screens/Hosts/HostLogs.tsx
@@ -1,0 +1,242 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useContext, useEffect, useMemo, useState } from "react";
+import { Alert, Button, Card, Form, Table } from "react-bootstrap";
+import HostLogsApi from "../../api/hostLogsApi";
+import Paginator from "../../components/Paginator";
+import Spinner from "../../components/Spinner";
+import { ServiceContext } from "../../store/ServiceContext";
+import { AppContext } from "../../store/context";
+import {
+  buildLogSearchUrl,
+  HostLogRow,
+  mapHostLogRows,
+} from "../../Utils/hostLogs";
+import HostLogTailModal from "./HostLogTailModal";
+import { useLazyQuicklinks } from "../../hooks/useLazyQuicklinks";
+
+type HostLogsProps = { hostName: string };
+type SortField = "componentDisplayName" | "serviceDisplayName";
+
+export default function HostLogs({ hostName }: HostLogsProps) {
+  const { clusterName } = useContext(AppContext);
+  const { allServiceModels } = useContext(ServiceContext);
+  const { loadQuicklinks, quicklinks } = useLazyQuicklinks("LOGSEARCH");
+  const [rows, setRows] = useState<HostLogRow[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [retryCount, setRetryCount] = useState(0);
+  const [serviceFilter, setServiceFilter] = useState("");
+  const [componentFilter, setComponentFilter] = useState("");
+  const [extensionFilter, setExtensionFilter] = useState("");
+  const [sortField, setSortField] = useState<SortField>("serviceDisplayName");
+  const [sortAscending, setSortAscending] = useState(true);
+  const [currentPage, setCurrentPage] = useState(1);
+  const [itemsPerPage, setItemsPerPage] = useState(10);
+  const [selectedLog, setSelectedLog] = useState<{
+    componentName: string;
+    filePath: string;
+    logSearchUrl: string;
+  } | null>(null);
+
+  useEffect(() => {
+    void loadQuicklinks();
+  }, [loadQuicklinks]);
+
+  const logSearchBaseUrl = quicklinks
+    .flatMap((quicklink: any) => quicklink.links || [])
+    .find((link: any) => link.label === "Log Search UI")?.url || "";
+
+  useEffect(() => {
+    let active = true;
+    setLoading(true);
+    setError(null);
+    const serviceNames = Object.fromEntries(
+      (allServiceModels || []).map((service: any) => [
+        service.serviceName || service.ServiceInfo?.service_name,
+        service.displayName || service.ServiceInfo?.service_name,
+      ]),
+    );
+    void HostLogsApi.fetchHostLogs(clusterName, hostName)
+      .then((response) => {
+        if (active) {
+          setRows(mapHostLogRows(response, hostName, serviceNames));
+        }
+      })
+      .catch((requestError) => {
+        if (active) {
+          setError(
+            requestError?.response?.data?.message || "Ambari could not load host logs.",
+          );
+        }
+      })
+      .finally(() => {
+        if (active) {
+          setLoading(false);
+        }
+      });
+    return () => {
+      active = false;
+    };
+  }, [allServiceModels, clusterName, hostName, retryCount]);
+
+  const serviceOptions = useMemo(
+    () => Array.from(new Map(rows.map((row) => [row.serviceName, row.serviceDisplayName])).entries()),
+    [rows],
+  );
+  const componentOptions = useMemo(
+    () => Array.from(new Map(rows.map((row) => [row.componentName, row.componentDisplayName])).entries()),
+    [rows],
+  );
+  const filteredRows = useMemo(() => rows
+    .map((row) => ({
+      ...row,
+      files: row.files.filter((file) => !extensionFilter || file.filePath.endsWith(extensionFilter)),
+    }))
+    .filter((row) =>
+      (!serviceFilter || row.serviceName === serviceFilter)
+      && (!componentFilter || row.componentName === componentFilter)
+      && (!extensionFilter || row.files.length > 0),
+    )
+    .sort((left, right) => {
+      const result = left[sortField].localeCompare(right[sortField]);
+      return sortAscending ? result : -result;
+    }), [componentFilter, extensionFilter, rows, serviceFilter, sortAscending, sortField]);
+
+  useEffect(() => setCurrentPage(1), [componentFilter, extensionFilter, serviceFilter]);
+  const maxPage = Math.max(1, Math.ceil(filteredRows.length / itemsPerPage));
+  const page = Math.min(currentPage, maxPage);
+  const pageRows = filteredRows.slice((page - 1) * itemsPerPage, page * itemsPerPage);
+  const changeSort = (field: SortField) => {
+    if (sortField === field) {
+      setSortAscending((value) => !value);
+    } else {
+      setSortField(field);
+      setSortAscending(true);
+    }
+  };
+
+  if (loading) {
+    return <Spinner />;
+  }
+
+  return (
+    <Card className="p-3 rounded-0">
+      {selectedLog && (
+        <HostLogTailModal
+          componentName={selectedLog.componentName}
+          filePath={selectedLog.filePath}
+          hostName={hostName}
+          logSearchUrl={selectedLog.logSearchUrl}
+          onClose={() => setSelectedLog(null)}
+        />
+      )}
+      <h2>Logs</h2>
+      {error && (
+        <Alert variant="danger">
+          {error}{" "}
+          <Button size="sm" variant="outline-danger" onClick={() => setRetryCount((value) => value + 1)}>
+            Retry
+          </Button>
+        </Alert>
+      )}
+      <div className="d-flex gap-2 mb-3 flex-wrap">
+        <Form.Select aria-label="Filter logs by service" className="w-auto" value={serviceFilter} onChange={(event) => setServiceFilter(event.target.value)}>
+          <option value="">All services</option>
+          {serviceOptions.map(([value, label]) => <option key={value} value={value}>{label}</option>)}
+        </Form.Select>
+        <Form.Select aria-label="Filter logs by component" className="w-auto" value={componentFilter} onChange={(event) => setComponentFilter(event.target.value)}>
+          <option value="">All components</option>
+          {componentOptions.map(([value, label]) => <option key={value} value={value}>{label}</option>)}
+        </Form.Select>
+        <Form.Select aria-label="Filter logs by extension" className="w-auto" value={extensionFilter} onChange={(event) => setExtensionFilter(event.target.value)}>
+          <option value="">All extensions</option>
+          <option value=".log">.log</option>
+          <option value=".out">.out</option>
+        </Form.Select>
+      </div>
+      <Table hover responsive>
+        <thead>
+          <tr>
+            <th><Button variant="link" onClick={() => changeSort("serviceDisplayName")}>Service</Button></th>
+            <th><Button variant="link" onClick={() => changeSort("componentDisplayName")}>Component</Button></th>
+            <th>Files</th>
+          </tr>
+        </thead>
+        <tbody>
+          {pageRows.map((row) => (
+            <tr key={row.id}>
+              <td>{row.serviceDisplayName}</td>
+              <td>{row.componentDisplayName}</td>
+              <td>
+                {row.files.map((file) => (
+                  <div key={file.filePath}>
+                    <Button
+                      variant="link"
+                      title={file.filePath}
+                      onClick={() => setSelectedLog({
+                        componentName: row.logComponentName,
+                        filePath: file.filePath,
+                        logSearchUrl: buildLogSearchUrl(
+                          logSearchBaseUrl,
+                          hostName,
+                          row.logComponentName,
+                          file.filePath,
+                        ),
+                      })}
+                    >
+                      {file.fileName}
+                    </Button>
+                    {logSearchBaseUrl ? (
+                      <a
+                        className="ms-2"
+                        href={buildLogSearchUrl(
+                          logSearchBaseUrl,
+                          hostName,
+                          row.logComponentName,
+                          file.filePath,
+                        )}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        Open in Log Search
+                      </a>
+                    ) : null}
+                  </div>
+                ))}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </Table>
+      {!error && filteredRows.length === 0 && <p className="text-muted">No logs match the current filters.</p>}
+      <Paginator
+        currentPage={page}
+        maxPage={maxPage}
+        changePage={(newPage) => setCurrentPage(Math.min(maxPage, Math.max(1, newPage)))}
+        itemsPerPage={itemsPerPage}
+        setItemsPerPage={(value) => {
+          setItemsPerPage(value);
+          setCurrentPage(1);
+        }}
+        totalItems={filteredRows.length}
+      />
+    </Card>
+  );
+}

--- a/ambari-web/latest/src/screens/Hosts/HostSummary.tsx
+++ b/ambari-web/latest/src/screens/Hosts/HostSummary.tsx
@@ -42,10 +42,10 @@ import {
   faRefresh,
   faWarning,
 } from "@fortawesome/free-solid-svg-icons";
-import { get, isEmpty, set, startCase, uniq } from "lodash";
+import { get, isEmpty, map, set, startCase, uniq } from "lodash";
 import Modal from "../../components/Modal";
 import Table from "../../components/Table";
-import { ComponentStatus, ComponentType, PassiveStateOnFilters } from "./enums";
+import { ComponentStatus, ComponentType } from "./enums";
 import Tooltip from "../../components/Tooltip";
 import { getCmponentsToBeRestarted } from "./HostsList";
 import SelectTimeRangeModal from "../../components/SelectTimeRangeModal";
@@ -64,14 +64,11 @@ import {
   getComponentDisplayName,
   getComponentName,
   getCustomCommands,
-  isActive,
   isAddableToHost,
   isDeletable,
   isDeleteComponentDisabled,
-  isEnableHiveInteractive,
   isInit,
   isMoveComponentDisabled,
-  isOozieServerAddable,
   isReassignable,
   isRefreshConfigsAllowed,
   isRestartable,
@@ -79,6 +76,12 @@ import {
   isStart,
   maxToInstall,
 } from "./utils";
+import ConfigsApi from "../../api/configsApi";
+import {
+  type HostComponentConfigRules,
+  hostComponentConfigRules,
+  shouldExcludeAddableHostComponent,
+} from "../../Utils/hosts";
 import {
   checkNnLastCheckpointTime,
   decommission,
@@ -147,6 +150,12 @@ export default function HostsSummary({
   //Note:- Below states should be part of the context
   const [allComponents, setAllComponents] = useState<IHostComponent[]>([]);
   const [addableComponents, setAddableComponents] = useState<any[]>([]);
+  const [componentRules, setComponentRules] = useState<HostComponentConfigRules>({
+    enableHiveInteractive: false,
+    hiveDatabaseType: "",
+    isOozieServerAddable: true,
+  });
+  const [componentRulesLoaded, setComponentRulesLoaded] = useState(false);
   const { getKDCSessionState } = useKDCSessionState(() => { });
   const { services: stackServices } = useStackServices();
   const { getConfigByName } = useConfigs([], stackServices as any);
@@ -234,10 +243,46 @@ export default function HostsSummary({
   }, [serviceComponentInfo]);
 
   useEffect(() => {
-    if (!isEmpty(allComponents)) {
+    if (!isEmpty(allComponents) && componentRulesLoaded) {
       getAddableComponents();
     }
-  }, [allComponents, allHostModels, clusterComponents]);
+  }, [allComponents, allHostModels, clusterComponents, componentRules, componentRulesLoaded]);
+
+  useEffect(() => {
+    let active = true;
+    const installedServices = map(services, "ServiceInfo.service_name") as string[];
+    const relevantServices = ["HIVE", "OOZIE"].filter((serviceName) =>
+      installedServices.includes(serviceName),
+    );
+    setComponentRulesLoaded(false);
+    if (!clusterName || !relevantServices.length) {
+      setComponentRules(hostComponentConfigRules({}, installedServices));
+      setComponentRulesLoaded(true);
+      return () => {
+        active = false;
+      };
+    }
+
+    void ConfigsApi.getConfigValues(clusterName, relevantServices.join(","))
+      .then((response) => {
+        if (active) {
+          setComponentRules(hostComponentConfigRules(response, installedServices));
+        }
+      })
+      .catch(() => {
+        if (active) {
+          setComponentRules(hostComponentConfigRules({}, installedServices));
+        }
+      })
+      .finally(() => {
+        if (active) {
+          setComponentRulesLoaded(true);
+        }
+      });
+    return () => {
+      active = false;
+    };
+  }, [clusterName, JSON.stringify(map(services, "ServiceInfo.service_name"))]);
 
   useEffect(() => {
     if (!isEmpty(allHostModels)) {
@@ -278,17 +323,23 @@ export default function HostsSummary({
   // Check specific authorizations for host component operations
   const canStartStopServices = hasAuthorization("SERVICE.START_STOP");
   const canAddDeleteServices = hasAuthorization("HOST.ADD_DELETE_COMPONENTS");
-  const canModifyConfigs = hasAuthorization("SERVICE.MODIFY_CONFIGS");
-  const canManageHostComponents = hasAuthorization(
-    "HOST.ADD_DELETE_COMPONENTS"
+  const canDecommissionRecommission = hasAuthorization(
+    "SERVICE.DECOMMISSION_RECOMMISSION"
   );
+  const canRunCustomCommands = hasAuthorization("SERVICE.RUN_CUSTOM_COMMAND");
+  const canToggleComponentMaintenance =
+    hasAuthorization("SERVICE.TOGGLE_MAINTENANCE") ||
+    hasAuthorization("HOST.TOGGLE_MAINTENANCE");
+  const canToggleHostMaintenance = hasAuthorization("HOST.TOGGLE_MAINTENANCE");
   const canMoveComponents = hasAuthorization("SERVICE.MOVE");
 
   const canPerformActions =
     canStartStopServices ||
     canAddDeleteServices ||
-    canModifyConfigs ||
-    canManageHostComponents;
+    canDecommissionRecommission ||
+    canRunCustomCommands ||
+    canToggleComponentMaintenance ||
+    canMoveComponents;
 
   const getHostMetrics = async (startTime: number, endTime: number) => {
     // Use a unique cache-busting parameter that includes the time range
@@ -345,12 +396,11 @@ export default function HostsSummary({
         !installedComponents.includes(getComponentName(component)) &&
         !hasCardinalityConflict(component)
       ) {
-        if (
-          (getComponentName(component) === "OOZIE_SERVER" &&
-            !isOozieServerAddable()) ||
-          (getComponentName(component) === "HIVE_SERVER_INTERACTIVE" &&
-            !isEnableHiveInteractive())
-        ) {
+        if (shouldExcludeAddableHostComponent(
+          getComponentName(component),
+          installedServices,
+          componentRules,
+        )) {
           return;
         }
         components.push({
@@ -495,13 +545,7 @@ export default function HostsSummary({
   };
 
   const isToggleMaintenanceModeAvailable = (component: IHostComponent) => {
-    return (
-      isActive(component) ||
-      ![
-        PassiveStateOnFilters.IMPLIED_FROM_SERVICE,
-        PassiveStateOnFilters.IMPLIED_FROM_SERVICE_AND_HOST,
-      ].includes(get(component, "passiveState") as PassiveStateOnFilters)
-    );
+    return !component.isImpliedState();
   };
 
   const getActions = useCallback(
@@ -511,8 +555,8 @@ export default function HostsSummary({
 
       //Actions of Clients
       if (get(component, "componentCategory", "") === ComponentType.CLIENT) {
-        // Refresh configs - Requires SERVICE.MODIFY_CONFIGS authorization
-        if (canModifyConfigs) {
+        // Refresh and custom commands use the semantic custom-command permission.
+        if (canRunCustomCommands) {
           actions.push(
             <div
               key="refresh-configs"
@@ -589,15 +633,17 @@ export default function HostsSummary({
           );
         }
 
-        // Custom commands - Requires SERVICE.START_STOP authorization
-        if (canStartStopServices) {
+        if (canRunCustomCommands) {
           getClientCustomCommands(component).forEach(
             (cmd: any, index: number) => {
               actions.push(
                 <div
                   key={`custom-${index}`}
+                  className={get(cmd, "disabled", false) ? "disabled-btn" : ""}
                   onClick={() => {
-                    executeCustomCommand(cmd, component);
+                    if (!get(cmd, "disabled", false)) {
+                      executeCustomCommand(cmd, component);
+                    }
                   }}
                 >
                   {get(cmd, "label", "")}
@@ -609,10 +655,10 @@ export default function HostsSummary({
       }
       //Actions of Masters and Slaves
       else {
-        // Decommission - Requires SERVICE.START_STOP authorization
+        // Decommission and recommission have an independent service permission.
         if (
           isComponentDecommissionAvailable(component) &&
-          canStartStopServices
+          canDecommissionRecommission
         ) {
           actions.push(
             <div
@@ -642,7 +688,7 @@ export default function HostsSummary({
         // Recommission - Requires SERVICE.START_STOP authorization
         if (
           isComponentRecommissionAvailable(component) &&
-          canStartStopServices
+          canDecommissionRecommission
         ) {
           actions.push(
             <div
@@ -753,10 +799,6 @@ export default function HostsSummary({
                 }
             }
 
-            if (state === ComponentStatus.UPGRADE_FAILED) {
-                actions.push(<div key="retry-upgrade">Retry Upgrade</div>);
-            }
-
             // Re-Install Failed - Requires SERVICE.ADD_DELETE_SERVICES authorization
             if (
                 state === ComponentStatus.INSTALL_FAILED &&
@@ -786,19 +828,20 @@ export default function HostsSummary({
 
             // Move operations - Requires SERVICE.MOVE authorization
             if (canMoveComponents && isReassignable(component, getClusterHosts().length)) {
+                const moveDisabled = isMoveComponentDisabled(
+                    component,
+                    getClusterHosts().length,
+                    get(clusterComponents, "items", [])
+                );
                 actions.push(
                     <div
                         key="move"
-                        onClick={() => moveComponent(component)}
-                        className={
-                            isMoveComponentDisabled(
-                                component,
-                                getClusterHosts().length,
-                                get(clusterComponents, "items", [])
-                            )
-                                ? "disabled-btn"
-                                : ""
-                        }
+                        onClick={() => {
+                          if (!moveDisabled) {
+                            moveComponent(component);
+                          }
+                        }}
+                        className={moveDisabled ? "disabled-btn" : ""}
                     >
                         Move
                     </div>
@@ -806,15 +849,15 @@ export default function HostsSummary({
             }
         }
 
-        // Maintenance Mode - Always available (no specific authorization required)
-        actions.push(
+        if (canToggleComponentMaintenance) {
+          actions.push(
           <div
             key="maintenance-mode"
             onClick={() => {
               if (isToggleMaintenanceModeAvailable(component)) {
                 setSelectedActionData(
                   component,
-                  isActive(component)
+                  component.isActive()
                     ? "turn on maintenance mode"
                     : "turn off maintenance mode",
                   false,
@@ -827,11 +870,12 @@ export default function HostsSummary({
               isToggleMaintenanceModeAvailable(component) ? "" : "disabled-btn"
             }
           >
-            {isActive(component)
+            {component.isActive()
               ? "Turn On Maintenance Mode"
               : "Turn Off Maintenance Mode"}
           </div>
-        );
+          );
+        }
 
         // Re-Install Init - Requires SERVICE.ADD_DELETE_SERVICES authorization
         if (isInit(component) && canAddDeleteServices) {
@@ -865,7 +909,8 @@ export default function HostsSummary({
               className={
                 isDeleteComponentDisabled(
                   component,
-                  get(clusterComponents, "items", [])
+                  get(clusterComponents, "items", []),
+                  componentRules.hiveDatabaseType,
                 )
                   ? "disabled-btn"
                   : ""
@@ -874,7 +919,8 @@ export default function HostsSummary({
                 if (
                   !isDeleteComponentDisabled(
                     component,
-                    get(clusterComponents, "items", [])
+                    get(clusterComponents, "items", []),
+                    componentRules.hiveDatabaseType,
                   )
                 ) {
                   const data = {
@@ -891,8 +937,7 @@ export default function HostsSummary({
           );
         }
 
-        // Refresh configs - Requires SERVICE.MODIFY_CONFIGS authorization
-        if (isRefreshConfigsAllowed(component) && canModifyConfigs) {
+        if (isRefreshConfigsAllowed(component) && canRunCustomCommands) {
           actions.push(
             <div
               key="refresh-component-configs"
@@ -911,8 +956,7 @@ export default function HostsSummary({
           );
         }
 
-        // Custom commands - Requires SERVICE.START_STOP authorization
-        if (canStartStopServices) {
+        if (canRunCustomCommands) {
           getCustomCommands(
             component,
             get(clusterComponents, "items", [])
@@ -923,8 +967,11 @@ export default function HostsSummary({
               actions.push(
                 <div
                   key={`transition-observer-${index}`}
+                  className={get(cmd, "disabled", false) ? "disabled-btn" : ""}
                   onClick={() => {
-                    transitionToObserver(component);
+                    if (!get(cmd, "disabled", false)) {
+                      transitionToObserver(component);
+                    }
                   }}
                 >
                   {get(cmd, "label", "")}
@@ -934,8 +981,11 @@ export default function HostsSummary({
               actions.push(
                 <div
                   key={`custom-master-${index}`}
+                  className={get(cmd, "disabled", false) ? "disabled-btn" : ""}
                   onClick={() => {
-                    executeCustomCommand(cmd, component);
+                    if (!get(cmd, "disabled", false)) {
+                      executeCustomCommand(cmd, component);
+                    }
                   }}
                 >
                   {get(cmd, "label", "")}
@@ -954,6 +1004,12 @@ export default function HostsSummary({
       JSON.stringify(allHostModels),
       clusterName,
       JSON.stringify(serviceModels),
+      canAddDeleteServices,
+      canDecommissionRecommission,
+      canMoveComponents,
+      canRunCustomCommands,
+      canStartStopServices,
+      canToggleComponentMaintenance,
     ]
   );
 
@@ -1322,7 +1378,7 @@ export default function HostsSummary({
                       {/* Edit Rack - Requires HOST.ADD_DELETE_COMPONENTS authorization */}
                       {key === "Rack" &&
                       get(summary, key) &&
-                      canManageHostComponents &&
+                      canToggleHostMaintenance &&
                       !isUpgradeInProgress ? (
                         <FontAwesomeIcon
                           icon={faPencil}

--- a/ambari-web/latest/src/screens/Hosts/HostsList.tsx
+++ b/ambari-web/latest/src/screens/Hosts/HostsList.tsx
@@ -26,7 +26,7 @@ import {
   useState,
 } from "react";
 import { useParams } from "react-router-dom";
-import { Button, Card, Form, ProgressBar } from "react-bootstrap";
+import { Alert, Button, Card, Form, ProgressBar } from "react-bootstrap";
 import { cloneDeep, get, isEmpty, startCase } from "lodash";
 import DefaultButton from "../../components/DefaultButton";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
@@ -51,7 +51,10 @@ import { Link } from "react-router-dom";
 import { ComponentStatus, HostStatus } from "./enums";
 import { serviceNameToModelKeyMap, sortByColIdToKeyMapping } from "./constants";
 import NestedDropdown from "../../components/NestedDropdown";
-import { bulkOperationConfirm } from "./bulkOperations";
+import {
+  bulkOperationConfirm,
+  isBulkComponentDeleteVisible,
+} from "./bulkOperations";
 import { AppContext } from "../../store/context";
 import useStackVersion from "../../hooks/useStackVersion";
 import { ServiceContext } from "../../store/ServiceContext";
@@ -96,7 +99,6 @@ export default function HostsList() {
   const [paginationLoading, setPaginationLoading] = useState(false);
   const [showFilters, setShowFilters] = useState(false);
   const [showModal, setShowModal] = useState(false);
-  const [allHostModels, setAllHostModels] = useState<Host[]>([]);
   const [currentHostModels, setCurrentHostModels] = useState<Host[]>([]);
   const [allHostCount, setAllHostCount] = useState(0);
   const [selectedHosts, setSelectedHosts] = useState<string[]>([]);
@@ -112,6 +114,8 @@ export default function HostsList() {
     },
   });
   const [clusterComponents, setClusterComponents] = useState<any>({});
+  const [clusterLoadError, setClusterLoadError] = useState<string | null>(null);
+  const [clusterRetryCount, setClusterRetryCount] = useState(0);
   const [maxPage, setMaxPage] = useState(1);
   const [currentPage, setCurrentPage] = useState(1);
   const [itemsPerPage, setItemsPerPage] = useState(10);
@@ -137,7 +141,7 @@ export default function HostsList() {
   // {{#havePermissions "HOST.ADD_DELETE_COMPONENTS, HOST.TOGGLE_MAINTENANCE, HOST.ADD_DELETE_HOSTS"}}
   const canShowHostActions = havePermissions("HOST.ADD_DELETE_COMPONENTS, HOST.TOGGLE_MAINTENANCE, HOST.ADD_DELETE_HOSTS");
 
-  useHostConfigUpdater(
+  const hostData = useHostConfigUpdater(
     hostApiQueryParams,
     currentHostModels,
     setCurrentHostModels,
@@ -155,8 +159,10 @@ export default function HostsList() {
   });
 
   useEffect(() => {
-    getClusterComponents();
-  }, []);
+    if (clusterName) {
+      void getClusterComponents();
+    }
+  }, [clusterName, clusterRetryCount]);
 
   useEffect(() => {
     if (params.componentName && !isEmpty(clusterComponents)) {
@@ -251,20 +257,16 @@ export default function HostsList() {
   }, [currentHostModels]);
 
   useEffect(() => {
-    if (
-      get(hostApiQueryParams, "RequestInfo.query", "") === "page_size=10&from=0"
-    ) {
+    if (!filterString) {
       setAllHostCount(totalItems);
-      setAllHostModels(currentHostModels);
     }
-  }),
-    [JSON.stringify(hostApiQueryParams), totalItems];
+  }, [filterString, totalItems]);
 
   useEffect(() => {
     const queryParams = getQueryParameters(selectedFilters);
     const computedQueryParams = computeParameters(queryParams);
     setFilterString(computedQueryParams);
-  }, [selectedFilters.length]);
+  }, [selectedFilters]);
 
   useEffect(() => {
     setMaxPage(Math.ceil(totalItems / itemsPerPage));
@@ -329,11 +331,20 @@ export default function HostsList() {
 
   const getClusterComponents = async () => {
     setLoading(true);
-    const response = await HostsApi.getClusterComponents(
-      clusterName,
-      "ServiceComponentInfo/service_name,host_components/HostRoles/display_name,host_components/HostRoles/host_name,host_components/HostRoles/public_host_name,host_components/HostRoles/state,host_components/HostRoles/maintenance_state,host_components/HostRoles/stale_configs,host_components/HostRoles/ha_state,host_components/HostRoles/desired_admin_state,&minimal_response=true"
-    );
-    setClusterComponents(response);
+    setClusterLoadError(null);
+    try {
+      const response = await HostsApi.getClusterComponents(
+        clusterName,
+        "ServiceComponentInfo/service_name,host_components/HostRoles/display_name,host_components/HostRoles/host_name,host_components/HostRoles/public_host_name,host_components/HostRoles/state,host_components/HostRoles/maintenance_state,host_components/HostRoles/stale_configs,host_components/HostRoles/ha_state,host_components/HostRoles/desired_admin_state,&minimal_response=true"
+      );
+      setClusterComponents(response);
+    } catch (error: any) {
+      setClusterLoadError(
+        error?.response?.data?.message || "Ambari could not load host component data.",
+      );
+    } finally {
+      setLoading(false);
+    }
   };
 
   const isAllSelected = () => {
@@ -806,27 +817,29 @@ export default function HostsList() {
                 selectedFilters
               ),
           },
-          {
-            label: "Set Rack",
-            onClick: () =>
-              bulkOperationConfirm(
-                {
-                  action: "SET_RACK_INFO",
-                  message: "Set Rack",
-                  callback: setCurrentHostModels,
-                },
-                hostsNames,
-                selection,
-                clusterName,
-                stackVersionList,
-                serviceComponentInfo,
-                serviceModels,
-                getKDCSessionState,
-                selectedFilters
-              ),
-          },
         ]);
       }
+
+      // Ember exposes Set Rack whenever the outer Host Actions permission gate is open.
+      result.push({
+        label: "Set Rack",
+        onClick: () =>
+          bulkOperationConfirm(
+            {
+              action: "SET_RACK_INFO",
+              message: "Set Rack",
+              callback: setCurrentHostModels,
+            },
+            hostsNames,
+            selection,
+            clusterName,
+            stackVersionList,
+            serviceComponentInfo,
+            serviceModels,
+            getKDCSessionState,
+            selectedFilters
+          ),
+      });
 
       // HOST.ADD_DELETE_HOSTS authorization check for delete host operation
       if (canAddDeleteHosts) {
@@ -997,7 +1010,8 @@ export default function HostsList() {
               getKDCSessionState,
               selectedFilters
             ),
-          isVisible: false,
+          // Classic deliberately omits component deletion only for All Hosts.
+          isVisible: isBulkComponentDeleteVisible(selection),
         },
       ]);
     }
@@ -1075,7 +1089,6 @@ export default function HostsList() {
   };
 
   const getHostActionsMenuSecondLevel = (selection: string) => {
-    //TODO: Add the actions based on user authorizations/permissions
     let secondLevelMenu = [
       {
         label: "Hosts",
@@ -1084,21 +1097,9 @@ export default function HostsList() {
     ];
 
     let components: any = {};
-    let installedServices: any[] = [];
-
-    if (getSelectedAndFilteredHostsCount("filtered") !== 0) {
-      currentHostModels.forEach((host) => {
-        get(host, "hostComponents", []).forEach((component) => {
-          installedServices.push(get(component, "serviceName", ""));
-        });
-      });
-    } else {
-      allHostModels.forEach((host) => {
-        get(host, "hostComponents", []).forEach((component) => {
-          installedServices.push(get(component, "serviceName", ""));
-        });
-      });
-    }
+    const installedServices = get(clusterComponents, "items", [])
+      .filter((component: any) => get(component, "host_components", []).length > 0)
+      .map((component: any) => get(component, "ServiceComponentInfo.service_name", ""));
 
     const allComponents = getAllComponents(serviceComponentInfo);
     allComponents.forEach((component: any) => {
@@ -1197,7 +1198,11 @@ export default function HostsList() {
   }, [
     JSON.stringify(currentHostModels),
     JSON.stringify(stackVersionList),
-    selectedHosts.length,
+    JSON.stringify(selectedHosts),
+    JSON.stringify(selectedFilters),
+    JSON.stringify(clusterComponents),
+    JSON.stringify(serviceComponentInfo),
+    clusterName,
     allHostCount,
     totalItems,
     canStartStopServices,
@@ -1340,7 +1345,25 @@ export default function HostsList() {
               )}
             </div>
           </div>
-          {loading ? (
+          {hostData.error || clusterLoadError ? (
+            <Alert variant="danger" className="m-3">
+              {hostData.error || clusterLoadError}{" "}
+              <Button
+                size="sm"
+                variant="outline-danger"
+                onClick={() => {
+                  if (hostData.error) {
+                    hostData.retry();
+                  }
+                  if (clusterLoadError) {
+                    setClusterRetryCount((value) => value + 1);
+                  }
+                }}
+              >
+                Retry
+              </Button>
+            </Alert>
+          ) : loading || hostData.isLoading ? (
             <Spinner />
           ) : (
             <div>

--- a/ambari-web/latest/src/screens/Hosts/actions.test.tsx
+++ b/ambari-web/latest/src/screens/Hosts/actions.test.tsx
@@ -1,0 +1,106 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  getConfigValues: vi.fn(),
+  getNnCheckPointTime: vi.fn(),
+  hide: vi.fn(),
+  parseNnCheckPointTime: vi.fn(),
+  show: vi.fn(),
+}));
+
+vi.mock("../../api/hostsApi", () => ({
+  HostsApi: { getNnCheckPointTime: mocks.getNnCheckPointTime },
+}));
+vi.mock("../../api/configsApi", () => ({
+  default: { getConfigValues: mocks.getConfigValues },
+}));
+vi.mock("../../store/ModalManager", () => ({
+  default: { hide: mocks.hide, show: mocks.show },
+}));
+vi.mock("./utils", async (importOriginal) => ({
+  ...await importOriginal<typeof import("./utils")>(),
+  parseNnCheckPointTime: mocks.parseNnCheckPointTime,
+}));
+
+import RecommendationModal from "../../components/RecommendationModal";
+import { addComponent, checkNnLastCheckpointTime } from "./actions";
+
+describe("Hosts actions", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.getNnCheckPointTime.mockImplementation(
+      (_clusterName: string, hostName: string) => Promise.resolve({ hostName }),
+    );
+    mocks.parseNnCheckPointTime.mockImplementation(
+      (response: { hostName: string }) => Promise.resolve(response.hostName),
+    );
+    mocks.getConfigValues.mockResolvedValue({
+      items: [{
+        configurations: [{
+          type: "hadoop-env",
+          properties: { hdfs_user: "hdfs-service" },
+        }],
+      }],
+    });
+  });
+
+  it("checks every NameNode and continues the operation only once", async () => {
+    const operation = vi.fn();
+
+    await checkNnLastCheckpointTime(operation, ["nn1", "nn2"], "c1");
+
+    expect(mocks.getNnCheckPointTime.mock.calls).toEqual([
+      ["c1", "nn1"],
+      ["c1", "nn2"],
+    ]);
+    expect(mocks.show).toHaveBeenCalledTimes(1);
+    const modal = mocks.show.mock.calls[0][0];
+    expect(modal.modalBody).toContain("nn1, nn2");
+    expect(modal.modalBody).toContain("sudo su hdfs-service");
+    expect(operation).not.toHaveBeenCalled();
+
+    await modal.successCallback();
+    expect(mocks.hide).toHaveBeenCalledTimes(1);
+    expect(operation).toHaveBeenCalledTimes(1);
+  });
+
+  it("uses the optional component's service instead of stale caller context", async () => {
+    const component = {
+      clusterName: "c1",
+      componentName: "HBASE_MASTER",
+      displayName: "HBase Master",
+      hostName: "host1",
+      serviceName: "HBASE",
+    } as any;
+
+    await addComponent(component, {
+      fromServiceSummary: true,
+      serviceName: "HDFS",
+      validDropDownHosts: ["host1"],
+    });
+
+    expect(mocks.show).toHaveBeenCalledTimes(1);
+    const modal = mocks.show.mock.calls[0][0];
+    expect(modal.type).toBe(RecommendationModal);
+    expect(modal.props.serviceName).toBe("HBASE");
+    expect(modal.props.componentName).toBe("HBASE_MASTER");
+  });
+});

--- a/ambari-web/latest/src/screens/Hosts/actions.tsx
+++ b/ambari-web/latest/src/screens/Hosts/actions.tsx
@@ -41,6 +41,7 @@ import {
 } from "./utils/ComponentDependency";
 import {
   showAlertModal,
+  showErrorModal,
   translate,
   translateWithVariables,
 } from "../../Utils/Utility";
@@ -48,6 +49,7 @@ import { addDeleteComponentsMap } from "../../Utils/Utility";
 import RecommendationModal from "../../components/RecommendationModal";
 import ConfirmationModal from "../../components/ConfirmationModal";
 import { IHost } from "../../models/host";
+import ConfigsApi from "../../api/configsApi";
 
 export const sendComponentCommand = async (
   component: IHostComponent,
@@ -118,37 +120,58 @@ export const restartAllStaleConfigComponents = async (
 };
 
 export const checkNnLastCheckpointTime = async (
-  callback: Function | Promise<any>,
-  hostName: string,
+  callback: () => void | Promise<void>,
+  hostNames: string | string[],
   clusterName: string
 ) => {
-  const isNNCheckpointTooOld = await pullNnCheckPointTime(
-    hostName,
-    clusterName
+  const names = Array.isArray(hostNames) ? hostNames : [hostNames];
+  const checkpointStates = await Promise.all(
+    names.map(async (hostName) => {
+      try {
+        return await pullNnCheckPointTime(hostName, clusterName);
+      } catch {
+        return null;
+      }
+    })
   );
-  if (isNNCheckpointTooOld) {
-    //TODO: get the hdfs user and remove the hardcoded hdfs user from below commands
+  const oldCheckpointHosts = checkpointStates.filter(
+    (hostName): hostName is string => typeof hostName === "string" && Boolean(hostName)
+  );
+  const isCheckpointUnavailable = checkpointStates.some(
+    (checkpointState) => checkpointState == null
+  );
+
+  const continueOperation = async () => {
+    modalManager.hide();
+    await callback();
+  };
+
+  if (oldCheckpointHosts.length) {
+    let hdfsUser = "<hdfs-user>";
+    try {
+      const currentConfigs = await ConfigsApi.getConfigValues(clusterName, "HDFS");
+      const hadoopEnv = get(currentConfigs, "items", [])
+        .flatMap((item: Record<string, unknown>) => get(item, "configurations", []))
+        .find((config: Record<string, unknown>) => config.type === "hadoop-env");
+      hdfsUser = get(hadoopEnv, "properties.hdfs_user", hdfsUser);
+    } catch {
+      // The operation can still proceed with the same placeholder used by classic Ambari.
+    }
+    const hosts = oldCheckpointHosts.join(", ");
     const msg =
       `The last HDFS checkpoint is older than ${nnCheckpointAgeAlertThreshold} hours. ` +
       "Make sure that you have taken a checkpoint before proceeding. Otherwise, the NameNode(s) can take a very long time to start up." +
-      `\n\n1. Login to the NameNode host ${isNNCheckpointTooOld}` +
+      `\n\n1. Login to the NameNode host${oldCheckpointHosts.length > 1 ? "s" : ""} ${hosts}` +
       "\n\n2. Put the NameNode in Safe Mode (read-only mode): \n\n" +
-      "    sudo su hdfs -l -c 'hdfs dfsadmin -safemode enter'" +
+      `    sudo su ${hdfsUser} -l -c 'hdfs dfsadmin -safemode enter'` +
       "\n\n3. Once in Safe Mode, create a Checkpoint:\n\n" +
-      "    sudo su hdfs -l -c 'hdfs dfsadmin -saveNamespace" +
+      `    sudo su ${hdfsUser} -l -c 'hdfs dfsadmin -saveNamespace'` +
       "\n";
     const modalProps = {
       modalTitle: "Warning",
       modalBody: msg,
       onClose: () => {},
-      successCallback: async () => {
-        if (typeof callback === "function") {
-          callback();
-        } else if (callback instanceof Promise) {
-          await callback;
-        }
-        modalManager.hide();
-      },
+      successCallback: continueOperation,
       options: {
         okButtonText: "Next",
         okButtonVariant: "primary",
@@ -158,20 +181,13 @@ export const checkNnLastCheckpointTime = async (
       },
     };
     modalManager.show(modalProps);
-  } else if (isNNCheckpointTooOld === null) {
+  } else if (isCheckpointUnavailable) {
     const modalProps = {
       modalTitle: "Warning",
       modalBody:
         "Could not determine the age of the last HDFS checkpoint. Please ensure that you have a recent checkpoint. Otherwise, the NameNode(s) can take a very long time to start up.",
       onClose: () => {},
-      successCallback: async () => {
-        if (typeof callback === "function") {
-          callback();
-        } else if (callback instanceof Promise) {
-          await callback;
-        }
-        modalManager.hide();
-      },
+      successCallback: continueOperation,
       options: {
         okButtonText: "Proceed Anyway",
         okButtonVariant: "danger",
@@ -182,11 +198,7 @@ export const checkNnLastCheckpointTime = async (
     };
     modalManager.show(modalProps);
   } else {
-    if (typeof callback === "function") {
-      callback();
-    } else if (callback instanceof Promise) {
-      await callback;
-    }
+    await callback();
   }
 };
 
@@ -364,9 +376,7 @@ export const installClients = async (
       .replace(
         "{1}",
         missedComponents
-          .map((component: IHostComponent) => {
-            getComponentDisplayName(component);
-          })
+          .map((component: IHostComponent) => getComponentDisplayName(component))
           .join(", ")
       );
     showAlertModal(
@@ -603,7 +613,7 @@ export const deleteComponent = async (component: IHostComponent, data: any) => {
   const componentsMapItem = get(addDeleteComponentsMap, componentName);
 
   if (componentsMapItem) {
-    data.deleteAndReconfigureComponent(componentsMapItem, component);
+    await data.deleteAndReconfigureComponent(componentsMapItem, component);
   } else if (componentName === "JOURNALNODE") {
     data.navigate("/main/services/highAvailability/JournalNode/manage/step1");
   } else {
@@ -615,7 +625,19 @@ export const deleteComponent = async (component: IHostComponent, data: any) => {
         }}
         componentDisplayName={getComponentDisplayName(component)}
         add={false}
-        callback={() => data._doDeleteHostComponent(component)}
+        callback={async () => {
+          try {
+            await data._doDeleteHostComponent(component);
+          } catch (error) {
+            showErrorModal(
+              get(
+                error,
+                "response.data.message",
+                get(error, "message", "Unable to delete the host component.")
+              )
+            );
+          }
+        }}
       />
     );
   }
@@ -626,7 +648,7 @@ export const addComponentWithCheck = async (
   data: any
 ) => {
   await data.getKDCSessionState(async () => {
-    addComponent(component, data);
+    await addComponent(component, data);
   });
 };
 
@@ -656,7 +678,7 @@ export const addComponent = async (component: IHostComponent, data: any) => {
   }
 
   if (componentsMapItem) {
-    data.addAndReconfigureComponent(
+    await data.addAndReconfigureComponent(
       componentsMapItem,
       hostName,
       component,
@@ -665,8 +687,8 @@ export const addComponent = async (component: IHostComponent, data: any) => {
   } else if (componentName === "JOURNALNODE") {
     data.navigate("/main/services/highAvailability/JournalNode/manage/step1");
   } else {
-    // Get service name from component or data
-    const serviceName = data.serviceName || get(component, "serviceName") || "";
+    // The component metadata is authoritative when this action is reused across services.
+    const serviceName = get(component, "serviceName") || data.serviceName || "";
     const componentNameForModal = data.componentNameFromService || get(component, "componentName") || "";
     
     modalManager.show(

--- a/ambari-web/latest/src/screens/Hosts/batchUtils.tsx
+++ b/ambari-web/latest/src/screens/Hosts/batchUtils.tsx
@@ -131,19 +131,23 @@ export const restartHostComponents = async (
 export const getComponentsFromServer = async (
   options: any,
   clusterName: string,
-  callBack: (responseData: any) => void
+  callBack: (responseData: any) => void | Promise<void>
 ) => {
-  const requestParameters = constructComponentsCallUrl(options);
-  const data = {
-    parameters: requestParameters.params,
-    fields: requestParameters.fields,
-  };
-  const responseData: any = await HostsApi.getHostComponents(
-    clusterName,
-    requestParameters.fields,
-    data
-  );
-  callBack(responseData);
+  try {
+    const requestParameters = constructComponentsCallUrl(options);
+    const data = {
+      parameters: requestParameters.params,
+      fields: requestParameters.fields,
+    };
+    const responseData: any = await HostsApi.getHostComponents(
+      clusterName,
+      requestParameters.fields,
+      data
+    );
+    await callBack(responseData);
+  } catch (error) {
+    showErrorModal(get(error, "response.data.message", get(error, "message", "Unable to load host components.")));
+  }
 };
 
 const constructComponentsCallUrl = (options: any) => {

--- a/ambari-web/latest/src/screens/Hosts/bulkOperations.test.ts
+++ b/ambari-web/latest/src/screens/Hosts/bulkOperations.test.ts
@@ -1,0 +1,56 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  buildBulkHostQueryParams,
+  isBulkComponentDeleteVisible,
+} from "./bulkOperations";
+
+describe("Hosts bulk-operation targeting", () => {
+  it("targets the explicit host set for Selected Hosts", () => {
+    expect(buildBulkHostQueryParams("selected", ["host1", "host2"], []))
+      .toEqual([{
+        key: "Hosts/host_name",
+        value: ["host1", "host2"],
+        type: "MULTIPLE",
+      }]);
+  });
+
+  it("uses the active predicates for Filtered Hosts", () => {
+    const filters = [{
+      field: { label: "Host Name", value: "hostName" },
+      value: { label: "worker", value: "worker" },
+    }] as any;
+
+    const result = buildBulkHostQueryParams("filtered", [], filters);
+    expect(result).not.toEqual([]);
+    expect(JSON.stringify(result)).toContain("worker");
+  });
+
+  it("sends no predicate for All Hosts", () => {
+    expect(buildBulkHostQueryParams("all", ["host1"], []))
+      .toEqual([]);
+  });
+
+  it("exposes component deletion for Selected and Filtered, but not All", () => {
+    expect(isBulkComponentDeleteVisible("selected")).toBe(true);
+    expect(isBulkComponentDeleteVisible("filtered")).toBe(true);
+    expect(isBulkComponentDeleteVisible("all")).toBe(false);
+  });
+});

--- a/ambari-web/latest/src/screens/Hosts/bulkOperations.tsx
+++ b/ambari-web/latest/src/screens/Hosts/bulkOperations.tsx
@@ -64,18 +64,11 @@ export const bulkOperationConfirm = (
   getKDCSessionState: (callback: () => Promise<void>) => Promise<void>,
   selectedFilters: SelectedFilters
 ) => {
-  let queryParams: any[] = [];
-  if (selection === "selected") {
-    if (hostsNames.length) {
-      queryParams.push({
-        key: "Hosts/host_name",
-        value: hostsNames,
-        type: "MULTIPLE",
-      });
-    }
-  } else if (selection === "filtered") {
-    queryParams = getQueryParameters(selectedFilters);
-  }
+  const queryParams = buildBulkHostQueryParams(
+    selection,
+    hostsNames,
+    selectedFilters,
+  );
   getHostsForBulkOperations(
     queryParams,
     operationData,
@@ -87,6 +80,29 @@ export const bulkOperationConfirm = (
   );
 };
 
+export const buildBulkHostQueryParams = (
+  selection: string,
+  hostNames: string[],
+  selectedFilters: SelectedFilters,
+) => {
+  let queryParams: any[] = [];
+  if (selection === "selected") {
+    if (hostNames.length) {
+      queryParams.push({
+        key: "Hosts/host_name",
+        value: hostNames,
+        type: "MULTIPLE",
+      });
+    }
+  } else if (selection === "filtered") {
+    queryParams = getQueryParameters(selectedFilters);
+  }
+  return queryParams;
+};
+
+export const isBulkComponentDeleteVisible = (selection: string) =>
+  selection !== "all";
+
 const getHostsForBulkOperations = async (
   queryParams: any,
   operationData: any,
@@ -96,20 +112,26 @@ const getHostsForBulkOperations = async (
   serviceModels: any,
   getKDCSessionState: (callback: () => Promise<void>) => Promise<void>
 ) => {
-  const data = {
-    parameters: computeParameters(queryParams),
-    operationData: operationData,
-  };
-  const response = await HostsApi.getHostsBulkOperations(clusterName, data);
-  getHostsForBulkOperationSuccessCallback(
-    response,
-    data,
-    stackVersionList,
-    clusterName,
-    serviceComponentInfo,
-    serviceModels,
-    getKDCSessionState
-  );
+  try {
+    const data = {
+      parameters: computeParameters(queryParams),
+      operationData: operationData,
+    };
+    const response = await HostsApi.getHostsBulkOperations(clusterName, data);
+    getHostsForBulkOperationSuccessCallback(
+      response,
+      data,
+      stackVersionList,
+      clusterName,
+      serviceComponentInfo,
+      serviceModels,
+      getKDCSessionState
+    );
+  } catch (error) {
+    showErrorModal(
+      get(error, "response.data.message", get(error, "message", "Unable to load hosts for this operation."))
+    );
+  }
 };
 
 const getHostsForBulkOperationSuccessCallback = (
@@ -160,6 +182,11 @@ const getHostsForBulkOperationSuccessCallback = (
       );
       return;
     }
+    operationData.repositoryVersion = get(
+      repoVersion,
+      "repository_version",
+      get(repoVersion, "repositoryVersion.repositoryVersion", "")
+    );
     hostNamesSkipped = getSkippedForPassiveStateHosts(hosts, repoVersion);
   }
 
@@ -217,7 +244,9 @@ const getBulkOperationConfirmPopupModalBody = (
           "Components on these hosts are stopped so decommission will be skipped.";
         break;
       case "PASSIVE_STATE":
-        bodyMessageExtended = `Some hosts have components from a stack which is not current. Before bringing these hosts out of maintenance mode, it is recommended that you upgrade their components to {target version}`; //TODO: determine the target version
+        if (operationData.state === "OFF") {
+          bodyMessageExtended = `Some hosts have components from a stack which is not current. Before bringing these hosts out of maintenance mode, it is recommended that you upgrade their components to ${operationData.repositoryVersion || "the current version"}.`;
+        }
         break;
       default:
         bodyMessageExtended = "";
@@ -310,7 +339,11 @@ const getSkippedForDecommissionHosts = (
 
 const getSkippedForPassiveStateHosts = (hosts: any, repoVersion: any) => {
   const hostNames = hosts.map((host: any) => host.hostName);
-  const outOfSyncHosts = get(repoVersion, "outOfSyncHosts", []);
+  const outOfSyncHosts = get(
+    repoVersion,
+    "out_of_sync_hosts",
+    get(repoVersion, "outOfSyncHosts", [])
+  );
   const hostNamesSkipped = outOfSyncHosts.filter((host: any) =>
     hostNames.includes(host)
   );
@@ -520,14 +553,9 @@ const getComponentsFromServerForHostsCallback = async (
     };
 
     if (operationData.action === "INSTALLED" && isHDFSStarted) {
-      if (nn_hosts.length === 1) {
-        checkNnLastCheckpointTime(request, nn_hosts[0], clusterName);
-      }
-      if (nn_hosts.length > 1) {
-        //checkNnLastCheckpointTime(request); TODO: yet to be implemented from service side
-      }
+      void checkNnLastCheckpointTime(request, nn_hosts, clusterName);
     } else {
-      request();
+      void request();
     }
   } else {
     modalManager.show({
@@ -567,12 +595,12 @@ const bulkOperationForHostComponentsSuccessCallback = (
     );
   } else {
     modalManager.show(
-      <BackgroundOperations
+        <BackgroundOperations
         isOpen={true}
         onClose={() => {
           modalManager.hide();
         }}
-        requestId={get(response, "data.Requests.id", "")}
+        requestId={get(response, "Requests.id", "")}
       />
     );
   }
@@ -627,20 +655,27 @@ const getComponentsFromServerForRestartCallback = (
   const nn_count = namenodes.length;
 
   if (nn_count === 1 && isHDFSStarted) {
-    const hostName = namenodes[0].hostName;
-    checkNnLastCheckpointTime(
-      restartHostComponents(
+    void checkNnLastCheckpointTime(
+      () => restartHostComponents(
         hostComponents,
         "Restart all components on the selected hosts",
         "HOST"
       ),
-      hostName,
+      namenodes[0].hostName,
       clusterName
     );
   } else if (nn_count > 1 && isHDFSStarted) {
-    // checkNnLastCheckpointTime(restartHostComponents(hostComponents, "Restart all components on the selected hosts", "HOST")); TODO: yet to be implemented from service side
+    void checkNnLastCheckpointTime(
+      () => restartHostComponents(
+        hostComponents,
+        "Restart all components on the selected hosts",
+        "HOST"
+      ),
+      namenodes.map((namenode: any) => namenode.hostName),
+      clusterName
+    );
   } else {
-    restartHostComponents(
+    void restartHostComponents(
       hostComponents,
       "Restart all components on the selected hosts",
       "HOST"

--- a/ambari-web/latest/src/screens/Hosts/details.tsx
+++ b/ambari-web/latest/src/screens/Hosts/details.tsx
@@ -53,6 +53,7 @@ import {
   ResourceTypeEnum,
 } from "./supportClientConfigsDownload";
 import RecommendationModal from "../../components/RecommendationModal";
+import { deleteHostComponentsInOrder } from "../../Utils/hosts";
 
 export const doAction = (option: any) => {
   switch (option.action) {
@@ -676,7 +677,7 @@ const raiseDeleteComponentsError = (
   modalManager.show(modalProps);
 };
 
-const reconfigureAndDeleteHost = (
+const reconfigureAndDeleteHost = async (
   container: any,
   context: any,
   properties: any
@@ -688,8 +689,8 @@ const reconfigureAndDeleteHost = (
     "loadComponentRelatedConfigs"
   );
 
-  get(context, "host.hostComponents", []).forEach(
-    (component: IHostComponent) => {
+  try {
+    for (const component of get(context, "host.hostComponents", [])) {
       const componentsMapItem = addDeleteComponentsMap[component.componentName];
       if (componentsMapItem) {
         reconfiguredComponents.push(component.displayName);
@@ -699,14 +700,19 @@ const reconfigureAndDeleteHost = (
         if (componentsMapItem.addPropertyName) {
           set(properties, componentsMapItem.addPropertyName, true);
         }
-        loadComponentRelatedConfigs(
+        await loadComponentRelatedConfigs(
           componentsMapItem.configTagsCallbackName,
           componentsMapItem.configsCallbackName,
           properties
         );
       }
     }
-  );
+  } catch (error) {
+    showErrorModal(
+      get(error, "response.data.message", get(error, "message", "Unable to load component configuration."))
+    );
+    return;
+  }
 
   modalManager.show(
     <RecommendationModal
@@ -816,7 +822,7 @@ const confirmDeleteHost = (container: any, context: any) => {
       </div>
     ),
     successCallback: () => {
-      doDeleteHost(context, container, {}, {});
+      void doDeleteHost(context, container);
       modalManager.hide();
     },
     options: {
@@ -830,11 +836,9 @@ const confirmDeleteHost = (container: any, context: any) => {
   modalManager.show(modalProps);
 };
 
-const doDeleteHost = (
+const doDeleteHost = async (
   context: any,
-  container: any,
-  groupedPropertiesToChange: any,
-  deletedHostComponentError: any
+  container: any
 ) => {
   const allComponents = get(context, "host.hostComponents", []);
   const doDeleteHostComponent = get(context, "doDeleteHostComponent");
@@ -845,48 +849,33 @@ const doDeleteHost = (
   );
   const putConfigsToServer = get(context, "putConfigsToServer", () => {});
   const clearConfigsChanges = get(context, "clearConfigsChanges", () => {});
-  let deleteRequests = [];
-
-  const deleteHost = async () => {
-    if (allComponents.length > 0) {
-      for (const component of allComponents) {
-        deleteRequests.push(doDeleteHostComponent(component));
-      }
-      try {
-        await Promise.all(deleteRequests);
-        if (container.isReconfigureRequired) {
-          const reconfiguredComponents = allComponents
-            .filter(
-              (component: IHostComponent) =>
-                addDeleteComponentsMap[component.componentName]
-            )
-            .map((component: any) => component.displayName)
-            .join(", ");
-          applyConfigsCustomization();
-          putConfigsToServer(groupedPropertiesToChange, reconfiguredComponents);
-          clearConfigsChanges();
-        }
-        await deleteHostCall(context);
-      } catch (e) {
-        set(
-          deletedHostComponentError,
-          "xhr.responseText",
-          `{"message": "${get(
-            deletedHostComponentError,
-            "xhr.statusText",
-            ""
-          )}"}`
-        );
-        showErrorModal(get(deletedHostComponentError, "xhr.responseText", ""));
-      }
+  try {
+    await deleteHostComponentsInOrder(allComponents, doDeleteHostComponent);
+    if (container.isReconfigureRequired) {
+      const reconfiguredComponents = allComponents
+        .filter(
+          (component: IHostComponent) =>
+            addDeleteComponentsMap[component.componentName]
+        )
+        .map((component: any) => component.displayName)
+        .join(", ");
+      applyConfigsCustomization();
+      await putConfigsToServer(
+        get(context, "groupedPropertiesToChange.current", []),
+        reconfiguredComponents
+      );
+      clearConfigsChanges();
     }
-  };
-
-  return deleteHost();
+    await deleteHostCall(context);
+  } catch (error) {
+    showErrorModal(
+      get(error, "response.data.message", get(error, "message", "Unable to delete the host."))
+    );
+  }
 };
 
 const deleteHostCall = async (context: any) => {
-  const clusterName = get(context, "host.cluster", "");
+  const clusterName = get(context, "clusterName", get(context, "host.cluster", ""));
   const hostName = get(context, "host.hostName", "");
   try {
     await HostsApi.deleteHost(clusterName, hostName);

--- a/ambari-web/latest/src/screens/Hosts/hooks/useComponentAddDelete.tsx
+++ b/ambari-web/latest/src/screens/Hosts/hooks/useComponentAddDelete.tsx
@@ -21,7 +21,11 @@ import { useState, useRef, useContext, useEffect } from "react";
 import { HostsApi } from "../../../api/hostsApi";
 import { IHostComponent } from "../../../models/hostComponent";
 import { AppContext } from "../../../store/context";
-import { zooKeeperRelatedServices, serviceMap } from "../../../Utils/Utility";
+import {
+  showErrorModal,
+  zooKeeperRelatedServices,
+  serviceMap,
+} from "../../../Utils/Utility";
 import { t } from "i18next";
 import {
   getComponentDisplayName,
@@ -104,16 +108,19 @@ function useComponentAddDelete(
         }}
         //@ts-ignore
         setRecommendedPropertiesToChange={setRecommendedPropertiesToChange}
-        callback={(properties: any) => {
+        callback={async (properties: any) => {
           setRecommendedPropertiesToChange(properties);
-          _doDeleteHostComponent(component, () => {
+          try {
+            await _doDeleteHostComponent(component);
             applyConfigsCustomization();
-            putConfigsToServer(
+            await putConfigsToServer(
               groupedPropertiesToChange.current,
               get(component, "componentName")
             );
             clearConfigsChanges();
-          });
+          } catch (error) {
+            showErrorModal(get(error, "response.data.message", get(error, "message", "Unable to delete the host component.")));
+          }
         }}
       />
     );
@@ -148,8 +155,8 @@ function useComponentAddDelete(
       componentsMapItem.configsCallbackName
     );
 
-    // Get service name from component or data
-    const serviceName = data.serviceName || get(component, "serviceName") || "";
+    // The component metadata is authoritative when this hook is reused across services.
+    const serviceName = get(component, "serviceName") || data.serviceName || "";
     const componentName =
       data.componentNameFromService || get(component, "componentName") || "";
 
@@ -291,11 +298,7 @@ function useComponentAddDelete(
         }
       });
     }
-    try {
-      await Promise.all(requests);
-    } catch (error) {
-      console.error("Error while saving configurations: ", error);
-    }
+    await Promise.all(requests);
   };
 
   const applyConfigsCustomization = () => {
@@ -327,17 +330,16 @@ function useComponentAddDelete(
 
   const _doDeleteHostComponent = async (
     component: IHostComponent,
-    deleteComponentSuccessCallback?: Function,
-    callback?: Function
+    deleteComponentSuccessCallback?: (componentName: string, hostName: string) => void | Promise<void>,
+    callback?: () => void | Promise<void>
   ) => {
     const componentName = get(component, "componentName");
     const hostName = get(component, "hostName");
-    const url = componentName
-      ? `/clusters/${clusterName}/hosts/${hostName}/host_components/${componentName}`
-      : `/clusters/${clusterName}/hosts/${hostName}`;
-
     try {
-      await HostsApi.componentDelete(url);
+      if (!componentName) {
+        throw new Error("A component name is required for component deletion.");
+      }
+      await HostsApi.deleteHostComponent(clusterName, hostName, componentName);
       if (setAllHostModels) {
         setAllHostModels((prevModels: IHost[]) => {
           return prevModels.map((host) => {
@@ -357,15 +359,16 @@ function useComponentAddDelete(
         });
       }
       if (deleteComponentSuccessCallback) {
-        deleteComponentSuccessCallback(componentName, hostName);
+        await deleteComponentSuccessCallback(componentName, hostName);
       }
 
       if (callback) {
-        callback();
+        await callback();
       }
       _deletedHostComponentError.current = "";
     } catch (err) {
       _deletedHostComponentError.current = JSON.stringify(err);
+      throw err;
     }
   };
 

--- a/ambari-web/latest/src/screens/Hosts/index.tsx
+++ b/ambari-web/latest/src/screens/Hosts/index.tsx
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-import { Button, Col, Nav, Row, Tab } from "react-bootstrap";
+import { Alert, Button, Col, Nav, Row, Tab } from "react-bootstrap";
 import HostsSummary from "./HostSummary";
 import HostConfigs from "./HostConfigs";
 import HostAlerts from "../Alerts/HostAlerts";
@@ -29,7 +29,6 @@ import { useHostConfigUpdater } from "../../hooks/useHostConfigUpdater";
 import { useParams, useNavigate } from "react-router-dom";
 import { IHostComponent } from "../../models/hostComponent";
 import { AppContext } from "../../store/context";
-import { supports } from "../../data/configs/services/config";
 import { confirmRecoverHost, doAction } from "./details";
 import { useHostChecks } from "../../hooks/useHostChecks";
 import HostChecks from "./HostChecks";
@@ -45,18 +44,28 @@ import useComponentAddDelete from "./hooks/useComponentAddDelete";
 import { translate, translateWithVariables } from "../../Utils/Utility";
 import classNames from "classnames";
 import { useAuth } from "../../hooks/useAuth";
+import HostLogs from "./HostLogs";
+import useKerberosMode from "../../hooks/useKerberosMode";
 
 export function Hosts() {
   const params = useParams();
   const navigate = useNavigate();
-  const { isKerberosEnabled, clusterName, upgradeIsRunning } =
+  const {
+    isKerberosEnabled,
+    clusterName,
+    services,
+    supports,
+    upgradeIsRunning,
+  } =
     useContext(AppContext);
   const { allServiceModels: serviceModels } = useContext(ServiceContext);
   const [allHostModels, setAllHostModels] = useState<IHost[]>([]);
-  const { stackVersionList } = useStackVersion();
+  const { stackVersion, stackVersionList } = useStackVersion();
   const [showHostCheck, setShowHostCheck] = useState(false);
   const [clusterComponents, setClusterComponents] = useState<any>({});
   const [loading, setLoading] = useState(true);
+  const [clusterLoadError, setClusterLoadError] = useState<string | null>(null);
+  const [clusterRetryCount, setClusterRetryCount] = useState(0);
 
   const { services: stackServices } = useStackServices();
   const { getConfigByName } = useConfigs([], stackServices as any);
@@ -64,7 +73,8 @@ export function Hosts() {
   const [activeTab, setActiveTab] = useState(params.tab || "summary");
 
   // Authorization hooks - implementing Ember.js host authorization patterns
-  const { hasAuthorization, isAdmin, isOperator, havePermissions } = useAuth();
+  const { hasAuthorization, isAdmin, isOperator } = useAuth();
+  const { isLoaded: isKerberosModeLoaded, isManualKerberos } = useKerberosMode();
 
   // Use computed upgrade property instead of utility function
   const isUpgradeInProgress = upgradeIsRunning;
@@ -73,14 +83,15 @@ export function Hosts() {
   const canStartStopServices = hasAuthorization("SERVICE.START_STOP");
   const canToggleHostMaintenance = hasAuthorization("HOST.TOGGLE_MAINTENANCE");
   const canAddDeleteHosts = hasAuthorization("HOST.ADD_DELETE_HOSTS");
-  const canViewConfigs =
-    hasAuthorization("SERVICE.VIEW_CONFIGS") ||
-    hasAuthorization("CLUSTER.VIEW_CONFIGS");
+  const canViewOperationalLogs = hasAuthorization("SERVICE.VIEW_OPERATIONAL_LOGS");
   const canRunHostChecks = isAdmin() || isOperator();
-
-  // Overall permission check for Host Actions menu - matches Ember template logic
-  // {{#havePermissions "HOST.ADD_DELETE_COMPONENTS, HOST.TOGGLE_MAINTENANCE, HOST.ADD_DELETE_HOSTS"}}
-  const canShowHostActions = havePermissions("HOST.ADD_DELETE_COMPONENTS, HOST.TOGGLE_MAINTENANCE, HOST.ADD_DELETE_HOSTS");
+  const isLogSearchInstalled = services.some(
+    (service: any) => get(service, "ServiceInfo.service_name") === "LOGSEARCH",
+  );
+  const canShowLogs = Boolean(
+    supports.logSearch && isLogSearchInstalled && canViewOperationalLogs,
+  );
+  const stackVersionsAvailable = stackVersionList.length > 0;
 
   const hostApiQueryParams = useMemo(() => {
     return {
@@ -88,9 +99,13 @@ export function Hosts() {
         query: `Hosts/host_name.in(${params.hostname})`,
       },
     };
-  }, []);
+  }, [params.hostname]);
 
-  useHostConfigUpdater(hostApiQueryParams, allHostModels, setAllHostModels);
+  const hostData = useHostConfigUpdater(
+    hostApiQueryParams,
+    allHostModels,
+    setAllHostModels,
+  );
   const { startHostCheck, stopHostCheck, isHostCheckRunning, hostCheckResult } =
     useHostChecks();
 
@@ -100,6 +115,7 @@ export function Hosts() {
     putConfigsToServer,
     clearConfigsChanges,
     loadComponentRelatedConfigs,
+    groupedPropertiesToChange,
   } = useComponentAddDelete(
     clusterComponents,
     stackServices,
@@ -124,8 +140,16 @@ export function Hosts() {
   }, [params.tab]);
 
   useEffect(() => {
-    getClusterComponents();
-  }, [get(allHostModels, "[0].hostComponents", []).length]);
+    if (clusterName && allHostModels.length) {
+      void getClusterComponents();
+    }
+  }, [clusterName, get(allHostModels, "[0].hostComponents", []).length, clusterRetryCount]);
+
+  useEffect(() => {
+    if (!hostData.isLoading && !hostData.error && allHostModels.length === 0) {
+      navigate("/main/hosts", { replace: true });
+    }
+  }, [allHostModels.length, hostData.error, hostData.isLoading, navigate]);
 
   useEffect(() => {
     if (showHostCheck) {
@@ -142,7 +166,7 @@ export function Hosts() {
     };
   };
 
-  const tabs = {
+  const tabs: Record<string, { title: React.ReactNode; component: React.ReactNode }> = {
     summary: {
       title: "SUMMARY",
       component: (
@@ -174,13 +198,32 @@ export function Hosts() {
           </Button>
         </>
       ),
-      component: <HostAlerts hostname={params.hostname} />,
-    },
-    versions: {
-      title: "VERSIONS",
-      component: <HostStackVersions />,
+      component: <HostAlerts key={params.hostname} hostname={params.hostname} />,
     },
   };
+  if (stackVersionsAvailable) {
+    tabs.stackVersions = {
+      title: "VERSIONS",
+      component: <HostStackVersions host={allHostModels[0]} />,
+    };
+  }
+  if (canShowLogs) {
+    tabs.logs = {
+      title: "LOGS",
+      component: <HostLogs hostName={params.hostname || ""} />,
+    };
+  }
+
+  useEffect(() => {
+    if (params.tab === "versions" && stackVersionsAvailable) {
+      navigate(`/main/hosts/${params.hostname}/stackVersions`, { replace: true });
+      return;
+    }
+    const versionStateLoaded = stackVersion !== undefined;
+    if (params.tab && versionStateLoaded && !Object.hasOwn(tabs, params.tab)) {
+      navigate(`/main/hosts/${params.hostname}/summary`, { replace: true });
+    }
+  }, [canShowLogs, params.hostname, params.tab, stackVersion, stackVersionsAvailable]);
 
   const isActive = () => {
     return get(allHostModels, "[0]")?.isActive();
@@ -188,19 +231,26 @@ export function Hosts() {
 
   const getClusterComponents = async () => {
     setLoading(true);
-    const response = await HostsApi.getClusterComponents(
-      clusterName,
-      "ServiceComponentInfo/service_name,host_components/HostRoles/display_name,host_components/HostRoles/host_name,host_components/HostRoles/public_host_name,host_components/HostRoles/state,host_components/HostRoles/maintenance_state,host_components/HostRoles/stale_configs,host_components/HostRoles/ha_state,host_components/HostRoles/desired_admin_state,&minimal_response=true"
-    );
-    setClusterComponents(response);
-    setLoading(false);
+    setClusterLoadError(null);
+    try {
+      const response = await HostsApi.getClusterComponents(
+        clusterName,
+        "ServiceComponentInfo/service_name,host_components/HostRoles/display_name,host_components/HostRoles/host_name,host_components/HostRoles/public_host_name,host_components/HostRoles/state,host_components/HostRoles/maintenance_state,host_components/HostRoles/stale_configs,host_components/HostRoles/ha_state,host_components/HostRoles/desired_admin_state,&minimal_response=true"
+      );
+      setClusterComponents(response);
+    } catch (error: any) {
+      setClusterLoadError(
+        error?.response?.data?.message || "Ambari could not load host component data.",
+      );
+    } finally {
+      setLoading(false);
+    }
   };
 
   const getMaintenanceOptions = () => {
     const isNotHeartBeating =
       get(allHostModels, "[0].state", "") === "HEARTBEAT_LOST";
     const hostName = get(allHostModels, "[0].hostName", "");
-    const isManualKerberos = false; // TODO: replace this hardcoded value with App.get('router.mainAdminKerberosController.isManualKerberos')
     let result: any[] = [];
 
     // SERVICE.START_STOP authorization check for component operations
@@ -294,12 +344,11 @@ export function Hosts() {
     if (
       isKerberosEnabled &&
       supports.regenerateKeytabsOnSingleHost &&
-      canToggleHostMaintenance &&
-      !isUpgradeInProgress
+      isKerberosModeLoaded &&
+      !isManualKerberos
     ) {
       result.push({
         label: translate("admin.kerberos.button.regenerateKeytabs"),
-        isVisible: isKerberosEnabled || isManualKerberos,
         icon: "repeat",
         onClick: () => {
           doAction({
@@ -321,6 +370,7 @@ export function Hosts() {
           doAction({
             action: "deleteHost",
             hostName: hostName,
+            clusterName: clusterName,
             host: get(allHostModels, "[0]"),
             clusterComponents: get(clusterComponents, "items", []),
             serviceModels: serviceModels,
@@ -329,6 +379,7 @@ export function Hosts() {
             putConfigsToServer,
             clearConfigsChanges,
             loadComponentRelatedConfigs,
+            groupedPropertiesToChange,
           });
         },
       });
@@ -369,11 +420,6 @@ export function Hosts() {
   };
 
   const getClients = () => {
-    // Only return client configs if user has permission to view configs
-    if (!canViewConfigs) {
-      return [];
-    }
-
     let clients: any[] = [];
     const hostName = get(allHostModels, "[0].hostName", "");
     const hostComponents = get(allHostModels, "[0].hostComponents", []);
@@ -412,9 +458,8 @@ export function Hosts() {
   const buildHostActionsSubmenu = () => {
     const submenu = [...getMaintenanceOptions()];
 
-    // Add client configs download if user has permission and there are clients
     const clients = getClients();
-    if (canViewConfigs && clients.length > 0) {
+    if (clients.length > 0) {
       submenu.push({
         label: translate("services.service.actions.downloadClientConfigs"),
         submenu: clients,
@@ -482,13 +527,34 @@ export function Hosts() {
             </Nav>
           </Col>
           <Col className="d-flex justify-content-end">
-            {canShowHostActions && (
-              <NestedDropdown menu={hostActionsMenu} dropDirection="start" />
-            )}
+            <NestedDropdown menu={hostActionsMenu} dropDirection="start" />
           </Col>
         </Row>
         <Row>
-          {loading ? (
+          {hostData.error || clusterLoadError ? (
+            <Col className="p-4">
+              <Alert variant="danger">
+                {hostData.error || clusterLoadError}{" "}
+                <Button
+                  size="sm"
+                  variant="outline-danger"
+                  onClick={() => {
+                    if (hostData.error) {
+                      hostData.retry();
+                    }
+                    if (clusterLoadError) {
+                      setClusterRetryCount((value) => value + 1);
+                    }
+                  }}
+                >
+                  Retry
+                </Button>{" "}
+                <Button size="sm" variant="outline-secondary" onClick={() => navigate("/main/hosts")}>
+                  Back to Hosts
+                </Button>
+              </Alert>
+            </Col>
+          ) : loading || hostData.isLoading ? (
             <Spinner />
           ) : (
             <Col className="p-4">

--- a/ambari-web/latest/src/screens/Hosts/utils.tsx
+++ b/ambari-web/latest/src/screens/Hosts/utils.tsx
@@ -75,7 +75,7 @@ export const hostComponentCustomCommandMap = {
     ),
     label: translate("services.service.actions.run.rebalanceHdfsNodes"),
   },
-  TRANSITION_NAMENODE: {
+  MAKEOBSERVER: {
     action: "makeObserver",
     customCommand: "MAKEOBSERVER",
     context: translate("services.service.actions.run.makeObserver.context"),
@@ -183,50 +183,6 @@ export const addDeleteComponentsMap: any = {
     configTagsCallbackName: "loadRangerConfigs",
     configsCallbackName: "onLoadRangerConfigs",
   },
-};
-
-const serviceComponentMetrics = [
-  "host_components/metrics/jvm/memHeapUsedM",
-  "host_components/metrics/jvm/HeapMemoryMax",
-  "host_components/metrics/jvm/HeapMemoryUsed",
-  "host_components/metrics/jvm/memHeapCommittedM",
-  "host_components/metrics/mapred/jobtracker/trackers_decommissioned",
-  "host_components/metrics/cpu/cpu_wio",
-  "host_components/metrics/rpc/client/RpcQueueTime_avg_time",
-  "host_components/metrics/dfs/FSNamesystem/*",
-  "host_components/metrics/dfs/namenode/Version",
-  "host_components/metrics/dfs/namenode/LiveNodes",
-  "host_components/metrics/dfs/namenode/DeadNodes",
-  "host_components/metrics/dfs/namenode/DecomNodes",
-  "host_components/metrics/dfs/namenode/TotalFiles",
-  "host_components/metrics/dfs/namenode/UpgradeFinalized",
-  "host_components/metrics/dfs/namenode/Safemode",
-  "host_components/metrics/runtime/StartTime",
-];
-
-const serviceSpecificParams = {
-  FLUME: "host_components/processes/HostComponentProcess",
-  YARN:
-    "host_components/metrics/yarn/Queue," +
-    "host_components/metrics/yarn/ClusterMetrics/NumActiveNMs," +
-    "host_components/metrics/yarn/ClusterMetrics/NumLostNMs," +
-    "host_components/metrics/yarn/ClusterMetrics/NumUnhealthyNMs," +
-    "host_components/metrics/yarn/ClusterMetrics/NumRebootedNMs," +
-    "host_components/metrics/yarn/ClusterMetrics/NumDecommissionedNMs",
-  HBASE:
-    "host_components/metrics/hbase/master/IsActiveMaster," +
-    "host_components/metrics/hbase/master/MasterStartTime," +
-    "host_components/metrics/hbase/master/MasterActiveTime," +
-    "host_components/metrics/hbase/master/AverageLoad," +
-    "host_components/metrics/master/AssignmentManager/ritCount",
-  STORM:
-    "metrics/api/v1/cluster/summary,metrics/api/v1/topology/summary,metrics/api/v1/nimbus/summary",
-  HDFS: "host_components/metrics/dfs/namenode/ClusterId",
-  SSM: "host_components/processes/HostComponentProcess",
-};
-
-var requestsRunningStatus = {
-  updateServiceMetric: false,
 };
 
 export const populateHostComponentModels = (hostComponent: any) => {
@@ -376,14 +332,6 @@ export const getCardinalityValue = (
   }
 };
 
-export const isOozieServerAddable = () => {
-  return true; //TODO: get it from the context once it is implemented as of now it is hardcoded
-};
-
-export const isEnableHiveInteractive = () => {
-  return false; //TODO: get it from the context once it is implemented as of now it is hardcoded
-};
-
 export const sortBasedOnMasterSlave = (data: any, key: string) => {
   const masterComponents = data.filter(
     (component: any) => get(component, key, "") === ComponentType.MASTER
@@ -470,7 +418,8 @@ export const isDeletable = (component: IHostComponent, serviceModels: any) => {
 
 export const isDeleteComponentDisabled = (
   component: IHostComponent,
-  clusterComponents: any
+  clusterComponents: any,
+  hiveDatabaseType = "",
 ) => {
   const stackComponentCount = minToInstall(component);
   const componentName = getComponentName(component);
@@ -490,12 +439,7 @@ export const isDeleteComponentDisabled = (
     componentName === "MYSQL_SERVER" &&
     get(component, "serviceName", "") === "HIVE"
   ) {
-    const db_type = ["Existing"]; //TODO: visit it again, refer it from same method from file host_component_view.js in existing ambari - reading from configs file
-    if (db_type.includes("Existing") && status) {
-      return false;
-    } else {
-      return true;
-    }
+    return !(hiveDatabaseType.includes("Existing") && status);
   }
 
   if (componentName === "JOURNALNODE") {
@@ -577,17 +521,8 @@ export const getCustomCommands = (
   component: IHostComponent,
   clusterComponents: any
 ) => {
-  //TODO: Revisit this function
-  let commands: string[] = get(component, "customCommands", []);
+  const commands: string[] = get(component, "customCommands", []);
   let customCommands: any[] = [];
-
-  // Add MAKEOBSERVER command for NAMENODE components
-  if (getComponentName(component) === "NAMENODE" && 
-      get(component, "workStatus", "") === ComponentStatus.STARTED) {
-    if (!commands.includes("MAKEOBSERVER")) {
-      commands = [...commands, "MAKEOBSERVER"];
-    }
-  }
 
   commands.forEach((command: string) => {
     if (
@@ -604,6 +539,7 @@ export const getCustomCommands = (
       component: get(component, "componentName", ""),
       command: command,
       context: get(hostComponentCustomCommandMap, command + ".context", ""),
+      disabled: get(hostComponentCustomCommandMap, command + ".disabled", false),
     });
   });
   return customCommands;
@@ -1244,7 +1180,12 @@ export const installHostComponentCall = async (
   const updatedComponent = { ...component, hostName: hostName };
 
   try {
-    updateAndCreateServiceComponent(componentName, data, clusterName);
+    await ensureServiceComponent(
+      componentName,
+      get(component, "serviceName", ""),
+      data,
+      clusterName
+    );
     const payload = {
       RequestInfo: {
         context:
@@ -1265,9 +1206,17 @@ export const installHostComponentCall = async (
       hostName,
       payload
     );
-    addNewComponentSuccessCallback(res, {}, { component: updatedComponent }, setAllHostModels);
+    await addNewComponentSuccessCallback(
+      res,
+      {},
+      { component: updatedComponent },
+      setAllHostModels
+    );
   } catch (error) {
-    console.log("error in updating and creating service component", error);
+    showErrorModal(
+      get(error, "response.data.message", get(error, "message", "Unable to add the host component."))
+    );
+    throw error;
   }
 };
 
@@ -1347,141 +1296,32 @@ const addNewComponentSuccessCallback = async (
   defaultSuccessCallbackWithoutReload(requestId);
 };
 
-const updateAndCreateServiceComponent = async(
+const ensureServiceComponent = async (
   componentName: string,
+  serviceName: string,
   data: any,
   clusterName: string
 ) => {
-  var url =
-    "/components/?fields=ServiceComponentInfo/service_name," +
-    "ServiceComponentInfo/category,ServiceComponentInfo/installed_count,ServiceComponentInfo/started_count,ServiceComponentInfo/init_count,ServiceComponentInfo/install_failed_count,ServiceComponentInfo/unknown_count,ServiceComponentInfo/total_count,ServiceComponentInfo/display_name,host_components/HostRoles/host_name&minimal_response=true";
-  try {
-    await HostsApi.updateComponentsState(clusterName, url);
-    updateServiceMetric(
-      componentName,
-      data,
-      createServiceComponent,
-      clusterName
-    );
-  } catch (error) {
-    console.log("error in updating and creating service component", error);
-  }
-};
-
-const getConditionalFields = (data: any) => {
-  let conditionalFields = serviceComponentMetrics.slice(0);
-  let serviceParams = cloneDeep(serviceSpecificParams);
-  set(serviceParams, "ONEFS", "metrics/*,");
-
-  data.services.forEach((service: any) => {
-    const urlParams = get(serviceParams, service.ServiceInfo.service_name);
-    if (urlParams) {
-      conditionalFields.push(urlParams);
-    }
-  });
-
-  return conditionalFields;
-};
-
-const isComponentPresent = (
-  componentName: string,
-  allServiceComponents: any
-) => {
-  return allServiceComponents.items?.some((item: any) => {
+  const allServiceComponents = get(data, "clusterComponents", {});
+  const isPresent = get(allServiceComponents, "items", []).some((item: any) => {
     return get(item, "ServiceComponentInfo.component_name") === componentName;
   });
-};
-
-const updateServiceMetric = async (
-  componentName: string,
-  data: any,
-  callback: Function,
-  clusterName: string
-) => {
-  const isATSPresent = isComponentPresent(
-    "APP_TIMELINE_SERVER",
-    data.clusterComponents
-  );
-  const isHaEnabled = false;
-
-  const conditionalFields = getConditionalFields(data);
-  const conditionalFieldsString =
-    conditionalFields.length > 0 ? "," + conditionalFields.join(",") : "";
-  const isFlumeInstalled = data.services.filter(
-    (service: any) => service.ServiceInfo.service_name === "FLUME"
-  );
-  const isATSInstalled =
-    data.services.filter(
-      (service: any) => service.ServiceInfo.service_name === "YARN"
-    ) && isATSPresent;
-  const flumeHandlerParam = isFlumeInstalled
-    ? "ServiceComponentInfo/component_name=FLUME_HANDLER|"
-    : "";
-  const atsHandlerParam = isATSInstalled
-    ? "ServiceComponentInfo/component_name=APP_TIMELINE_SERVER|"
-    : "";
-  const haComponents = isHaEnabled
-    ? "ServiceComponentInfo/component_name=JOURNALNODE|ServiceComponentInfo/component_name=ZKFC|"
-    : "";
-  const url =
-    "/components/?" +
-    flumeHandlerParam +
-    atsHandlerParam +
-    haComponents +
-    "ServiceComponentInfo/category.in(MASTER,CLIENT)&fields=" +
-    "ServiceComponentInfo/service_name," +
-    "host_components/HostRoles/display_name," +
-    "host_components/HostRoles/host_name," +
-    "host_components/HostRoles/public_host_name," +
-    "host_components/HostRoles/state," +
-    "host_components/HostRoles/maintenance_state," +
-    "host_components/HostRoles/stale_configs," +
-    "host_components/HostRoles/ha_state," +
-    "host_components/HostRoles/desired_admin_state," +
-    conditionalFieldsString +
-    "&minimal_response=true";
-
-  if (!requestsRunningStatus.updateServiceMetric) {
-    requestsRunningStatus.updateServiceMetric = true;
-    try {
-      await HostsApi.updateServiceMetric(clusterName, url);
-      requestsRunningStatus.updateServiceMetric = false;
-      callback(componentName, data, clusterName);
-    } catch (error) {
-      console.log("error in updating service metric", error);
-    }
-  } else {
-    callback(componentName, data, clusterName);
-  }
-};
-
-const createServiceComponent = (
-  componentName: string,
-  data: any,
-  clusterName: string
-) => {
-  const allServiceComponents = data.clusterComponents;
-
-  if (
-    allServiceComponents &&
-    isComponentPresent(componentName, allServiceComponents)
-  ) {
+  if (isPresent) {
     return;
-  } else {
-    const payload = {
-      components: [
-        {
-          ServiceComponentInfo: {
-            component_name: componentName,
-          },
-        },
-      ],
-    };
-    const serviceName = allServiceComponents.items.find((item: any) => {
-      return item.ServiceComponentInfo.component_name === componentName;
-    }).ServiceComponentInfo.service_name;
-    HostsApi.commonCreateComponent(clusterName, serviceName, payload);
   }
+  if (!serviceName) {
+    throw new Error(`Unable to determine the service for ${componentName}.`);
+  }
+  const payload = {
+    components: [
+      {
+        ServiceComponentInfo: {
+          component_name: componentName,
+        },
+      },
+    ],
+  };
+  await HostsApi.commonCreateComponent(clusterName, serviceName, payload);
 };
 
 export function getServiceByConfigTypeMap(stackServices: any) {

--- a/ambari-web/latest/src/screens/Services/AddWizardUrlMapping.tsx
+++ b/ambari-web/latest/src/screens/Services/AddWizardUrlMapping.tsx
@@ -105,12 +105,11 @@ function AddHostWizardModal() {
               </div>
             }
             onClose={() => {
-              flushStateToDb("cancel");
               modalManager.hide();
             }}
-            successCallback={() => {
+            successCallback={async () => {
+              await flushStateToDb("cancel");
               modalManager.hide();
-              window.location.href = "/#/main/hosts";
             }}
           />
         );

--- a/docs/frontend-refactor/react-current/03-hosts-gap.md
+++ b/docs/frontend-refactor/react-current/03-hosts-gap.md
@@ -1,0 +1,206 @@
+<!---
+   Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+
+# React Hosts Comparison
+
+## Comparison Scope
+
+| Item | Value |
+| --- | --- |
+| Ember baseline | `ember-baseline/03-hosts.md` |
+| React implementation | `ambari-web/latest`, module 03 work based on `c01b54be25` |
+| Feature IDs | `HOST-LIST-001` through `HOST-ADD-008` |
+| Review date | 2026-08-14 |
+| Metrics boundary | Host Metrics, metric charts, metric filters/data, and `HOST-TAB-005` are excluded |
+
+The comparison used the corrected Ember baseline, classic source, React source, AJAX definitions and call sites, direct HTTP calls, browser entry points, and realtime inventories. The heuristic `generated/api-by-module/hosts.md` inventory was used only as a search aid.
+
+## Current Conclusion
+
+| Status | Count |
+| --- | ---: |
+| `NEEDS_RUNTIME_VALIDATION` | 46 |
+| `PARTIAL` | 3 |
+| `NOT_REQUIRED` | 4 |
+| `OUT_OF_SCOPE` | 1 |
+| Total | 54 |
+
+No known static implementation gap remains in the 46 runtime-gated IDs. `HOST-LIST-005`, `HOST-BULK-010`, and `HOST-COMP-009` retain explicit boundaries described below. The four `NOT_REQUIRED` IDs are classic placeholders or broken unreachable behavior and must not be recreated in React.
+
+## Feature Status
+
+### List, Search, and Selection
+
+| ID | Status | React implementation and remaining boundary |
+| --- | --- | --- |
+| `HOST-LIST-001` | `NEEDS_RUNTIME_VALIDATION` | Server paging/sorting, host/component/version mapping, totals, health, maintenance, selection, realtime convergence, serialized polling, and recoverable failures are implemented |
+| `HOST-LIST-002` | `NEEDS_RUNTIME_VALIDATION` | Host, component, state, stale-config, maintenance, and version predicates are built through the classic field/type map; stack-version visibility now applies classic older/compatible rules |
+| `HOST-LIST-003` | `NEEDS_RUNTIME_VALIDATION` | Combo facets, multi-values, lazy host suggestions, regex escaping, field allowlisting, and Axios override-body request shape are implemented |
+| `HOST-LIST-004` | `NEEDS_RUNTIME_VALIDATION` | Row and current-page select-all operations preserve selected host names across paging/filter changes and drive Selected/Filtered/All counts and targets |
+| `HOST-LIST-005` | `PARTIAL` | Host, alert, component, and version navigation entry points work; arbitrary Combo Search state is not yet restored after leaving and returning to Hosts |
+| `HOST-LIST-006` | `NOT_REQUIRED` | Classic contains no Hosts export entry point or backend contract |
+
+### Bulk Operations
+
+| ID | Status | React implementation and remaining boundary |
+| --- | --- | --- |
+| `HOST-BULK-001` | `NEEDS_RUNTIME_VALIDATION` | Start/stop/restart eligibility, skip sets, immediate/scheduled requests, progress, and multi-NameNode checkpoint protection are implemented |
+| `HOST-BULK-002` | `NEEDS_RUNTIME_VALIDATION` | Host maintenance authorization, no-op filtering, stack mismatch warning, update, and feedback are implemented |
+| `HOST-BULK-003` | `NOT_REQUIRED` | Classic has no bulk component-maintenance operation; React correctly does not invent one |
+| `HOST-BULK-004` | `NEEDS_RUNTIME_VALIDATION` | DataNode, NodeManager, and RegionServer decommission/recommission paths preserve their distinct checks and request flows |
+| `HOST-BULK-005` | `NEEDS_RUNTIME_VALIDATION` | Install/reinstall component/client filtering, KDC session gating, request submission, and progress are implemented |
+| `HOST-BULK-006` | `NEEDS_RUNTIME_VALIDATION` | Stale client config refresh/configure selection and request execution are implemented |
+| `HOST-BULK-007` | `NEEDS_RUNTIME_VALIDATION` | Set Rack is exposed through the classic outer Host Actions gate and submits only validated changes |
+| `HOST-BULK-008` | `NEEDS_RUNTIME_VALIDATION` | Bulk host-deletion dry run, last/non-addable/running component checks, skipped hosts, confirmation, and result reporting are implemented |
+| `HOST-BULK-009` | `NEEDS_RUNTIME_VALIDATION` | Component deletion is available for Selected and Filtered, deliberately absent for All, and enforces state/minimum-count checks and dry-run results |
+| `HOST-BULK-010` | `PARTIAL` | Immediate/scheduled request creation and progress are present; complete pending-schedule/wizard/upgrade conflict enforcement remains shared with module 02 and owning flows |
+
+### Host Details and Actions
+
+| ID | Status | React implementation and remaining boundary |
+| --- | --- | --- |
+| `HOST-DETAIL-001` | `NEEDS_RUNTIME_VALIDATION` | Non-Metrics host identity, health, rack, OS, uptime, capacity summaries, and component state/actions are mapped |
+| `HOST-DETAIL-002` | `NEEDS_RUNTIME_VALIDATION` | Rack validation, confirmation, update, and model refresh are implemented |
+| `HOST-DETAIL-003` | `NEEDS_RUNTIME_VALIDATION` | Host maintenance permission, impact/version warning, request, and feedback are implemented |
+| `HOST-DETAIL-004` | `NEEDS_RUNTIME_VALIDATION` | Deletability checks, special-component configuration loading, sequential component deletion, configuration write, and final host deletion stop on the first failure |
+| `HOST-DETAIL-005` | `NEEDS_RUNTIME_VALIDATION` | Recover Host validates component states, submits ordered INIT/INSTALLED batches, obtains KDC state, regenerates keytabs for Kerberos, and opens progress |
+| `HOST-DETAIL-006` | `NEEDS_RUNTIME_VALIDATION` | Single-client and all-client archive URLs use the correct resource scopes; blocked popups no longer cause a null `focus()` call |
+| `HOST-DETAIL-007` | `NEEDS_RUNTIME_VALIDATION` | Entry requires enabled non-manual Kerberos plus `regenerateKeytabsOnSingleHost`; like classic it has no invented UI authorization gate and relies on backend authorization |
+| `HOST-DETAIL-008` | `NEEDS_RUNTIME_VALIDATION` | Start/stop/restart-all excludes clients, honors heartbeat and permission state, checks every selected NameNode checkpoint, loads the configured HDFS user for recovery instructions, and opens the returned request once |
+| `HOST-DETAIL-009` | `NEEDS_RUNTIME_VALIDATION` | Admin/Operator Check Host confirmation, task creation/polling, categorized warnings, rerun, failure, and cleanup are present and remain separate from Recover Host |
+| `HOST-DETAIL-010` | `NOT_REQUIRED` | The classic log donut uses random placeholder data and is not reproduced |
+
+### Host Component Actions
+
+| ID | Status | React implementation and remaining boundary |
+| --- | --- | --- |
+| `HOST-COMP-001` | `NEEDS_RUNTIME_VALIDATION` | Per-component start/stop/restart state, maintenance, heartbeat, permission, confirmation, and progress behavior are implemented |
+| `HOST-COMP-002` | `NEEDS_RUNTIME_VALIDATION` | Install/reinstall creates or associates the host component before installation and propagates request failures |
+| `HOST-COMP-003` | `NEEDS_RUNTIME_VALIDATION` | Optional-component cardinality/dependency/host checks, recommendation UI, host selection, configuration rework, component-authoritative service selection, Oozie/Hive config gates, and the HDFS/Ozone exclusion are implemented |
+| `HOST-COMP-004` | `NEEDS_RUNTIME_VALIDATION` | Last-instance/state validation, JournalNode routing, recommendation/config updates, deletion, and error propagation are implemented |
+| `HOST-COMP-005` | `NEEDS_RUNTIME_VALIDATION` | Slave decommission/recommission and HDFS/HBase/YARN-specific safety checks are implemented |
+| `HOST-COMP-006` | `NEEDS_RUNTIME_VALIDATION` | Component maintenance visibility accepts the classic Service or Host permission path and refreshes after update |
+| `HOST-COMP-007` | `NEEDS_RUNTIME_VALIDATION` | Refresh-config actions use stack metadata/stale state and track their request |
+| `HOST-COMP-008` | `NEEDS_RUNTIME_VALIDATION` | Stack-defined custom commands preserve service/component/host filters and request progress |
+| `HOST-COMP-009` | `PARTIAL` | Eligible Move Master entries navigate to the Reassign Master flow; full Reassign behavior belongs to the later HA module |
+| `HOST-COMP-010` | `NEEDS_RUNTIME_VALIDATION` | Visible compatible host versions can be installed with exact payload, authorization, confirmation, duplicate lock, error Retry, optimistic state, and request progress |
+| `HOST-COMP-011` | `NOT_REQUIRED` | React does not reproduce classic's unreachable `UPGRADE_FAILED` action backed by an unregistered endpoint and hard-coded obsolete version |
+
+### Detail Tabs and Logs
+
+| ID | Status | React implementation and remaining boundary |
+| --- | --- | --- |
+| `HOST-TAB-001` | `NEEDS_RUNTIME_VALIDATION` | Host Configs loads only services assigned to the host, applies overrides/groups, hides all editing controls, and gates only config-group reassignment with `SERVICE.MANAGE_CONFIG_GROUPS` |
+| `HOST-TAB-002` | `NEEDS_RUNTIME_VALIDATION` | Host alert instances, filters, sorting, paging, service/definition links, serialized polling, Retry, and teardown are implemented |
+| `HOST-TAB-003` | `NEEDS_RUNTIME_VALIDATION` | Versions availability routing, classic visibility rules, filters, install authorization/payload/progress, and failure Retry are implemented |
+| `HOST-TAB-004` | `NEEDS_RUNTIME_VALIDATION` | Logs menu/route, metadata, filters, tail, copy/open, Log Search links, quick-link resolution, failure recovery, and polling cleanup are implemented |
+| `HOST-LOG-001` | `NEEDS_RUNTIME_VALIDATION` | Host logging resources are mapped by service/component/file with filters, sort, paging, and recoverable metadata failures |
+| `HOST-LOG-002` | `NEEDS_RUNTIME_VALIDATION` | Tail size changes, serialized two-second refresh, older-page loading, merge/deduplication, copy/open, Retry, dependency reset, and unmount cleanup are implemented |
+| `HOST-LOG-003` | `NEEDS_RUNTIME_VALIDATION` | LOGSEARCH quick-link resolution builds encoded host/component/path URLs for both log rows and the tail popup |
+| `HOST-LOG-004` | `NEEDS_RUNTIME_VALIDATION` | Loaded text is copied or opened locally with `textContent`; Hosts task logs reuse the module 02 Background Operations implementation |
+| `HOST-TAB-005` | `OUT_OF_SCOPE` | Host Metrics and all Metrics data are excluded |
+
+### Add Host Wizard
+
+| ID | Status | React implementation and remaining boundary |
+| --- | --- | --- |
+| `HOST-ADD-001` | `NEEDS_RUNTIME_VALIDATION` | Seven-step Add Host uses lowercase normalization, duplicate/installed handling, pattern/FQDN warnings, Linux SSH/manual modes, Windows PowerShell mode, support flags, and classic-compatible bootstrap fields |
+| `HOST-ADD-002` | `NEEDS_RUNTIME_VALIDATION` | Bootstrap launch/poll, registration wait, retry/remove, preinstalled checks, warning categories, rerun, skip boundaries, and timer cleanup are implemented |
+| `HOST-ADD-003` | `NEEDS_RUNTIME_VALIDATION` | Slave/client assignment uses installed metadata, dependencies, cardinality, and concrete client expansion |
+| `HOST-ADD-004` | `NEEDS_RUNTIME_VALIDATION` | Only selected component services load config groups; Default/non-default selection and the empty-component skip path are persisted |
+| `HOST-ADD-005` | `NEEDS_RUNTIME_VALIDATION` | Review summarizes hosts/components/groups, registers hosts and component associations, applies full config-group payload arrays, checkpoints stages, and exposes retryable failures |
+| `HOST-ADD-006` | `NEEDS_RUNTIME_VALIDATION` | Install and selected non-client start requests are polled without duplicate Strict Mode submissions; Kerberos keytabs regenerate between phases; failed phases and task logs are retryable. No explicit service-check request is invented |
+| `HOST-ADD-007` | `NEEDS_RUNTIME_VALIDATION` | Summary distinguishes success/warnings/failures, shows failed tasks, clears wizard state, and returns to Hosts without mutating cluster provisioning state |
+| `HOST-ADD-008` | `NEEDS_RUNTIME_VALIDATION` | Hydration, current step and phase/request persistence, serialized writes, resume, cancellation, completion cleanup, initialization errors, and Retry are implemented |
+
+## Backend Contract Comparison
+
+| Contract area | React behavior | Runtime gate |
+| --- | --- | --- |
+| Host list/details | Uses Ambari POST plus `X-Http-Method-Override: GET` predicates where required; maps host/component/version/log resources and realtime host/component/request events | Large clusters, paging totals, every predicate, slow requests, and REST/event races |
+| Host suggestions | Keeps paging/fields in Axios `params`, allowlists the field, regex-escapes input, and places the predicate in `RequestInfo.query` | Real server predicate parser, empty input, Unicode, large distinct sets, and 403/500 |
+| Host/component updates | Preserves `RequestInfo.context`, operation level, query, desired state/admin/maintenance state, and returned `Requests.id` | Every component state, no-op/synchronous response, permission denial, and backend validation |
+| Bulk schedules | Preserves host/component filters, immediate and scheduled batches, intervals/tolerance, dry runs, skip sets, and progress identity | Pending schedules, collisions with wizard/upgrade, partial execution, cancellation, and long batches |
+| Host/component deletion | Uses component DELETE, config reconfiguration, dry-run host/component bulk DELETE, and final host DELETE without continuing after a failed prerequisite | Last master, special masters, unknown components, partial dry-run result, config failure, and concurrent state changes |
+| Check/Recover Host | Uses preinstalled check task create/poll separately from ordered recovery batches and Kerberos regeneration | Every warning family, rerun, heartbeat loss, mixed component states, KDC expiry, and task failure |
+| Alerts | Loads `/clusters/{cluster}/alerts` with exact host filtering and periodic refresh | High alert volume, maintenance states, deleted definitions, and route teardown |
+| Host stack versions | Loads compatible repository versions, applies classic visibility, and POSTs exact `HostStackVersions` install payload | Cross-stack compatibility, support flag, older versions, all states, permissions, and install failures |
+| Host Configs/groups | Loads stack configurations/themes, current values, host services, and full service config groups; PUTs complete group-array payloads for membership transitions | Default/non-default moves, multiple services/groups, final/hidden/custom/widget properties, 403, and concurrent edits |
+| Host logs | Loads host logging metadata and `/logging/searchEngine` tail pages; resolves LOGSEARCH quick links/config and opens encoded external URLs | Real log payload fields, rotation, pagination ordering, quick-link overrides/HTTPS, clipboard and popup blocking |
+| Add Host bootstrap | POSTs `/bootstrap`, polls `/bootstrap/{requestId}`, waits for registration, then runs preinstalled checks | Linux SSH users/ports/keys, manual Agent, Windows PowerShell, mixed success, timeout, retry, and removal |
+| Add Host deployment | Registers hosts, associates component groups, PUTs full config groups, installs and starts selected components, regenerates Kerberos keytabs, and polls request/tasks | Multi-service/client assignments, HA clusters, KDC renewal, partial phase failures, resume, cancellation, and browser reload |
+
+## Five Independent Audits
+
+| Pass | Independent entry | Findings | Result |
+| --- | --- | --- | --- |
+| 1. Feature and route inventory | Every baseline ID, Hosts menu, list row, detail action, tab, log popup, and all seven Add Host steps | Missing Logs UI, incomplete detail routes, generic Installer steps in Add Host, wrong action visibility, and unrecoverable load failures were found | All entry points are mapped; placeholders and Metrics are explicitly excluded; three cross-module/persistence boundaries remain named |
+| 2. API and payload reverse scan | Classic AJAX definitions/call sites, direct HTTP/browser calls, React APIs, predicates, IDs, operation levels, config groups, bootstrap, tasks, and quick links | Malformed host suggestion Axios shape, missing comma in fields, unencoded identifiers, wrong request ID shape, incomplete config-group payload, and missing compatible-version/log-search contracts were found | Exact request construction and response identity are covered by API/utility tests and the runtime contract table |
+| 3. Permission, state, and destructive sequencing | Every classic authorization wrapper and indirect action-map condition; selection modes; delete/install/reconfigure ordering | Baseline incorrectly claimed keytab authorization, bulk component maintenance, editable Host Configs, and Add Host service checks; React hid actions incorrectly and could continue after failed component/config work | Baseline corrected; action gates match classic; component/host deletion and Add Host stages stop and retry at failures |
+| 4. Async, realtime, HA, Kerberos, and persistence | Poll overlap/cleanup, socket convergence, multi-NameNode checks, KDC sessions/keytabs, wizard hydration/write ordering, Strict Mode, cancellation, retry | Polls could overlap/leak, multi-NameNode checkpoint checks were skipped, stage labels could persist stale text, config-group failure was silent in classic, and stale wizard writes could follow cleanup | Polling and persistence are serialized; lifecycle cleanup and stage checkpoints are explicit; React deliberately blocks on config-group failure |
+| 5. Executable acceptance and regression scan | Focused utility/API/component tests, TypeScript build, full test/build/lint commands, diff checks, and runtime scenario design | Static reading alone could not prove request shapes, failure stops, compatibility filtering, task polling, or Strict Mode behavior | Targeted tests cover high-risk boundaries; full repository verification and the real-cluster matrix remain mandatory |
+
+## Compatibility Decisions
+
+| Classic behavior or defect | React decision |
+| --- | --- |
+| Add Host starts installation even when an unawaited config-group PUT fails silently | Stop before installation, show the backend error, retain completed checkpoints, and retry only the failed/remaining stages |
+| Add Host Windows plus `customizeAgentUserAccount=true` can validate a hidden empty Agent user | Do not mount or validate Linux-only fields in Windows PowerShell mode |
+| Direct Logs URL bypasses installed-LOGSEARCH and `SERVICE.VIEW_OPERATIONAL_LOGS` menu conditions | Apply the complete menu condition to direct React navigation rather than preserving the classic gate gap |
+| Log text is written with `document.write()` | Open a local `pre` and assign `textContent`; use `noopener noreferrer` for Log Search links |
+| Host/component destructive callbacks can lose rejected promises | Await each prerequisite, surface its backend message, and never delete the host after a component/config failure |
+| `UPGRADE_FAILED` component action calls an unregistered obsolete endpoint | Do not expose or implement the broken action |
+| A host-version compatibility model may not be loaded when Hosts maps versions | Fetch the compatible repository set before mapping and apply the same older/cross-stack visibility rule deterministically |
+
+## Automated Evidence
+
+Focused coverage includes:
+
+* Host event/component/request convergence, maintenance transitions, predicate escaping, stack-version compatibility, and destructive sequencing.
+* Host suggestions, alerts, stack-version installation/compatibility, bootstrap, config groups, host logs, and KDC mode API shapes.
+* Serialized polling failure/retry/unmount behavior.
+* Host Alerts and Stack Versions filters, permissions, install failure recovery, and progress.
+* Host Configs read-only controls, service-specific groups, Default/non-default transitions, authorization, and Retry.
+* Add Host input helpers, assignments, config-group payloads, deployment failure checkpoints, Strict Mode polling, unmount cleanup, and completion semantics.
+* Multi-NameNode checkpoints and configured HDFS-user instructions, Selected/Filtered/All bulk targeting, component-delete visibility, failure-stop sequencing, config-driven optional-component selection, Log Search encoding, and log-tail teardown.
+
+## Runtime Acceptance Matrix
+
+1. Load 0, 1, 10, 11, hundreds, and thousands of hosts; page, sort, filter, select, receive host/component/request events, and inject slow/failed responses.
+2. Exercise every Combo Search facet/operator/multi-value, regex metacharacters, empty suggestions, service/component/version route filters, and filter return-navigation behavior.
+3. Run Selected, Filtered, and All bulk actions; verify the exact target set and that component Delete exists only for Selected/Filtered.
+4. Start, stop, restart, install, refresh, decommission, recommission, maintain, set rack, and delete with eligible, skipped, no-op, heartbeat-lost, maintenance, and permission-denied targets.
+5. Stop/restart one and multiple NameNodes with recent, old, missing, failed, active, and standby checkpoint responses; ensure one warning/operation submission.
+6. Delete a component and host with last-master, running, unknown, special reconfiguration, config-load, config-save, component-delete, and host-delete failures.
+7. Recover hosts with every allowed/disallowed component-state mix in simple and Kerberized clusters, including expired KDC sessions and keytab failure.
+8. Validate Host Actions and component actions as Cluster User, service operator, cluster operator, cluster administrator, and Ambari administrator during normal, upgrade, wizard, and heartbeat-loss states.
+9. Validate single/all client-config downloads, encoded names, browser popup blocking, and archive contents.
+10. Run Check Host with every warning category, no warnings, create/poll failure, rerun, close, route change, and slow task response.
+11. Load Host Configs for zero/one/many services and groups; move Default to non-default, between non-default groups, and back; cover 403/500, concurrent changes, hidden/final/custom/widget properties, and role visibility.
+12. Load and mutate host alerts while sorting/filtering/paging; navigate to service and definition; leave during a slow poll and verify teardown.
+13. Validate same-stack older/current/newer versions, compatible/incompatible cross-stack versions, `displayOlderVersions`, all host states, install permission, 202/no-ID/error responses, and progress.
+14. Load logs with missing metadata, many services/components/files, `.log`/`.out`, log rotation, duplicate pages, tail-size changes, older pages, slow/failing polls, Retry, copy/open, and unmount.
+15. Resolve HTTP/HTTPS and overridden LOGSEARCH quick links; open row/tail links and verify exact host/component/path selection and `noopener` isolation.
+16. Add Linux hosts using root/non-root SSH, custom port, valid/invalid keys, manual Agent registration, patterns, mixed installed/new hosts, lowercase/duplicate names, and all-installed rejection.
+17. Add Windows hosts through PowerShell Remoting with `customizeAgentUserAccount` both false and true; confirm hidden Linux fields never block continuation.
+18. Run bootstrap with mixed success/failure/timeout, retry/remove, late Agent registration, skipped checks, every environment warning, rerun, and route/modal cleanup.
+19. Assign multiple slaves and concrete clients across services and config groups; cover no components, Default, existing non-default groups, dependency/cardinality limits, and missing metadata.
+20. Fail and retry every Review/Install/Start/Kerberos/config-group phase; reload between phases; use Strict Mode; inspect task logs; cancel/complete while writes are queued; verify no stale state or provisioning-state mutation.
+21. Exercise immediate and scheduled batches with pending schedule, wizard, upgrade, partial batch, cancellation, request/schedule identity, and Background Operations progress.
+22. Enter Add Host and Logs through both menus and direct URLs to confirm the documented classic and intentional React authorization boundaries.
+
+No `NEEDS_RUNTIME_VALIDATION` item may be changed to `COVERED` until its applicable matrix cases pass against a real Ambari Server.

--- a/docs/frontend-refactor/react-current/issues/03-hosts.md
+++ b/docs/frontend-refactor/react-current/issues/03-hosts.md
@@ -1,0 +1,114 @@
+<!---
+   Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+
+## Problem
+
+The React Hosts module does not yet provide a reliable equivalent to the classic Ember UI. Host list data and realtime events can diverge, failures can leave pages permanently loading, bulk target queries and action visibility do not consistently match Selected/Filtered/All semantics, and destructive component/host operations may continue after a failed prerequisite.
+
+Host Details also lacks complete routing, permission, checkpoint, Kerberos, Check/Recover Host, Alerts, Stack Versions, Host Configs, and Logs behavior. Host Configs incorrectly exposes editing concepts even though classic Host mode is read-only. Host Stack Version rows do not apply classic older-version and cross-stack compatibility visibility. Host Logs lacks complete metadata/tail lifecycle and Log Search navigation.
+
+The Add Host flow reuses generic Installer steps and misses critical Add Host-specific behavior across Linux SSH, manual Agent registration, Windows PowerShell Remoting, bootstrap, environment checks, slave/client assignment, config groups, deployment checkpoints, installation/start polling, Kerberos keytabs, retries, summary, persistence, cancellation, and completion.
+
+This issue covers the complete non-Metrics Hosts module defined by the corrected classic baseline. Host Metrics, metric charts, and Metrics APIs are not part of the scope.
+
+## Scope
+
+* Reconcile paged Host REST data with host-component, host, and completed decommission/recommission events without losing false, zero, OFF, or multi-host updates.
+* Preserve server paging/sorting, Combo Search predicates, lazy suggestions, regex safety, Selected/Filtered/All target construction, counts, and action visibility.
+* Add recoverable loading and request failures and ensure pollers schedule only after the current request settles and clean up on dependency change or unmount.
+* Match bulk start/stop/restart, host maintenance, decommission/recommission, install/reinstall, configure, set rack, host deletion, component deletion, and immediate/scheduled request behavior.
+* Check every affected NameNode checkpoint before stop/restart and submit the protected operation only once.
+* Match Host Details routes and Host/component action permission, heartbeat, maintenance, state, cardinality, dependency, recommendation, reconfiguration, and progress boundaries.
+* Stop component/host deletion after the first failed component, configuration load, configuration save, or backend delete request.
+* Preserve separate Check Host and Recover Host flows, including warning categories, rerun, ordered recovery, KDC session checks, and keytab regeneration.
+* Make Host Configs service-specific and read-only, map assigned config groups/overrides, and gate only config-group reassignment with `SERVICE.MANAGE_CONFIG_GROUPS`.
+* Implement Host Alerts polling/filtering/navigation and Host Stack Version visibility, filtering, authorization, installation, Retry, and request progress.
+* Implement Host Logs metadata, filters, sorting, paging, tail/older rows, merge/deduplication, copy/open, serialized polling, cleanup, error Retry, and encoded Log Search quick-link navigation.
+* Replace generic Installer Review/Install/Summary reuse with Add Host-specific steps and exact stage persistence.
+* Match Add Host Linux SSH/manual modes, Windows PowerShell behavior, support flags, hostname normalization/validation, installed-host handling, bootstrap polling, registration, checks, retry, and removal.
+* Expand generic clients to concrete components, preserve service ownership, assign config groups with full array payloads, and block installation on failed prerequisites.
+* Install then start only selected non-client components, regenerate Kerberos keytabs between phases, poll tasks, expose logs, retry failed phases, and prevent duplicate Strict Mode requests.
+* Complete with a success/warning/failure summary, clear persisted state, return to Hosts, and never apply the new Installer provisioning-state mutation.
+* Add focused tests for APIs, predicates, event reconciliation, permissions, version visibility, config groups, destructive sequencing, bulk targeting, Add Host stages, polling, persistence, logs, and failure recovery.
+
+## Classic UI Baseline
+
+The acceptance baseline is `docs/frontend-refactor/ember-baseline/03-hosts.md`, feature IDs `HOST-LIST-001` through `HOST-ADD-008`. The detailed React comparison, five-pass audit, backend contracts, compatibility decisions, and runtime matrix are recorded in `docs/frontend-refactor/react-current/03-hosts-gap.md`.
+
+The baseline was corrected during the audit:
+
+* Classic has no bulk Component Maintenance operation; bulk `PASSIVE_STATE` is host-level.
+* Host keytab regeneration has indirect manual-Kerberos visibility but no explicit UI authorization gate.
+* Host Configs properties are always read-only; only config-group reassignment is permission-gated.
+* Add Host starts selected host components but does not explicitly request service checks.
+
+The authoritative network comparison includes global AJAX definitions/call sites, direct HTTP calls, browser entry points, realtime destinations, bootstrap/check requests, config groups, logging/quick links, and host/component/version operations.
+
+## Acceptance Criteria
+
+* Host list paging, sorting, filters, counts, and selections converge with realtime updates and expose Retry without overlapping requests or orphan timers.
+* Suggestion requests use an allowlisted field, escaped predicate, Axios query params, and `X-Http-Method-Override` body with no malformed or double-encoded query.
+* Selected, Filtered, and All operations target exactly their intended hosts; component deletion is offered for Selected/Filtered and not All.
+* Bulk and detail actions match classic permission/state/maintenance/heartbeat rules and open only real returned request IDs.
+* Every affected NameNode is checked; old or unavailable checkpoints produce one warning and one eventual callback.
+* Host/component destructive flows never continue after a failed prerequisite and display the backend error.
+* Check Host, Recover Host, client downloads, keytab regeneration, rack changes, host maintenance, and start/stop/restart-all match their documented independent boundaries.
+* Optional components use their own service metadata, validate dependencies/cardinality and Oozie/Hive/Ozone configuration gates, carry rejected promises, and apply selected configuration recommendations before install.
+* Host Configs contains no add/remove/final/undo/widget editing controls, shows only host services, maps groups/overrides, and performs complete Default/non-default membership transitions under the exact permission.
+* Host Alerts stop polling on exit and Host Stack Versions apply older/cross-stack compatibility before display and submit exact install payloads with recoverable failure.
+* Host Logs can filter and tail files, load older rows, copy/open safe text, stop polling on close, and open encoded Log Search URLs from both row and popup.
+* Add Host handles Linux automatic/manual and Windows modes, validates and normalizes hosts, polls bootstrap/registration/checks, supports retry/remove, and cleans every timer.
+* Add Host Review reports concrete components/groups, persists completed checkpoints, blocks on host/component/config-group/install failures, and retries only remaining work.
+* Add Host Install polls install/start tasks, regenerates keytabs in Kerberos mode, prevents duplicate phase requests, exposes failed-task logs and Retry, and does not invent an explicit service-check request.
+* Add Host Summary reports final outcomes, clears wizard persistence, returns to Hosts, and does not mutate cluster provisioning state.
+* Focused tests cover high-risk request shapes, false/zero event values, multi-host decommission, compatibility filtering, permission controls, failure sequencing, bulk targeting, Strict Mode, unmount cleanup, Log Search encoding, and Add Host recovery.
+* The applicable runtime matrix in `docs/frontend-refactor/react-current/03-hosts-gap.md` passes against a real Ambari Server.
+
+## Partial Cross-Module Boundaries
+
+`HOST-LIST-005` remains partial because arbitrary Combo Search state is not restored after navigating away and back. Direct component/version route filters and ordinary navigation are implemented.
+
+`HOST-BULK-010` remains partial until all pending-schedule, wizard, and upgrade conflicts are enforced across their owning modules. This issue preserves existing immediate/scheduled request behavior and correct request/schedule identity.
+
+`HOST-COMP-009` remains partial because this module owns the eligible Move Master entry, while the complete Reassign Master wizard belongs to the HA module.
+
+## Out of Scope
+
+* Host Metrics, Metrics routes, charts, metric filters, metric polling, and Metrics APIs.
+* Classic's random Host Summary log-count donut placeholder.
+* A Hosts export feature, because classic contains no such entry or contract.
+* Bulk Component Maintenance, because classic exposes only bulk Host Maintenance.
+* The broken unreachable classic component Re-upgrade action and its unregistered obsolete endpoint.
+* Full Reassign Master, HA, upgrade, and global Request Schedule conflict workflows owned by later modules.
+
+## Compatibility Decisions
+
+The React implementation must not reproduce known unsafe or failure-prone classic behavior:
+
+* A failed Add Host config-group update blocks installation and is retryable instead of failing silently while deployment continues.
+* Windows mode does not validate hidden Linux Agent/SSH fields.
+* Direct Logs navigation applies the complete menu authorization/installation gate rather than preserving classic's direct-route gap.
+* Loaded logs are opened with `textContent` and external Log Search links use encoded values plus `noopener noreferrer`.
+* Destructive operations await every prerequisite and stop on rejection.
+* Incompatible or hidden host versions are computed deterministically before rendering.
+* The broken classic `UPGRADE_FAILED` component action is not implemented.
+
+These are intentional compatibility corrections, not missing parity.
+
+## Verification Boundary
+
+Static code and focused tests are not sufficient to mark this issue covered. Forty-six IDs remain `NEEDS_RUNTIME_VALIDATION`, and three IDs remain `PARTIAL`, until the real-cluster matrix covers large host sets, every permission role and component state, HA/Kerberos modes, schedules, destructive failures, config groups, alerts, stack compatibility, logs/quick links, Linux/manual/Windows Add Host modes, bootstrap/check failures, reload/resume/cancel, and every deployment phase.


### PR DESCRIPTION
## What changes were proposed in this pull request?

Complete non-Metrics Hosts parity across list and realtime behavior, bulk and detail actions, Host Configs, Alerts, Stack Versions, Logs, and the full Add Host workflow, with audited comparison documentation and focused regression coverage.

## How was this patch tested?

Passed the full Vitest suite (38 files, 134 tests), TypeScript project build, Vite production build, git diff check, credential scan, and Ember baseline validation. ESLint remains blocked by pre-existing branch-wide rule debt.

```shell
cd ambari-web/latest && npm test -- --run && npm exec tsc -- -b --pretty false && npm run build
```

docs/frontend-refactor/react-current/03-hosts-gap.md

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.