### PR TITLE
AMBARI-26629: Complete React cluster installation workflow parity

### DIFF
--- a/ambari-web/latest/package-lock.json
+++ b/ambari-web/latest/package-lock.json
@@ -27,6 +27,7 @@
         "i18next-browser-languagedetector": "^8.1.0",
         "isomorphic-dompurify": "^2.26.0",
         "js-cookie": "^3.0.5",
+        "jszip": "^3.10.1",
         "lodash": "^4.17.21",
         "rc-slider": "^11.1.9",
         "react": "^19.0.0",
@@ -3230,6 +3231,12 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+      "license": "MIT"
+    },
     "node_modules/cosmiconfig": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.1.0.tgz",
@@ -4392,6 +4399,12 @@
         "node": ">= 4"
       }
     },
+    "node_modules/immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
+      "license": "MIT"
+    },
     "node_modules/immutable": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.2.tgz",
@@ -4503,6 +4516,12 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
       "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "license": "MIT"
+    },
+    "node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
       "license": "MIT"
     },
     "node_modules/isexe": {
@@ -4957,6 +4976,18 @@
         "node": ">=6"
       }
     },
+    "node_modules/jszip": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
+      "integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
+      "license": "(MIT OR GPL-3.0-or-later)",
+      "dependencies": {
+        "lie": "~3.3.0",
+        "pako": "~1.0.2",
+        "readable-stream": "~2.3.6",
+        "setimmediate": "^1.0.5"
+      }
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -4979,6 +5010,15 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/lie": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+      "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "immediate": "~3.0.5"
       }
     },
     "node_modules/lines-and-columns": {
@@ -5253,6 +5293,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "license": "(MIT AND Zlib)"
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -5456,6 +5502,12 @@
       "dev": true,
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "license": "MIT"
     },
     "node_modules/prop-types": {
       "version": "15.8.1",
@@ -5820,6 +5872,27 @@
       "integrity": "sha512-anMuVoV//g2N76Wxqvqjjo1X48r9Np3y1/gMl7arX84tAPXdy5R7sB5lO5hvCzQRYjqXwV8XMAiEBOUbyrZFrw==",
       "license": "MIT"
     },
+    "node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/readable-stream/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
+    },
     "node_modules/readdirp": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
@@ -6040,6 +6113,12 @@
       "integrity": "sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ==",
       "license": "MIT"
     },
+    "node_modules/setimmediate": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
+      "license": "MIT"
+    },
     "node_modules/shallowequal": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/shallowequal/-/shallowequal-1.1.0.tgz",
@@ -6134,6 +6213,21 @@
       "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
       "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/string_decoder/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "license": "MIT"
     },
     "node_modules/strip-json-comments": {
@@ -6553,6 +6647,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
     },
     "node_modules/vite": {
       "version": "6.3.5",

--- a/ambari-web/latest/package.json
+++ b/ambari-web/latest/package.json
@@ -30,6 +30,7 @@
     "i18next-browser-languagedetector": "^8.1.0",
     "isomorphic-dompurify": "^2.26.0",
     "js-cookie": "^3.0.5",
+    "jszip": "^3.10.1",
     "lodash": "^4.17.21",
     "rc-slider": "^11.1.9",
     "react": "^19.0.0",

--- a/ambari-web/latest/src/Utils/wizardOwnership.ts
+++ b/ambari-web/latest/src/Utils/wizardOwnership.ts
@@ -1,0 +1,35 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import ClusterApi from "../api/clusterApi";
+import { persistedPayload } from "./persistedSettings";
+
+export type InstallationWizardController =
+  | "clusterCreation"
+  | "addHostController"
+  | "addServiceController";
+
+export const claimWizard = (
+  userName: string,
+  controllerName: InstallationWizardController,
+) => ClusterApi.postPersistData(persistedPayload({
+  "wizard-data": { userName, controllerName },
+}));
+
+export const releaseWizard = () =>
+  ClusterApi.postPersistData(persistedPayload({ "wizard-data": null }));

--- a/ambari-web/latest/src/api/kerberosApi.ts
+++ b/ambari-web/latest/src/api/kerberosApi.ts
@@ -31,6 +31,15 @@ const KerberosApi = {
     return response.data;
   },
 
+  getKerberosDescriptorArtifact: async function (clusterName: string) {
+    const url = `/clusters/${clusterName}/artifacts/kerberos_descriptor?fields=artifact_data`;
+    const response = await supressErrorAmbariApi.request({
+      url,
+      method: "GET",
+    });
+    return response.data;
+  },
+
   getSecurityType: async function (clusterName: string) {
     const url = `clusters/${clusterName}?fields=Clusters/security_type`;
     const response = await ambariApi.request({

--- a/ambari-web/latest/src/api/versionsApi.test.ts
+++ b/ambari-web/latest/src/api/versionsApi.test.ts
@@ -66,4 +66,47 @@ describe("versions API", () => {
       },
     });
   });
+
+  it("loads version definitions and operating systems for the selected stack", async () => {
+    await VersionsApi.getVersionDefinitions("HDP/name");
+    await VersionsApi.getVersionOperatingSystems("HDP/name", "3.1 version");
+
+    expect(mocks.request).toHaveBeenNthCalledWith(1, {
+      url: expect.stringContaining(
+        "VersionDefinition/stack_name=HDP%2Fname",
+      ),
+      method: "GET",
+    });
+    expect(mocks.request.mock.calls[0][0].url).not.toContain("_=");
+    expect(mocks.request).toHaveBeenNthCalledWith(2, {
+      url: "/stacks/HDP%2Fname/versions/3.1%20version?fields=operating_systems/repositories/Repositories",
+      method: "GET",
+    });
+  });
+
+  it("preserves exact VDF dry-run and final submission contracts", async () => {
+    const xml = "<repository-version/>";
+    await VersionsApi.readVersionInfo(
+      xml,
+      { "Content-Type": "text/xml" },
+    );
+    await VersionsApi.readVersionInfo(
+      { VersionDefinition: { version_url: "https://repo/vdf.xml" } },
+      {},
+      false,
+    );
+
+    expect(mocks.request).toHaveBeenNthCalledWith(1, {
+      url: "/version_definitions?dry_run=true",
+      method: "POST",
+      headers: { "Content-Type": "text/xml" },
+      data: xml,
+    });
+    expect(mocks.request).toHaveBeenNthCalledWith(2, {
+      url: "/version_definitions",
+      method: "POST",
+      headers: {},
+      data: { VersionDefinition: { version_url: "https://repo/vdf.xml" } },
+    });
+  });
 });

--- a/ambari-web/latest/src/api/versionsApi.ts
+++ b/ambari-web/latest/src/api/versionsApi.ts
@@ -34,6 +34,13 @@ const VersionsApi = {
     });
     return response.data;
   },
+  getStacks: async function () {
+    const response = await ambariApi.request({
+      url: "/stacks",
+      method: "GET",
+    });
+    return response.data;
+  },
   getClusterInfo: async function () {
     const url = `/clusters?fields=Clusters/cluster_id`;
     const response = await ambariApi.request({
@@ -42,8 +49,8 @@ const VersionsApi = {
     });
     return response.data;
   },
-  getVersionDefinitions: async function () {
-    const url = `/version_definitions?fields=VersionDefinition/stack_default,VersionDefinition/stack_repo_update_link_exists,VersionDefinition/max_jdk,VersionDefinition/min_jdk,operating_systems/repositories/Repositories/*,operating_systems/OperatingSystems/*,VersionDefinition/stack_services,VersionDefinition/repository_version&VersionDefinition/show_available=true&VersionDefinition/stack_name=VDP&_=1727429673209`;
+  getVersionDefinitions: async function (stackName: string) {
+    const url = `/version_definitions?fields=VersionDefinition/stack_default,VersionDefinition/stack_repo_update_link_exists,VersionDefinition/max_jdk,VersionDefinition/min_jdk,operating_systems/repositories/Repositories/*,operating_systems/OperatingSystems/*,VersionDefinition/stack_services,VersionDefinition/repository_version&VersionDefinition/show_available=true&VersionDefinition/stack_name=${encodeURIComponent(stackName)}`;
     const response = await ambariApi.request({
       url: url,
       method: "GET",
@@ -58,8 +65,11 @@ const VersionsApi = {
     });
     return response.data;
   },
-  getVersionOperatingSystems: async function (versionName: string) {
-    const url = `/stacks/VDP/versions/${versionName}?fields=operating_systems/repositories/Repositories`;
+  getVersionOperatingSystems: async function (
+    stackName: string,
+    versionName: string,
+  ) {
+    const url = `/stacks/${encodeURIComponent(stackName)}/versions/${encodeURIComponent(versionName)}?fields=operating_systems/repositories/Repositories`;
     const response = await ambariApi.request({
       url: url,
       method: "GET",
@@ -69,11 +79,14 @@ const VersionsApi = {
   readVersionInfo: async function (
     payload: any,
     headers = {},
-    isDryRun = true
+    isDryRun = true,
+    skipUrlCheck = false,
   ) {
-    const url = `/version_definitions?skip_url_check=true${
-      isDryRun ? "&dry_run=true" : ""
-    }`;
+    const query = [
+      isDryRun ? "dry_run=true" : "",
+      skipUrlCheck ? "skip_url_check=true" : "",
+    ].filter(Boolean).join("&");
+    const url = `/version_definitions${query ? `?${query}` : ""}`;
     const response = await ambariApi.request({
       url: url,
       method: "POST",
@@ -132,13 +145,15 @@ const VersionsApi = {
     return response.data;
   },
   postVersionDefinitionFile: async function postVersionDefinitionFile(
-    data: any
+    data: any,
+    headers = {},
   ) {
     const url = `/version_definitions`;
     const response = await ambariApi.request({
       url,
       method: "POST",
       data,
+      headers,
     });
     return response.data;
   },

--- a/ambari-web/latest/src/components/AddVersionModal.tsx
+++ b/ambari-web/latest/src/components/AddVersionModal.tsx
@@ -32,6 +32,12 @@ type ModalProps = {
     onReadVersion: Function
 }
 
+export type VersionDefinitionSource = {
+    type: 'xml' | 'url'
+    payload: string | { VersionDefinition: { version_url: string } }
+    headers?: Record<string, string>
+}
+
 const AddVersionModal = ({ isOpen, onClose, onReadVersion }: ModalProps) => {
     const [uploadOption, setUploadOption] = useState(ReadOptions.FILE)
     const [file, setFile] = useState<File | undefined>(undefined)
@@ -41,27 +47,41 @@ const AddVersionModal = ({ isOpen, onClose, onReadVersion }: ModalProps) => {
             if (uploadOption === ReadOptions.FILE && file) {
                 const reader = new FileReader()
                 reader.onload = async function (event) {
-                    const fileContents = get(event, 'target.result', undefined)
-                    const versionResources = await VersionsApi.readVersionInfo(
-                        fileContents,
-                        {
-                            'Content-Type': 'text/xml',
-                        },
-                    )
-                    onReadVersion(versionResources)
+                    try {
+                        const fileContents = get(event, 'target.result', '')
+                        if (typeof fileContents !== 'string') {
+                            throw new Error('The version definition file is not text.')
+                        }
+                        const headers = { 'Content-Type': 'text/xml' }
+                        const versionResources = await VersionsApi.readVersionInfo(
+                            fileContents,
+                            headers,
+                        )
+                        onReadVersion(versionResources, {
+                            type: 'xml',
+                            payload: fileContents,
+                            headers,
+                        } satisfies VersionDefinitionSource)
+                    } catch {
+                        toast.error('Could not read version definition')
+                    }
                 }
                 reader.readAsText(file)
             } else if (uploadOption === ReadOptions.URL && fileUrl) {
                 // Fetch the content from the URL
-                const versionResources = await VersionsApi.readVersionInfo({
+                const payload = {
                     VersionDefinition: {
                         version_url: fileUrl,
                     },
-                })
-                onReadVersion(versionResources)
+                }
+                const versionResources = await VersionsApi.readVersionInfo(payload)
+                onReadVersion(versionResources, {
+                    type: 'url',
+                    payload,
+                } satisfies VersionDefinitionSource)
             }
         } catch (err) {
-            toast.error('Could not read version defintion')
+            toast.error('Could not read version definition')
         }
     }
     const handleClose=()=>{

--- a/ambari-web/latest/src/components/AssignMasters.tsx
+++ b/ambari-web/latest/src/components/AssignMasters.tsx
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-import { useEffect, useReducer, useState } from "react";
+import { useEffect, useReducer, useRef, useState } from "react";
 import { Row, Col, Form, Card, Button, CardBody, Alert } from "react-bootstrap";
 import { ChooseServicesApi } from "../api/chooseServicesApi";
 import AssignMastersApi from "../api/assignMastersApi";
@@ -30,6 +30,11 @@ import { faMinus, faPlus } from "@fortawesome/free-solid-svg-icons";
 import { blueprintUtils } from "../screens/ClusterWizard/utils";
 import { maxToInstall, isMultipleAllowed } from "../screens/Hosts/utils";
 import { AssignMastersProps, Host, Masters, State, Action, ServicesResponse } from "../screens/ClusterWizard/types/AssignMastersTypes";
+import {
+  getMasterValidationMessages,
+  masterValidationKey,
+  MasterValidationMessages,
+} from "../screens/ClusterWizard/masterValidation";
 
 const initialState: State = {
   hosts: {},
@@ -78,6 +83,7 @@ export default function AssignMasters({
   installedServices,
   parentState,
   setCanProceed,
+  setHasValidationIssues = () => {},
 }: AssignMastersProps) {
   const [state, dispatch] = useReducer(reducer, get(
       parentState,
@@ -87,8 +93,9 @@ export default function AssignMasters({
   const [loading, setLoading] = useState(false);
   const [mastersData, setMastersData] = useState<Masters[]>([]);
   const [servicesAndComponents, setServicesAndComponents] = useState<ServicesResponse | null>(null);
-  const [generalErrorMessages, setGeneralErrorMessages] = useState<string[]>([]);
-  const [generalWarningMessages, setGeneralWarningMessages] = useState<string[]>([]);
+  const [validationMessages, setValidationMessages] =
+    useState<MasterValidationMessages>({});
+  const validationSequence = useRef(0);
   const notMasters = ["MYSQL_SERVER", "HIVE_SERVER_INTERACTIVE"];
 
   useEffect(() => {
@@ -185,29 +192,6 @@ export default function AssignMasters({
           sortedHostsData[hostname] = hostsData[hostname];
         });
 
-      // validations.
-      const validationPayload = {
-        hosts: hostnames,
-        validate: "host_groups",
-        recommendations: {
-          blueprint: {
-            configurations: null,
-            host_groups: firstBlueprint,
-          },
-          blueprint_cluster_binding: {
-            host_groups: firstBlueprintClusterBinding,
-          },
-        },
-        services: services,
-      };
-      
-      try {
-        const validationResponse = await AssignMastersApi.postValidations(validationPayload, STACK, VERSION);
-        updateValidationsSuccessCallback(validationResponse);
-      } catch (error) {
-        console.error('Validation API call failed:', error);
-        setCanProceed(false);
-      }
       const servicesAndComponentsData: ServicesResponse =
         await ChooseServicesApi.getServices(STACK, VERSION);
       
@@ -296,6 +280,12 @@ export default function AssignMasters({
   };
 
   const validateChange = async (transformedMastersData: any) => {
+    const sequence = ++validationSequence.current;
+    if (!transformedMastersData.length) {
+      setCanProceed(false);
+      return;
+    }
+    setCanProceed(false);
     try {
       const allHostnames = map(transformedMastersData, "host_name");
       const hostnames = uniq(allHostnames);
@@ -309,9 +299,13 @@ export default function AssignMasters({
         STACK,
         VERSION,
       );
+      if (sequence !== validationSequence.current) return;
       updateValidationsSuccessCallback(validationResponse);
     } catch (error) {
+      if (sequence !== validationSequence.current) return;
       console.error('Validation API call failed:', error);
+      setValidationMessages({});
+      setHasValidationIssues(false);
       setCanProceed(false);
     }
   };
@@ -487,67 +481,13 @@ export default function AssignMasters({
   };
 
   /**
-  * Remove validation messages for components which are already installed
-  */
-  const filterNotInstalledComponents = (validationData: any) => {
-    return validationData.resources[0].items.filter((item: any) => {
-      const host = state.hosts[item.host];
-      return !host || !host.components.includes(item['component-name']);
-    });
-  };
-
-  /**
    * Process validation response
    */
   const updateValidationsSuccessCallback = (data: any) => {
-    const newGeneralErrorMessages: string[] = [];
-    const newGeneralWarningMessages: string[] = [];
-    
-    // Clear existing validation messages from mastersData
-    const updatedMastersData = mastersData.map(master => {
-      const { warnMessage, errorMessage, ...rest } = master;
-      return {
-        ...rest,
-        warnMessage: "",
-        errorMessage: "",
-      };
-    });
-    
-    let anyErrors = false;
-
-    // Process validation data - filter out installed components
-    const validationData = filterNotInstalledComponents(data);
-    validationData
-      .filter((item: any) => item.type === 'host-component')
-      .forEach((item: any) => {
-        // Find the master component that matches this validation item
-        const masterIndex = updatedMastersData.findIndex(master => 
-          master.component === item['component-name'] && 
-          master.hostName === item.host
-        );
-        
-        if (masterIndex !== -1) {
-          if (item.level === 'ERROR') {
-            anyErrors = true;
-            generalErrorMessages.push(item.message);
-            updatedMastersData[masterIndex] = {
-              ...updatedMastersData[masterIndex],
-              errorMessage: item.message
-            };
-          } else if (item.level === 'WARN') {
-            generalWarningMessages.push(item.message);
-            updatedMastersData[masterIndex] = {
-              ...updatedMastersData[masterIndex],
-              warnMessage: item.message
-            };
-          }
-        }
-      });
-
-    setGeneralErrorMessages(newGeneralErrorMessages);
-    setGeneralWarningMessages(newGeneralWarningMessages);
-
-    setCanProceed(!anyErrors);
+    const messages = getMasterValidationMessages(data, mastersData);
+    setValidationMessages(messages);
+    setHasValidationIssues(Object.keys(messages).length > 0);
+    setCanProceed(true);
   };
 
   return (
@@ -556,29 +496,6 @@ export default function AssignMasters({
       <p className="step-description">
         Assign master components to hosts you want to run them on.
       </p>
-      
-      {/* Display general validation messages */}
-      {generalErrorMessages.length > 0 && (
-        <Alert variant="danger" className="mb-3">
-          <strong>Validation Errors:</strong>
-          <ul className="mb-0 mt-2">
-            {generalErrorMessages.map((message, index) => (
-              <li key={index}>{message}</li>
-            ))}
-          </ul>
-        </Alert>
-      )}
-      
-      {generalWarningMessages.length > 0 && (
-        <Alert variant="warning" className="mb-3">
-          <strong>Validation Warnings:</strong>
-          <ul className="mb-0 mt-2">
-            {generalWarningMessages.map((message, index) => (
-              <li key={index}>{message}</li>
-            ))}
-          </ul>
-        </Alert>
-      )}
       
       {loading ? (
         <Spinner />
@@ -593,7 +510,11 @@ export default function AssignMasters({
                   .filter((master) => !master.isInstalled)
                   // Render each component
                   .map((master) => {
-                    const { component, hostName: hostname, display_name, errorMessage, warnMessage } = master;
+                    const { component, hostName: hostname, display_name } = master;
+                    const { errorMessage, warnMessage } =
+                      validationMessages[
+                        masterValidationKey(hostname, component)
+                      ] || {};
                     const displayName = display_name || component;
                     
                     return (

--- a/ambari-web/latest/src/components/StepWizard/WizardFooter.tsx
+++ b/ambari-web/latest/src/components/StepWizard/WizardFooter.tsx
@@ -28,6 +28,7 @@ interface PropTypes {
   onNext: Function;
   isNextEnabled: boolean;
   isBackEnabled?: boolean;
+  isCancelEnabled?: boolean;
   onCancel?: () => void;
   lifted?: boolean;
   sideItems?: any;
@@ -40,6 +41,7 @@ function WizardFooter({
   isNextEnabled,
   onCancel = () => {},
   isBackEnabled = true,
+  isCancelEnabled = true,
   lifted = false,
   sideItems,
 }: PropTypes) {
@@ -86,6 +88,7 @@ function WizardFooter({
           onClick={() => {
             setShowConfirmationModal(true);
           }}
+          disabled={!isCancelEnabled}
         >
           <span className="ms-1">CANCEL</span>
         </Button>

--- a/ambari-web/latest/src/hooks/useHostChecks.test.tsx
+++ b/ambari-web/latest/src/hooks/useHostChecks.test.tsx
@@ -1,0 +1,151 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { act, renderHook, waitFor } from "@testing-library/react";
+import type { ContextType, PropsWithChildren } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { AppContext } from "../store/context";
+
+const mocks = vi.hoisted(() => ({
+  getHostsData: vi.fn(),
+  getRequestStatus: vi.fn(),
+  makeRequest: vi.fn(),
+  pausePolling: vi.fn(),
+  poll: undefined as undefined | (() => Promise<void>),
+  resumePolling: vi.fn(),
+}));
+
+vi.mock("../api/hostsApi", () => ({
+  HostsApi: {
+    getHostsData: mocks.getHostsData,
+    getRequestStatus: mocks.getRequestStatus,
+    makeRequest: mocks.makeRequest,
+  },
+}));
+vi.mock("./usePolling", () => ({
+  default: (poll: () => Promise<void>) => {
+    mocks.poll = poll;
+    return {
+      pausePolling: mocks.pausePolling,
+      resumePolling: mocks.resumePolling,
+      stopPolling: vi.fn(),
+    };
+  },
+}));
+
+import { useHostChecks } from "./useHostChecks";
+
+const contextValue = {
+  ambariProperties: {
+    RootServiceComponents: {
+      properties: {
+        "java.home": "/opt/custom-java",
+        jdk_location: "/resources",
+      },
+    },
+  },
+  clusterName: "cluster1",
+} as ContextType<typeof AppContext>;
+
+function wrapper({ children }: PropsWithChildren) {
+  return <AppContext.Provider value={contextValue}>{children}</AppContext.Provider>;
+}
+
+describe("useHostChecks custom JDK validation", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.poll = undefined;
+    mocks.makeRequest
+      .mockResolvedValueOnce({ Requests: { id: 11 } })
+      .mockResolvedValueOnce({ Requests: { id: 12 } });
+    mocks.getHostsData.mockResolvedValue({
+      items: [{
+        Hosts: {
+          cpu_count: 4,
+          disk_info: [],
+          host_name: "host1",
+          os_family: "redhat7",
+          total_mem: 8192,
+        },
+      }],
+    });
+  });
+
+  it("runs java_home_check as a separate request and records host warnings", async () => {
+    const { result } = renderHook(() => useHostChecks(false, true), { wrapper });
+
+    await act(async () => {
+      result.current.startHostCheck([{ name: "host1" }]);
+      await Promise.resolve();
+    });
+    expect(mocks.makeRequest).toHaveBeenCalledTimes(1);
+
+    mocks.getRequestStatus.mockResolvedValueOnce({
+      Requests: {
+        inputs: "last_agent_env_check,installed_packages,existing_repos,transparentHugePage",
+        request_status: "COMPLETED",
+      },
+      tasks: [{
+        Tasks: {
+          host_name: "host1",
+          status: "COMPLETED",
+          structured_out: {
+            installed_packages: [],
+            last_agent_env_check: {},
+            transparentHugePage: { message: "never" },
+          },
+        },
+      }],
+    });
+    await act(async () => {
+      await mocks.poll?.();
+    });
+
+    expect(mocks.makeRequest).toHaveBeenLastCalledWith({
+      RequestInfo: {
+        action: "check_host",
+        context: "Check hosts",
+        parameters: {
+          check_execute_list: "java_home_check",
+          java_home: "/opt/custom-java",
+          jdk_location: "/resources",
+          threshold: "60",
+        },
+      },
+      "Requests/resource_filters": [{ hosts: "host1" }],
+    });
+
+    mocks.getRequestStatus.mockResolvedValueOnce({
+      Requests: { inputs: "java_home_check", request_status: "COMPLETED" },
+      tasks: [{
+        Tasks: {
+          host_name: "host1",
+          status: "COMPLETED",
+          structured_out: { java_home_check: { exit_code: 1 } },
+        },
+      }],
+    });
+    await act(async () => {
+      await mocks.poll?.();
+    });
+
+    await waitFor(() => expect(
+      result.current.hostCheckResult.jdkCategoryWarnings[0].hostsNames,
+    ).toEqual(["host1"]));
+  });
+});

--- a/ambari-web/latest/src/hooks/useHostChecks.tsx
+++ b/ambari-web/latest/src/hooks/useHostChecks.tsx
@@ -33,6 +33,17 @@ type BootHostType = {
   name: string;
 };
 
+type HostCheckRecoveryOptions = {
+  initialHosts?: BootHostType[];
+  initialRequestID?: number;
+  initialWarningData?: any;
+  onStateChange?: (state: {
+    isRunning: boolean;
+    requestID: number;
+    warningData: any;
+  }) => void;
+};
+
 export const initialWarningData: any = {
   allWarnings: [],
   repoCategoryWarnings: [],
@@ -45,20 +56,27 @@ export const initialWarningData: any = {
 
 export const useHostChecks = (
   isAddHostWizard = false,
-  isClusterInstallationWizard = false
+  isClusterInstallationWizard = false,
+  recovery: HostCheckRecoveryOptions = {},
 ) => {
   const { clusterName, ambariProperties } = useContext(AppContext);
 
-  const [requestID, setRequestID] = useState(-1);
-  const [warningData, setWarningData] = useState<any>(initialWarningData);
+  const [requestID, setRequestID] = useState<number>(
+    recovery.initialRequestID ?? -1,
+  );
+  const [warningData, setWarningData] = useState<any>(
+    recovery.initialWarningData || initialWarningData,
+  );
   const [componentInfo, setComponentInfo] = useState({});
-  const [isHostCheckRunning, setIsHostCheckRunning] = useState(false);
+  const [isHostCheckRunning, setIsHostCheckRunning] = useState(
+    recovery.initialRequestID != null && recovery.initialRequestID !== -1,
+  );
 
   const hostsPackagesData = useRef([]);
   const hostCheckResult = useRef(null);
   const skipBootstrap = useRef(false);
   const hostPackagesData = useRef([]);
-  const bootHosts = useRef<BootHostType[]>([]);
+  const bootHosts = useRef<BootHostType[]>(recovery.initialHosts || []);
   const dataForHostCheck = useRef({});
 
   const getHostCheckTasks = async () => {
@@ -69,9 +87,9 @@ export const useHostChecks = (
 
     const response = await HostsApi.getRequestStatus(
       requestID,
-      "Requests/inputs,Requests/request_status,tasks/Tasks/host_name,tasks/Tasks/structured_out/host_resolution_check/hosts_with_failures,tasks/Tasks/structured_out/host_resolution_check/failed_count,tasks/Tasks/structured_out/installed_packages,tasks/Tasks/structured_out/last_agent_env_check,tasks/Tasks/structured_out/transparentHugePage,tasks/Tasks/stdout,tasks/Tasks/stderr,tasks/Tasks/error_log,tasks/Tasks/command_detail,tasks/Tasks/status&minimal_response=true"
+      "Requests/inputs,Requests/request_status,Requests/end_time,tasks/Tasks/host_name,tasks/Tasks/structured_out/host_resolution_check/hosts_with_failures,tasks/Tasks/structured_out/host_resolution_check/failed_count,tasks/Tasks/structured_out/installed_packages,tasks/Tasks/structured_out/last_agent_env_check,tasks/Tasks/structured_out/transparentHugePage,tasks/Tasks/structured_out/java_home_check/exit_code,tasks/Tasks/stdout,tasks/Tasks/stderr,tasks/Tasks/error_log,tasks/Tasks/command_detail,tasks/Tasks/status&minimal_response=true"
     );
-    getHostCheckTasksSuccess(response);
+    await getHostCheckTasksSuccess(response);
   };
 
   const { pausePolling, resumePolling } = usePolling(getHostCheckTasks, 1000);
@@ -88,6 +106,14 @@ export const useHostChecks = (
       resumePolling();
     }
   }, [requestID]);
+
+  useEffect(() => {
+    recovery.onStateChange?.({
+      isRunning: isHostCheckRunning,
+      requestID,
+      warningData,
+    });
+  }, [isHostCheckRunning, requestID, warningData]);
 
   const getClusterComponents = async () => {
     const response = await HostsApi.getClusterComponents(
@@ -1019,7 +1045,68 @@ export const useHostChecks = (
     setWarningData(warningDataCopy);
   };
 
-  const getHostCheckTasksSuccess = (data: any) => {
+  const finishHostCheck = () => {
+    pausePolling();
+    setIsHostCheckRunning(false);
+    setRequestID(-1);
+  };
+
+  const launchJdkCheck = async () => {
+    const hostNames = map(bootHosts.current, "name").join(",");
+    const properties = get(ambariProperties, "RootServiceComponents.properties", {});
+    if (!hostNames || properties["jdk.name"]) {
+      finishHostCheck();
+      return;
+    }
+    const response = await HostsApi.makeRequest({
+      RequestInfo: {
+        action: "check_host",
+        context: "Check hosts",
+        parameters: {
+          check_execute_list: "java_home_check",
+          java_home: properties["java.home"],
+          jdk_location: properties.jdk_location,
+          threshold: "60",
+        },
+      },
+      "Requests/resource_filters": [{ hosts: hostNames }],
+    });
+    const nextRequestID = get(response, "Requests.id", -1);
+    if (nextRequestID === -1) {
+      finishHostCheck();
+      return;
+    }
+    setRequestID(nextRequestID);
+  };
+
+  const parseJdkCheckResults = (data: any) => {
+    const invalidHosts = get(data, "tasks", []).filter(
+      (task: any) => Number(get(
+        task,
+        "Tasks.structured_out.java_home_check.exit_code",
+        0,
+      )) === 1,
+    ).map((task: any) => get(task, "Tasks.host_name", ""));
+    const javaHome = get(
+      ambariProperties,
+      "RootServiceComponents.properties.java.home",
+      "",
+    );
+    setWarningData((current: any) => ({
+      ...current,
+      jdkCategoryWarnings: invalidHosts.length ? [{
+        category: "jdk",
+        hosts: invalidHosts.map((hostName: string) =>
+          `${hostName} does not have a valid JDK at ${javaHome}.`,
+        ),
+        hostsLong: invalidHosts,
+        hostsNames: invalidHosts,
+        name: `Invalid JDK location ${javaHome}`,
+      }] : [],
+    }));
+  };
+
+  const getHostCheckTasksSuccess = async (data: any) => {
     if (isEmpty(data)) {
       getGeneralHostCheck();
       return;
@@ -1027,7 +1114,6 @@ export const useHostChecks = (
     if (finishStates.includes(get(data, "Requests.request_status"))) {
       if (get(data, "Requests.inputs", "").includes("last_agent_env_check")) {
         pausePolling();
-        setIsHostCheckRunning(false);
         hostsPackagesData.current = get(data, "tasks", []).map((task: any) => {
           const installedPackages = get(
             task,
@@ -1045,7 +1131,15 @@ export const useHostChecks = (
           };
         });
         hostCheckResult.current = data;
-        getHostInfo();
+        await getHostInfo();
+        try {
+          await launchJdkCheck();
+        } catch {
+          finishHostCheck();
+        }
+      } else if (get(data, "Requests.inputs", "").includes("java_home_check")) {
+        parseJdkCheckResults(data);
+        finishHostCheck();
       } else if (
         get(data, "Requests.inputs", "").includes("host_resolution_check")
       ) {

--- a/ambari-web/latest/src/hooks/useKerberosMode.ts
+++ b/ambari-web/latest/src/hooks/useKerberosMode.ts
@@ -30,26 +30,35 @@ export default function useKerberosMode() {
   const { clusterName, isKerberosEnabled } = useContext(AppContext);
   const [kdcType, setKdcType] = useState("");
   const [isLoaded, setIsLoaded] = useState(!isKerberosEnabled);
+  const [error, setError] = useState("");
+  const [reloadKey, setReloadKey] = useState(0);
 
   useEffect(() => {
     let active = true;
     if (!isKerberosEnabled || !clusterName) {
       setKdcType("");
+      setError("");
       setIsLoaded(true);
       return () => {
         active = false;
       };
     }
     setIsLoaded(false);
+    setError("");
     void adminApi.getSecurityType(clusterName)
       .then((response) => {
         if (active) {
           setKdcType(kerberosTypeFromConfig(response));
         }
       })
-      .catch(() => {
+      .catch((requestError: any) => {
         if (active) {
           setKdcType("");
+          setError(
+            requestError?.response?.data?.message
+              || requestError?.message
+              || "Ambari could not determine the Kerberos KDC type.",
+          );
         }
       })
       .finally(() => {
@@ -60,11 +69,13 @@ export default function useKerberosMode() {
     return () => {
       active = false;
     };
-  }, [clusterName, isKerberosEnabled]);
+  }, [clusterName, isKerberosEnabled, reloadKey]);
 
   return {
+    error,
     isLoaded,
     isManualKerberos: isKerberosEnabled && kdcType === "none",
     kdcType,
+    reload: () => setReloadKey((value) => value + 1),
   };
 }

--- a/ambari-web/latest/src/router/RoutesList.test.tsx
+++ b/ambari-web/latest/src/router/RoutesList.test.tsx
@@ -1,0 +1,69 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { isValidElement, ReactElement } from "react";
+import { RouteObject } from "react-router-dom";
+import { describe, expect, it } from "vitest";
+import { ProtectedRoute } from "../components/AuthGuard";
+import FeatureRouteGuard from "../components/FeatureRouteGuard";
+import ServiceOperationRouteGuard from "../components/ServiceOperationRouteGuard";
+import RoutesList from "./RoutesList";
+
+function child(route: RouteObject, path?: string) {
+  const result = route.children?.find((candidate) => candidate.path === path);
+  if (!result) throw new Error(`Route ${path || "<pathless>"} was not found.`);
+  return result;
+}
+
+type GuardProps = {
+  children: ReactElement<GuardProps>;
+  requireAuthorization?: string;
+};
+
+function element(route: RouteObject): ReactElement<GuardProps> {
+  if (!isValidElement(route.element)) throw new Error("Route has no React element.");
+  return route.element as ReactElement<GuardProps>;
+}
+
+describe("installation route contracts", () => {
+  const root = RoutesList[0];
+  const authenticated = child(root);
+  const installer = child(authenticated, "installer");
+  const main = child(authenticated, "main");
+
+  it("protects Installer and Add Host with their mutation permissions and operation guard", () => {
+    const installerRoute = element(child(installer, ":stepNumber"));
+    expect(installerRoute.type).toBe(ProtectedRoute);
+    expect(installerRoute.props.requireAuthorization).toBe("AMBARI.ADD_DELETE_CLUSTERS");
+    expect(installerRoute.props.children.type).toBe(ServiceOperationRouteGuard);
+
+    const addHostRoute = element(child(main, "host/add/:stepNumber"));
+    expect(addHostRoute.type).toBe(ProtectedRoute);
+    expect(addHostRoute.props.requireAuthorization).toBe("HOST.ADD_DELETE_HOSTS");
+    expect(addHostRoute.props.children.type).toBe(ServiceOperationRouteGuard);
+  });
+
+  it("retains the Add Service feature, permission, and operation gates", () => {
+    const addServiceRoute = element(child(main, "service/add/:stepNumber"));
+    expect(addServiceRoute.type).toBe(FeatureRouteGuard);
+    const permissionRoute = addServiceRoute.props.children;
+    expect(permissionRoute.type).toBe(ProtectedRoute);
+    expect(permissionRoute.props.requireAuthorization).toBe("SERVICE.ADD_DELETE_SERVICES");
+    expect(permissionRoute.props.children.type).toBe(ServiceOperationRouteGuard);
+  });
+});

--- a/ambari-web/latest/src/router/RoutesList.tsx
+++ b/ambari-web/latest/src/router/RoutesList.tsx
@@ -88,11 +88,18 @@ const RoutesList: RouteObject[] = [
               {
                 path: ":stepNumber",
                 element: (
-                  <ClusterCreationWizard
-                    Context={ClusterCreationContext}
-                    Provider={ClusterCreationProvider}
-                    wizardSteps={wizardSteps as any}
-                  />
+                  <ProtectedRoute
+                    requireAuthorization="AMBARI.ADD_DELETE_CLUSTERS"
+                    redirectTo="/main/view"
+                  >
+                    <ServiceOperationRouteGuard>
+                      <ClusterCreationWizard
+                        Context={ClusterCreationContext}
+                        Provider={ClusterCreationProvider}
+                        wizardSteps={wizardSteps as any}
+                      />
+                    </ServiceOperationRouteGuard>
+                  </ProtectedRoute>
                 ),
               },
             ],
@@ -194,7 +201,19 @@ const RoutesList: RouteObject[] = [
               { path: "hosts/component/:componentName", element: <HostsList /> },
               { path: "hosts/version/:versionName/:versionStatus", element: <HostsList /> },
               { path: "hosts/:hostname/:tab", element: <Hosts /> },
-              { path: "host/add/:stepNumber", element: <AddWizardUrlMapping /> },
+              {
+                path: "host/add/:stepNumber",
+                element: (
+                  <ProtectedRoute
+                    requireAuthorization="HOST.ADD_DELETE_HOSTS"
+                    redirectTo="/main/hosts"
+                  >
+                    <ServiceOperationRouteGuard>
+                      <AddWizardUrlMapping />
+                    </ServiceOperationRouteGuard>
+                  </ProtectedRoute>
+                ),
+              },
               { path: "alerts", element: <Alerts /> },
               { path: "alerts/:alertId", element: <AlertDefinitionDetails /> },
               {

--- a/ambari-web/latest/src/screens/ClusterWizard/Step0.test.tsx
+++ b/ambari-web/latest/src/screens/ClusterWizard/Step0.test.tsx
@@ -1,0 +1,77 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { createContext } from "react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { ContextWrapper } from ".";
+import Step0 from "./Step0";
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+vi.mock("../../components/StepWizard/WizardFooter", () => ({
+  default: ({
+    isNextEnabled,
+    onNext,
+  }: {
+    isNextEnabled: boolean;
+    onNext: () => void;
+  }) => (
+    <button disabled={!isNextEnabled} onClick={onNext}>NEXT</button>
+  ),
+}));
+
+describe("cluster Name navigation", () => {
+  it("persists the entered name before advancing", async () => {
+    let resolvePersistence: () => void = () => undefined;
+    const flushStateToDb = vi.fn(() => new Promise<void>((resolve) => {
+      resolvePersistence = resolve;
+    }));
+    const dispatch = vi.fn();
+    const handleNextImperitive = vi.fn();
+    const value = {
+      dispatch,
+      flushStateToDb,
+      state: { clusterCreationSteps: {} },
+      stepWizardUtilities: {
+        currentStep: { canGoBack: false, name: "NAME" },
+        handleNextImperitive,
+      },
+    };
+    const WizardContext = createContext(value);
+    render(
+      <ContextWrapper.Provider value={{ Context: WizardContext }}>
+        <WizardContext.Provider value={value}>
+          <Step0 />
+        </WizardContext.Provider>
+      </ContextWrapper.Provider>,
+    );
+
+    fireEvent.change(screen.getByRole("textbox"), { target: { value: "cluster1" } });
+    fireEvent.click(screen.getByRole("button", { name: "NEXT" }));
+    expect(dispatch).toHaveBeenCalledWith(expect.objectContaining({
+      payload: { data: { clusterName: "cluster1" }, step: "NAME" },
+    }));
+    expect(flushStateToDb).toHaveBeenCalledWith("next");
+    expect(handleNextImperitive).not.toHaveBeenCalled();
+
+    resolvePersistence();
+    await waitFor(() => expect(handleNextImperitive).toHaveBeenCalledOnce());
+  });
+});

--- a/ambari-web/latest/src/screens/ClusterWizard/Step0.tsx
+++ b/ambari-web/latest/src/screens/ClusterWizard/Step0.tsx
@@ -105,7 +105,7 @@ function Step0({ wizardName = "clusterCreation" }) {
           <CardBody>
             <span> {t("installer.step0.nameClusterInstruction")}</span>
             <OverlayTrigger
-              trigger="hover"
+              trigger={["hover", "focus"]}
               key="learn more"
               placement="right"
               overlay={
@@ -148,13 +148,11 @@ function Step0({ wizardName = "clusterCreation" }) {
               type: ActionTypes.STORE_INFORMATION,
               payload: { step: currentStep.name, data: { clusterName } },
             });
-            flushStateToDb("next");
+            await Promise.resolve(flushStateToDb("next"));
             handleNextImperitive();
           }
         }}
-        onCancel={() => {
-          flushStateToDb("cancel");
-        }}
+        onCancel={() => void flushStateToDb("cancel")}
         onBack={() => {}}
       />
     </>

--- a/ambari-web/latest/src/screens/ClusterWizard/Step1.tsx
+++ b/ambari-web/latest/src/screens/ClusterWizard/Step1.tsx
@@ -55,7 +55,9 @@ import {
 } from "@fortawesome/free-solid-svg-icons";
 import VersionsApi from "../../api/versionsApi";
 import toast from "react-hot-toast";
-import AddVersionModal from "../../components/AddVersionModal";
+import AddVersionModal, {
+  VersionDefinitionSource,
+} from "../../components/AddVersionModal";
 import LostNetworkModal from "../../components/LostNetworkModal";
 import Table from "../../components/Table";
 import DefaultButton from "../../components/DefaultButton";
@@ -66,6 +68,8 @@ import { ActionTypes } from "./clusterStore/types";
 import { getStepData } from "../../Utils/Utility";
 import wizardSteps from "./wizardSteps";
 import { ContextWrapper } from ".";
+import { AppContext } from "../../store/context";
+import { isJdkCompatible } from "./versionSelection";
 
 enum RepositoryType {
   PUBLIC = "public",
@@ -88,7 +92,7 @@ export default function Step1({ wizardName = "clusterCreation" }) {
   );
   //   const history = useHistory();
   const [selectedChoice, setSelectedChoice] = useState<string>(
-    RepositoryType.LOCAL
+    RepositoryType.PUBLIC
   );
   const { stack, version } = useParams<any>();
   const [versionNumber, setVersionNumber] = useState(
@@ -108,6 +112,9 @@ export default function Step1({ wizardName = "clusterCreation" }) {
   const [showRedhatInfoModal, setShowRedhatInfoModal] =
     useState<boolean>(false);
   const [showAddVersionModal, setShowAddVersionModal] = useState(false);
+  const [showJdkWarning, setShowJdkWarning] = useState(false);
+  const [versionDefinitionSource, setVersionDefinitionSource] =
+    useState<VersionDefinitionSource | undefined>();
   const [addedVersions, setAddedVersions] = useState<{
     [key: string]: { label: string; value: string }[];
   }>({});
@@ -127,6 +134,7 @@ export default function Step1({ wizardName = "clusterCreation" }) {
       handleBackImperitive,
     },
   }: any = useContext(Context);
+  const { ambariProperties } = useContext(AppContext);
 
   const enableNext = () => {
     setNextEnabled(true);
@@ -169,31 +177,48 @@ export default function Step1({ wizardName = "clusterCreation" }) {
 
   useEffect(() => {
     async function getVersionDefinitions() {
-      const definitions: VersionDefinitionResponse =
-        await VersionsApi.getVersionDefinitions();
-      const sortedItems = definitions.items.sort((a: any, b: any) => {
-        const versionA = parseFloat(a.VersionDefinition.id.split("-")[1]);
-        const versionB = parseFloat(b.VersionDefinition.id.split("-")[1]);
+      try {
+        const stateData = get(
+          state,
+          `${wizardName}Steps.${currentStep.name}.data`,
+          {},
+        );
+        const stacks = await VersionsApi.getStacks();
+        const stackName = get(stateData, "selectedStack.stack_name")
+          || stack
+          || get(stacks, "items[0].Stacks.stack_name", "");
+        if (!stackName) {
+          throw new Error("No installable stack is available.");
+        }
+        const definitions: VersionDefinitionResponse =
+          await VersionsApi.getVersionDefinitions(stackName);
+        const sortedItems = [...(definitions.items || [])].sort((a: any, b: any) => {
+          const versionA = parseFloat(a.VersionDefinition.id.split("-")[1]);
+          const versionB = parseFloat(b.VersionDefinition.id.split("-")[1]);
 
-        return versionB - versionA;
-      });
-      setVersionDefinitions(sortedItems);
-      setNetworkIssues(definitions.items);
-      
-      const stateData = get(
-        state,
-        `${wizardName}Steps.${currentStep.name}.data`,
-        {}
-      );
-      
-      if (isEmpty(stateData)) {
-        // Only set defaults if no previous state exists
-        setSelectedStack(sortedItems[0]?.VersionDefinition);
-        selectNewVersion(sortedItems[0]?.VersionDefinition);
+          return versionB - versionA;
+        });
+        if (!sortedItems.length) {
+          throw new Error(`No installable version definition is available for ${stackName}.`);
+        }
+        setVersionDefinitions(sortedItems);
+        setNetworkIssues(sortedItems);
+
+        if (isEmpty(stateData)) {
+          setSelectedStack(sortedItems[0].VersionDefinition);
+          selectNewVersion(sortedItems[0].VersionDefinition);
+        }
+      } catch (error: any) {
+        toast.error(
+          error?.response?.data?.message
+            || error?.message
+            || "Could not load version definitions.",
+        );
+        jumpToStep(0, true);
       }
     }
-    getVersionDefinitions();
-  }, [state, wizardName, currentStep]);
+    void getVersionDefinitions();
+  }, [wizardName]);
 
   useEffect(() => {
     if (!versionNumber) {
@@ -237,10 +262,11 @@ export default function Step1({ wizardName = "clusterCreation" }) {
       // Fix for TLHASD-1260: Ensure proper state restoration for base URL persistence
       setSelectedVersion(stateData?.selectedVersion);
       setSelectedStack(stateData?.selectedStack); // Fixed typo: was 'selelectedStack'
-      setSelectedChoice(stateData?.selectedChoice);
-      setSkipValidation(stateData?.skipValidation);
-      setRedhatSatellite(stateData?.redhatSatellite);
+      setSelectedChoice(stateData?.selectedChoice ?? RepositoryType.PUBLIC);
+      setSkipValidation(Boolean(stateData?.skipValidation));
+      setRedhatSatellite(Boolean(stateData?.redhatSatellite));
       setOperatingSystems(stateData?.operatingSystems);
+      setVersionDefinitionSource(stateData?.versionDefinitionSource);
       // Fix for TLHASD-1260: Restore addedVersions from XML uploads
       if (stateData?.addedVersions) {
         setAddedVersions(stateData.addedVersions);
@@ -273,6 +299,7 @@ export default function Step1({ wizardName = "clusterCreation" }) {
         for (const repo of oSystem.repos) {
           if (
             oSystem.isAdded &&
+            !redhatSatellite &&
             !(
               remotePattern.test(repo.baseUrl) ||
               localPattern.test(repo.baseUrl)
@@ -293,7 +320,7 @@ export default function Step1({ wizardName = "clusterCreation" }) {
     } else {
       enableNext();
     }
-  }, [operatingSystems, versionNumber, versionValidationError, skipValidation]);
+  }, [operatingSystems, versionNumber, versionValidationError, skipValidation, redhatSatellite]);
 
   useEffect(() => {
     async function getVersionOs() {
@@ -310,6 +337,7 @@ export default function Step1({ wizardName = "clusterCreation" }) {
       
       const versionOperatingSystems =
         await VersionsApi.getVersionOperatingSystems(
+          selectedStack.stack_name,
           selectedStack.stack_version
         );
       let alreadyAddedOs: any = [];
@@ -319,9 +347,15 @@ export default function Step1({ wizardName = "clusterCreation" }) {
             return {
               id: repo.Repositories.repo_id,
               defaultId: repo.Repositories.repo_id,
-              baseUrl: "",
+              baseUrl:
+                repo.Repositories.base_url
+                || repo.Repositories.default_base_url
+                || "",
               name: repo?.Repositories?.repo_name,
-              defaultUrl: "",
+              defaultUrl:
+                repo.Repositories.default_base_url
+                || repo.Repositories.base_url
+                || "",
             };
           });
           const matchingOs = undefined;
@@ -614,7 +648,7 @@ export default function Step1({ wizardName = "clusterCreation" }) {
     if (!isAllOsValidated()) {
       return;
     }
-    if (skipValidation) {
+    if (skipValidation || redhatSatellite) {
       //   saveVersion();
       return true;
     } else {
@@ -629,7 +663,7 @@ export default function Step1({ wizardName = "clusterCreation" }) {
         for (const repo of repos) {
           versionValidationPromises.push(
             VersionsApi.validateRepos(
-              selectedStack.stack_version,
+              selectedStack.stack_name,
               selectedStack.stack_version,
               oSystem.os,
               repo.id,
@@ -691,7 +725,10 @@ export default function Step1({ wizardName = "clusterCreation" }) {
     }
   }
 
-  const readVersionCallback = async (versionResources: any) => {
+  const readVersionCallback = async (
+    versionResources: any,
+    source: VersionDefinitionSource,
+  ) => {
     try {
       const addedVersionOperatingSystems =
         versionResources?.resources?.[0]?.operating_systems;
@@ -699,7 +736,8 @@ export default function Step1({ wizardName = "clusterCreation" }) {
 
       const versionOperatingSystems =
         await VersionsApi.getVersionOperatingSystems(
-          selectedStack.stack_version
+          addedVersion.stack_name,
+          addedVersion.stack_version
         );
       const newVersion = {
         label: `${addedVersion.stack_name}-${addedVersion.repository_version}`,
@@ -765,6 +803,7 @@ export default function Step1({ wizardName = "clusterCreation" }) {
       setVersionNumber(
         addedVersionName.splice(2, addedVersionName.length).join(".")
       );
+      setVersionDefinitionSource(source);
       setShowAddVersionModal(false);
     } catch (err) {
       toast.error("Could not read version");
@@ -786,6 +825,76 @@ export default function Step1({ wizardName = "clusterCreation" }) {
   //         value: savedRepositoryVersionDetails?.repository_version,
   //     },
   // ];
+
+  const saveVersionSelection = async () => {
+    const allValidated = await validateRepos();
+    if (!allValidated) {
+      disableNext();
+      return;
+    }
+
+    const operatingSystemsCopy = cloneDeep(operatingSystems);
+    const allAddedOs = operatingSystemsCopy?.[selectedVersion.id]?.filter(
+      (oSystem) => oSystem.isAdded,
+    ) || [];
+    const versionUpdatePromises = allAddedOs.flatMap((oSystem) =>
+      oSystem.repos.map((repo) => VersionsApi.updateOSInfo(
+        selectedStack.stack_name,
+        selectedStack.stack_version,
+        oSystem.os,
+        repo.id,
+        {
+          Repositories: {
+            base_url: repo.baseUrl,
+            repo_name: repo.name,
+            verify_base_url: !skipValidation && !redhatSatellite,
+          },
+        },
+      )),
+    );
+
+    try {
+      await Promise.all(versionUpdatePromises);
+    } catch (error: any) {
+      toast.error(
+        error?.response?.data?.message
+          || "Ambari could not save the repository configuration.",
+      );
+      return;
+    }
+
+    dispatch({
+      type: ActionTypes.STORE_INFORMATION,
+      payload: {
+        step: currentStep.name,
+        data: {
+          selectedVersion,
+          selectedStack,
+          selectedChoice,
+          skipValidation,
+          redhatSatellite,
+          operatingSystems,
+          addedVersions,
+          versionDefinitionSource,
+        },
+      },
+    });
+    await Promise.resolve(flushStateToDb("next"));
+    handleNextImperitive();
+  };
+
+  const continueAfterJdkValidation = () => {
+    const compatible = isJdkCompatible(
+      ambariProperties?.["java.version"],
+      selectedStack?.min_jdk,
+      selectedStack?.max_jdk,
+    );
+    if (!compatible) {
+      setShowJdkWarning(true);
+      return;
+    }
+    void saveVersionSelection();
+  };
 
   return (
     <>
@@ -823,6 +932,22 @@ export default function Step1({ wizardName = "clusterCreation" }) {
         onClose={() => {
           setShowRegistrationModal(false);
         }}
+      />
+      <ConfirmationModal
+        modalTitle="Unsupported JDK Version"
+        modalBody={`The selected ${selectedStack?.stack_name || "stack"} ${
+          selectedStack?.stack_version || ""
+        } version requires JDK ${selectedStack?.min_jdk || selectedStack?.max_jdk} through ${
+          selectedStack?.max_jdk || selectedStack?.min_jdk
+        }, but Ambari Server uses ${ambariProperties?.["java.version"]}.`}
+        isOpen={showJdkWarning}
+        successCallback={() => {
+          setShowJdkWarning(false);
+          void saveVersionSelection();
+        }}
+        onClose={() => setShowJdkWarning(false)}
+        buttonVariant="danger"
+        okButtonText="PROCEED ANYWAY"
       />
       <div className="step-title">Select Version</div>
       <div className="step-description mt-2">
@@ -1118,6 +1243,7 @@ export default function Step1({ wizardName = "clusterCreation" }) {
                   checked={skipValidation}
                   type="checkbox"
                   id="skipValidation"
+                  disabled={redhatSatellite}
                   onChange={() => {
                     setSkipValidation(!skipValidation);
                   }}
@@ -1181,62 +1307,12 @@ export default function Step1({ wizardName = "clusterCreation" }) {
         lifted
         isNextEnabled={nextEnabled}
         step={currentStep}
-        onNext={async () => {
-          const allValidated = await validateRepos();
-          if (!allValidated) {
-            disableNext();
-          } else {
-            const operatingSystemsCopy = cloneDeep(operatingSystems);
-            const versionUpdatePromises = [];
-            const allAddedOs = operatingSystemsCopy?.[
-              selectedVersion.id
-            ].filter((oSystem) => oSystem.isAdded);
-            for (const oSystem of allAddedOs) {
-              const repos = oSystem.repos;
-              for (const repo of repos) {
-                versionUpdatePromises.push(
-                  VersionsApi.updateOSInfo(
-                    selectedStack.stack_name,
-                    selectedStack.stack_version,
-                    oSystem.os,
-                    repo.id,
-                    {
-                      Repositories: {
-                        base_url: repo.baseUrl,
-                        repo_name: repo.name,
-                        verify_base_url: true,
-                      },
-                    }
-                  )
-                );
-              }
-            }
-            Promise.allSettled(versionUpdatePromises).then(() => {
-              dispatch({
-                type: ActionTypes.STORE_INFORMATION,
-                payload: {
-                  step: currentStep.name,
-                  data: {
-                    selectedVersion,
-                    selectedStack,
-                    selectedChoice,
-                    skipValidation,
-                    redhatSatellite,
-                    operatingSystems,
-                    addedVersions,
-                  },
-                },
-              });
-              flushStateToDb("next");
-              handleNextImperitive();
-            });
-          }
-        }}
+        onNext={continueAfterJdkValidation}
         onCancel={() => {
           flushStateToDb("cancel");
         }}
-        onBack={() => {
-          flushStateToDb("back");
+        onBack={async () => {
+          await Promise.resolve(flushStateToDb("back"));
           handleBackImperitive();
         }}
       />

--- a/ambari-web/latest/src/screens/ClusterWizard/Step10.test.tsx
+++ b/ambari-web/latest/src/screens/ClusterWizard/Step10.test.tsx
@@ -1,0 +1,109 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { createContext } from "react";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ContextWrapper } from ".";
+
+const mocks = vi.hoisted(() => ({
+  flushStateToDb: vi.fn(),
+  updateCluster: vi.fn(),
+}));
+
+vi.mock("../../api/clusterApi", () => ({
+  default: { updateCluster: mocks.updateCluster },
+}));
+vi.mock("../../components/StepWizard/WizardFooter", () => ({
+  default: ({
+    isNextEnabled,
+    onNext,
+    step,
+  }: {
+    isNextEnabled: boolean;
+    onNext: () => void;
+    step: { nextLabel: string };
+  }) => (
+    <button disabled={!isNextEnabled} onClick={onNext}>
+      {step.nextLabel}
+    </button>
+  ),
+}));
+
+import Step10 from "./Step10";
+
+function wizardState(prefix: "clusterCreation" | "addService") {
+  return {
+    [`${prefix}Steps`]: {
+      NAME: { data: { clusterName: "cluster1" } },
+      HOSTS: { data: { installedHosts: [] } },
+      MASTERS: { data: { mastersData: [] } },
+      SLAVES_AND_CLIENTS: { data: { serviceComponents: [] } },
+      INSTALL_START_TEST: {
+        data: {
+          clusterStatus: { status: "STARTED" },
+          hostInfo: [],
+        },
+      },
+    },
+  };
+}
+
+function renderStep(wizardName: "clusterCreation" | "addService") {
+  const contextValue = {
+    state: wizardState(wizardName),
+    flushStateToDb: mocks.flushStateToDb,
+    stepWizardUtilities: { currentStep: { name: "SUMMARY" } },
+  };
+  const WizardContext = createContext(contextValue);
+  return render(
+    <ContextWrapper.Provider value={{ Context: WizardContext }}>
+      <WizardContext.Provider value={contextValue}>
+        <Step10 wizardName={wizardName} />
+      </WizardContext.Provider>
+    </ContextWrapper.Provider>,
+  );
+}
+
+describe("installation Summary completion", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.flushStateToDb.mockResolvedValue(undefined);
+    mocks.updateCluster.mockResolvedValue({});
+  });
+
+  afterEach(() => cleanup());
+
+  it("clears only Add Service state without changing cluster provisioning", async () => {
+    renderStep("addService");
+    fireEvent.click(screen.getByRole("button", { name: "COMPLETE" }));
+
+    await waitFor(() => expect(mocks.flushStateToDb).toHaveBeenCalledWith("complete"));
+    expect(mocks.updateCluster).not.toHaveBeenCalled();
+  });
+
+  it("keeps new-cluster state retryable when provisioning completion fails", async () => {
+    mocks.updateCluster.mockRejectedValueOnce(new Error("Provisioning update failed"));
+    renderStep("clusterCreation");
+    fireEvent.click(screen.getByRole("button", { name: "COMPLETE" }));
+
+    expect(await screen.findByText("Provisioning update failed")).toBeTruthy();
+    expect(mocks.flushStateToDb).not.toHaveBeenCalled();
+    expect(screen.getByRole("button", { name: "COMPLETE" }).hasAttribute("disabled")).toBe(false);
+  });
+});

--- a/ambari-web/latest/src/screens/ClusterWizard/Step10.tsx
+++ b/ambari-web/latest/src/screens/ClusterWizard/Step10.tsx
@@ -19,11 +19,10 @@
 import { useContext, useEffect, useRef, useState } from "react";
 import { cloneDeep, filter, find, flatten, get, map, some, uniq } from "lodash";
 import { pluralize, role } from "../../Utils/Utility";
-import { Card, CardBody } from "react-bootstrap";
+import { Alert, Card, CardBody } from "react-bootstrap";
 import WizardFooter from "../../components/StepWizard/WizardFooter";
 import ClusterApi from "../../api/clusterApi";
 import { ContextWrapper } from ".";
-import { syncConfigGroupsToServer } from "../../Utils/configGroupUtils";
 
 type Step10Props = {
   wizardName?: string;
@@ -37,6 +36,8 @@ function Step10({ wizardName = "clusterCreation" }: Step10Props) {
     stepWizardUtilities: { currentStep },
   }: any = useContext(Context);
   const [clusterInfoState, setClusterInfoState] = useState([]);
+  const [finishError, setFinishError] = useState("");
+  const [isFinishing, setIsFinishing] = useState(false);
   const clusterInfo = useRef<any>([]);
   const installFlag = useRef<boolean>(true);
   const startFlag = useRef<boolean>(true);
@@ -281,22 +282,53 @@ function Step10({ wizardName = "clusterCreation" }: Step10Props) {
     });
     setClusterInfoState(uniqueRecords);
   }, [clusterInfo.current]);
+
+  const finish = async () => {
+    if (isFinishing) return;
+    setIsFinishing(true);
+    setFinishError("");
+    try {
+      if (wizardName === "clusterCreation") {
+        const clusterName = getStepData("NAME", "clusterName");
+        await ClusterApi.updateCluster(clusterName, {
+          Clusters: { provisioning_state: "INSTALLED" },
+        });
+      }
+      await Promise.resolve(flushStateToDb("complete"));
+      if (wizardName === "clusterCreation") {
+        window.location.href = "/#/main/dashboard/metrics";
+        window.location.reload();
+      }
+    } catch (error: any) {
+      setFinishError(
+        error?.response?.data?.message
+          || error?.message
+          || "Ambari could not complete the installation workflow.",
+      );
+      setIsFinishing(false);
+    }
+  };
+
   return (
     <>
       <div className="step-title">Summary</div>
       <p className="step-description mt-2">
         Here is the summary of the install process.
       </p>
+      {finishError ? <Alert variant="danger">{finishError}</Alert> : null}
       <Card className="mt-2">
         <CardBody>
           {clusterInfoState.map((info: any) => {
             return (
-              <div className={`${info.color} mt-2`}>
+              <div key={info.id} className={`${info.color} mt-2`}>
                 {info?.displayStatement}
                 <div className="ms-2">
-                  {info.status.map((status: any) => {
+                  {info.status.map((status: any, index: number) => {
                     return (
-                      <div className={` mt-2 ${status.color}`}>
+                      <div
+                        key={`${info.id}-${status.displayStatement}-${index}`}
+                        className={` mt-2 ${status.color}`}
+                      >
                         {status.displayStatement}
                       </div>
                     );
@@ -308,28 +340,11 @@ function Step10({ wizardName = "clusterCreation" }: Step10Props) {
         </CardBody>
       </Card>
       <WizardFooter
-        isNextEnabled={true}
+        isNextEnabled={!isFinishing}
+        isCancelEnabled={!isFinishing}
         step={{ ...currentStep, nextLabel: "COMPLETE" }}
-        onNext={async () => {
-          const clusterName = getStepData("NAME", "clusterName");
-
-          if (wizardName === "clusterCreation") {
-            await ClusterApi.updateCluster(clusterName, {
-              Clusters: {
-                provisioning_state: "INSTALLED",
-              },
-            });
-            await syncConfigGroupsToServer(clusterName, state);
-            flushStateToDb("cancel");
-            window.location.href = "#/main/dashboard/metrics";
-            window.location.reload();
-          } else {
-            await flushStateToDb("cancel");
-          }
-        }}
-        onCancel={() => {
-          flushStateToDb("cancel");
-        }}
+        onNext={() => void finish()}
+        onCancel={() => void finish()}
         onBack={() => {}}
       />
     </>

--- a/ambari-web/latest/src/screens/ClusterWizard/Step2.tsx
+++ b/ambari-web/latest/src/screens/ClusterWizard/Step2.tsx
@@ -30,6 +30,7 @@ import WizardFooter from "../../components/StepWizard/WizardFooter";
 import { getStepData } from "../../Utils/Utility";
 import { ContextWrapper } from ".";
 import { prepareHostInput } from "../../Utils/hostWizard";
+import { AppContext } from "../../store/context";
 
 type FormFields = {
   targetHosts: string;
@@ -38,6 +39,7 @@ type FormFields = {
   sshUserAccount: string;
   sshPortNumber: number;
   agentUserAccount: string;
+  skipHostChecks: boolean;
 };
 
 interface Step2Props {
@@ -50,8 +52,8 @@ interface Step2Props {
 export default function Step2({
   wizardName = "clusterCreation",
   installedHosts = [],
-  customizeAgentUserAccount = false,
-  isWindowsStack = false,
+  customizeAgentUserAccount: customizeAgentUserAccountProp,
+  isWindowsStack: isWindowsStackProp,
 }: Step2Props) {
   const [showManualRegistrationWarning, setShowManualRegistrationWarning] =
     useState(false);
@@ -77,6 +79,7 @@ export default function Step2({
       sshUserAccount: "root",
       sshPortNumber: 22,
       agentUserAccount: "root",
+      skipHostChecks: false,
     },
   });
   const [formData, setFormData] = useState<FormFields>();
@@ -92,8 +95,22 @@ export default function Step2({
   const [showInstalledHostnameWarning, setShowInstalledHostnameWarning] =
     useState(false);
   const [showBeforeProceedModal, setShowBeforeProceedModal] = useState(false);
+  const [showSkipHostChecksWarning, setShowSkipHostChecksWarning] =
+    useState(false);
   const isSshRegistration = watch("isSshRegistration", true);
+  const skipHostChecks = watch("skipHostChecks", false);
   const { state, dispatch, flushStateToDb }: any = useContext(Context);
+  const { supports } = useContext(AppContext);
+  const selectedStackName = getStepData(
+    state,
+    "VERSION",
+    "selectedStack.stack_name",
+    `${wizardName}Steps`,
+  );
+  const customizeAgentUserAccount = customizeAgentUserAccountProp
+    ?? Boolean(supports.customizeAgentUserAccount);
+  const isWindowsStack = isWindowsStackProp
+    ?? selectedStackName === "HDPWIN";
 
   const enableNext = () => {
     setNextEnabled(true);
@@ -119,6 +136,7 @@ export default function Step2({
       setValue("sshUserAccount", stepData.sshUserAccount || "root");
       setValue("sshPortNumber", stepData.sshPortNumber || 22);
       setValue("agentUserAccount", stepData.agentUserAccount || "root");
+      setValue("skipHostChecks", Boolean(stepData.skipHostChecks));
       setHostNameArr(stepData.targetHosts || []);
     }
   }, [currentStep.name, setValue, state, wizardName]);
@@ -193,7 +211,7 @@ export default function Step2({
 
   useEffect(() => enableNext(), []);
 
-  const moveToNextStep = (
+  const moveToNextStep = async (
     submission: FormFields | undefined = formData,
     hosts: string[] = hostNameArr,
   ) => {
@@ -213,7 +231,7 @@ export default function Step2({
         },
       },
     });
-    flushStateToDb("next");
+    await Promise.resolve(flushStateToDb("next"));
     handleNextImperitive();
   };
 
@@ -330,6 +348,20 @@ export default function Step2({
             }}
           />
         ) : null}
+        {showSkipHostChecksWarning ? (
+          <Modal
+            isOpen={showSkipHostChecksWarning}
+            onClose={() => setShowSkipHostChecksWarning(false)}
+            modalTitle="Skip Host Checks"
+            modalBody="Host checks will be skipped. The JDK compatibility check will still run before installation."
+            successCallback={() => setShowSkipHostChecksWarning(false)}
+            options={{
+              cancelableViaBtn: false,
+              cancelableViaIcon: false,
+              okButtonText: "OK",
+            }}
+          />
+        ) : null}
         <h2 className="step-title">Install Options</h2>
         <p className="make-all-grey step-description">
           Enter the list of hosts to be included in the cluster and provide your
@@ -421,6 +453,22 @@ export default function Step2({
                 <Alert variant="info">
                   Windows hosts use PowerShell Remoting; SSH settings are not required.
                 </Alert>
+              )}
+              {wizardName === "addHost" && (
+                <Form.Check
+                  className="mb-3"
+                  id="skip-host-checks"
+                  type="checkbox"
+                  checked={skipHostChecks}
+                  label="Skip host checks"
+                  onChange={() => {
+                    const nextValue = !skipHostChecks;
+                    setValue("skipHostChecks", nextValue);
+                    if (nextValue) {
+                      setShowSkipHostChecksWarning(true);
+                    }
+                  }}
+                />
               )}
               {!isWindowsStack && <><div className="d-flex mb-2">
                 <DefaultButton
@@ -569,9 +617,9 @@ export default function Step2({
           //@ts-ignore
           registerRef?.current?.click();
         }}
-        onBack={() => {
+        onBack={async () => {
+          await Promise.resolve(flushStateToDb("back"));
           handleBackImperitive();
-          flushStateToDb("back");
         }}
       />
     </>

--- a/ambari-web/latest/src/screens/ClusterWizard/Step3.test.tsx
+++ b/ambari-web/latest/src/screens/ClusterWizard/Step3.test.tsx
@@ -22,7 +22,9 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { ContextWrapper } from ".";
 
 const mocks = vi.hoisted(() => ({
+  getBootstrapStatus: vi.fn(),
   isHostsRegistered: vi.fn(),
+  launchBootstrap: vi.fn(),
   loadAmbariProperties: vi.fn(),
   startHostCheck: vi.fn(),
 }));
@@ -31,7 +33,11 @@ vi.mock("../../api/clusterApi", () => ({
   default: { loadAmbariProperties: mocks.loadAmbariProperties },
 }));
 vi.mock("../../api/wizardApi", () => ({
-  default: { isHostsRegistered: mocks.isHostsRegistered },
+  default: {
+    getBootstrapStatus: mocks.getBootstrapStatus,
+    isHostsRegistered: mocks.isHostsRegistered,
+    launchBootstrap: mocks.launchBootstrap,
+  },
 }));
 vi.mock("../../hooks/useHostChecks", () => ({
   useHostChecks: () => ({
@@ -120,5 +126,59 @@ describe("Confirm Hosts registration polling", () => {
       await vi.advanceTimersByTimeAsync(3000);
     });
     expect(mocks.isHostsRegistered).toHaveBeenCalledTimes(2);
+  });
+
+  it("resumes a persisted bootstrap request instead of launching another one", async () => {
+    mocks.getBootstrapStatus.mockResolvedValue({
+      hostsStatus: [{ hostName: "host1", status: "RUNNING", log: "Installing" }],
+      status: "RUNNING",
+    });
+    const contextValue = {
+      dispatch: vi.fn(),
+      flushStateToDb: vi.fn(),
+      state: {
+        addHostSteps: {
+          HOSTS: {
+            data: {
+              installedHosts: [],
+              isSshRegistration: true,
+              targetHosts: ["host1"],
+            },
+          },
+          HOST_STATUS: {
+            data: {
+              bootstrapRequestId: "23",
+              hostsStatus: [{
+                bootLog: "Installing",
+                bootStatus: "RUNNING",
+                isChecked: false,
+                name: "host1",
+              }],
+            },
+          },
+        },
+      },
+      stepWizardUtilities: {
+        currentStep: { name: "HOST_STATUS" },
+        handleBackImperitive: vi.fn(),
+        handleNextImperitive: vi.fn(),
+      },
+    };
+    const WizardContext = createContext(contextValue);
+
+    render(
+      <ContextWrapper.Provider value={{ Context: WizardContext }}>
+        <WizardContext.Provider value={contextValue}>
+          <Step3 wizardName="addHost" />
+        </WizardContext.Provider>
+      </ContextWrapper.Provider>,
+    );
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(mocks.getBootstrapStatus).toHaveBeenCalledWith("23");
+    expect(mocks.launchBootstrap).not.toHaveBeenCalled();
   });
 });

--- a/ambari-web/latest/src/screens/ClusterWizard/Step3.tsx
+++ b/ambari-web/latest/src/screens/ClusterWizard/Step3.tsx
@@ -103,10 +103,6 @@ export default function Step3({ wizardName = "clusterCreation" }: Step3Props) {
   ]);
   const [showHostCheck, setShowHostCheck] = useState(false);
 
-  const { startHostCheck, isHostCheckRunning, hostCheckResult } = useHostChecks(
-    false,
-    true
-  );
   const { Context } = useContext(ContextWrapper);
   const {
     state,
@@ -118,6 +114,40 @@ export default function Step3({ wizardName = "clusterCreation" }: Step3Props) {
       handleBackImperitive,
     },
   }: any = useContext(Context);
+  const restoredConfirmData = get(
+    state,
+    `${wizardName}Steps.HOST_STATUS.data`,
+    {},
+  );
+  const confirmDataRef = useRef<Record<string, any>>(restoredConfirmData);
+  const persistConfirmData = (data: Record<string, any>) => {
+    confirmDataRef.current = { ...confirmDataRef.current, ...data };
+    dispatch({
+      type: ActionTypes.STORE_INFORMATION,
+      payload: {
+        step: "HOST_STATUS",
+        data: confirmDataRef.current,
+      },
+    });
+  };
+  const { startHostCheck, isHostCheckRunning, hostCheckResult } = useHostChecks(
+    wizardName === "addHost",
+    true,
+    {
+      initialHosts: restoredConfirmData.hostsStatus || restoredConfirmData.hosts || [],
+      initialRequestID: restoredConfirmData.hostCheckRequestId,
+      initialWarningData: restoredConfirmData.hostCheckResult,
+      onStateChange: ({ isRunning, requestID, warningData }) => {
+        persistConfirmData({
+          hostCheckCompleted:
+            confirmDataRef.current.hostCheckStarted && !isRunning && requestID === -1,
+          hostCheckRequestId: requestID,
+          hostCheckResult: warningData,
+          hostCheckRunning: isRunning,
+        });
+      },
+    },
+  );
   const [nextEnabled, setNextEnabled] = useState(false);
   const enableNext = () => {
     setNextEnabled(true);
@@ -126,14 +156,32 @@ export default function Step3({ wizardName = "clusterCreation" }: Step3Props) {
     setNextEnabled(false);
   };
 
-  const registrationStartedAt = useRef<any>(null);
+  const registrationStartedAt = useRef<any>(
+    restoredConfirmData.registrationStartedAt ?? null,
+  );
+  const registrationDeadline = useRef<number | null>(
+    restoredConfirmData.registrationDeadline ?? null,
+  );
   const registrationTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const bootstrapTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const bootstrapStarted = useRef(false);
+  const bootstrapRequestId = useRef<string | null>(
+    restoredConfirmData.bootstrapRequestId || null,
+  );
+  const bootstrapStarted = useRef(Boolean(bootstrapRequestId.current));
+  const bootstrapPollStarted = useRef(false);
+  const registrationPollInFlight = useRef(false);
+  const registrationResumeStarted = useRef(false);
   const isMounted = useRef(true);
   //TODO: Remove this hack
-  const serviceCheckStarted = useRef(false);
+  const serviceCheckStarted = useRef(Boolean(
+    restoredConfirmData.hostCheckStarted || restoredConfirmData.hostCheckCompleted,
+  ));
   const hostsRef = useRef<Host[]>([]);
+  const shouldSkipHostChecks = wizardName === "addHost" && Boolean(get(
+    state,
+    `${wizardName}Steps.${wizardSteps[2].name}.data.skipHostChecks`,
+    false,
+  ));
 
   const {
     currentItems,
@@ -164,15 +212,23 @@ export default function Step3({ wizardName = "clusterCreation" }: Step3Props) {
   }, []);
 
   useEffect(() => {
-    if (
-      !isEmpty(get(state, `${wizardName}Steps.${wizardSteps[2].name}.data`, {}))
-    ) {
+    if (!isEmpty(get(state, `${wizardName}Steps.${wizardSteps[2].name}.data`, {}))) {
       loadHosts();
     }
-  }, [state]);
+  }, [wizardName]);
 
   useEffect(() => {
     hostsRef.current = hosts;
+    if (hostsRef.current.length) {
+      persistConfirmData({
+        hosts,
+        hostsStatus: hosts,
+        otherRegHosts,
+        bootstrapRequestId: bootstrapRequestId.current,
+        registrationStartedAt: registrationStartedAt.current,
+        registrationDeadline: registrationDeadline.current,
+      });
+    }
     if (hostsRef.current.length) {
       const installOptions = get(
         state,
@@ -180,18 +236,42 @@ export default function Step3({ wizardName = "clusterCreation" }: Step3Props) {
         {},
       );
       if (installOptions.isSshRegistration) {
-        if (!bootstrapStarted.current && hostsRef.current.some(
+        if (
+          bootstrapRequestId.current
+          && !bootstrapPollStarted.current
+          && hostsRef.current.some((host) =>
+            [BootStatus.PENDING, BootStatus.RUNNING].includes(
+              host.bootStatus as BootStatus,
+            ),
+          )
+        ) {
+          bootstrapStarted.current = true;
+          bootstrapPollStarted.current = true;
+          void pollBootstrap(bootstrapRequestId.current);
+        } else if (!bootstrapStarted.current && hostsRef.current.some(
           (host) => host.bootStatus === BootStatus.PENDING,
         )) {
           void startAutomaticBootstrap(installOptions);
-        } else if (
-          !registrationStartedAt.current
-          && hostsRef.current.some((host) => host.bootStatus === BootStatus.DONE)
-        ) {
-          startRegistration();
+        } else if (hostsRef.current.some((host) =>
+          [BootStatus.DONE, BootStatus.REGISTERING].includes(
+            host.bootStatus as BootStatus,
+          ),
+        )) {
+          if (!registrationStartedAt.current) {
+            startRegistration();
+          } else if (!registrationResumeStarted.current) {
+            registrationResumeStarted.current = true;
+            void isHostsRegistered();
+          }
         }
       } else if (!registrationStartedAt.current) {
         startRegistration();
+      } else if (
+        isRegistrationInProgress()
+        && !registrationResumeStarted.current
+      ) {
+        registrationResumeStarted.current = true;
+        void isHostsRegistered();
       }
 
     }
@@ -249,15 +329,34 @@ export default function Step3({ wizardName = "clusterCreation" }: Step3Props) {
 
   const beginHostsCheck = () => {
     if (!isRegistrationInProgress() && hostsRef.current.length > 0) {
-      startHostCheckLocal(hostsRef.current);
       serviceCheckStarted.current = true;
+      if (shouldSkipHostChecks) {
+        if (getRegisteredHosts(hostsRef.current).length) {
+          enableNext();
+        }
+      } else {
+        startHostCheckLocal(hostsRef.current);
+      }
     }
   };
 
   const startRegistration = () => {
     if (registrationStartedAt.current === null) {
-      registrationStartedAt.current = Date.now();
-      isHostsRegistered();
+      const installOptions = get(
+        state,
+        `${wizardName}Steps.${wizardSteps[2].name}.data`,
+        {},
+      );
+      const startedAt = Date.now();
+      registrationStartedAt.current = startedAt;
+      registrationResumeStarted.current = true;
+      registrationDeadline.current = startedAt
+        + addHostRegistrationTimeoutSecs(Boolean(installOptions.isSshRegistration)) * 1000;
+      persistConfirmData({
+        registrationStartedAt: startedAt,
+        registrationDeadline: registrationDeadline.current,
+      });
+      void isHostsRegistered();
     }
   };
 
@@ -280,8 +379,11 @@ export default function Step3({ wizardName = "clusterCreation" }: Step3Props) {
     const bootstrapStillRunning = hostsRef.current.some(
       (host) => host.bootStatus === BootStatus.RUNNING,
     );
-    const withinTimeout = registrationStartedAt.current !== null
-      && Date.now() - registrationStartedAt.current < timeoutSecs * 1000;
+    if (registrationDeadline.current === null && registrationStartedAt.current !== null) {
+      registrationDeadline.current = registrationStartedAt.current + timeoutSecs * 1000;
+    }
+    const withinTimeout = registrationDeadline.current !== null
+      && Date.now() < registrationDeadline.current;
     if (bootstrapStillRunning || withinTimeout) {
       if (registrationTimer.current) {
         clearTimeout(registrationTimer.current);
@@ -337,9 +439,15 @@ export default function Step3({ wizardName = "clusterCreation" }: Step3Props) {
         ));
       if (!terminal) {
         bootstrapTimer.current = setTimeout(() => void pollBootstrap(requestId), 3000);
+      } else {
+        bootstrapStarted.current = false;
+        bootstrapRequestId.current = null;
+        persistConfirmData({ bootstrapRequestId: null });
       }
     } catch (error: any) {
       bootstrapStarted.current = false;
+      bootstrapRequestId.current = null;
+      persistConfirmData({ bootstrapRequestId: null });
       failBootstrapHosts(
         error?.response?.data?.message || "Ambari could not bootstrap the selected hosts.",
       );
@@ -368,9 +476,14 @@ export default function Step3({ wizardName = "clusterCreation" }: Step3Props) {
         failBootstrapHosts(response.log || "Ambari could not start host bootstrap.");
         return;
       }
+      bootstrapRequestId.current = requestId;
+      bootstrapPollStarted.current = true;
+      persistConfirmData({ bootstrapRequestId: requestId });
       await pollBootstrap(requestId);
     } catch (error: any) {
       bootstrapStarted.current = false;
+      bootstrapRequestId.current = null;
+      persistConfirmData({ bootstrapRequestId: null });
       failBootstrapHosts(
         error?.response?.data?.message || "Ambari could not start host bootstrap.",
       );
@@ -378,6 +491,8 @@ export default function Step3({ wizardName = "clusterCreation" }: Step3Props) {
   };
 
   const isHostsRegistered = async () => {
+    if (registrationPollInFlight.current) return;
+    registrationPollInFlight.current = true;
     try {
       const response = await WizardApi.isHostsRegistered();
       if (response && isMounted.current) {
@@ -393,6 +508,8 @@ export default function Step3({ wizardName = "clusterCreation" }: Step3Props) {
         {},
       );
       scheduleRegistrationPoll(installOptions);
+    } finally {
+      registrationPollInFlight.current = false;
     }
   };
 
@@ -420,7 +537,15 @@ export default function Step3({ wizardName = "clusterCreation" }: Step3Props) {
         updatedHost.bootStatus = BootStatus.REGISTERING;
         updatedHost.bootLog =
           (updatedHost.bootLog || "") + "Registering with the server...\n\n";
-        registrationStartedAt.current = Date.now();
+        const startedAt = Date.now();
+        const installOptions = get(
+          state,
+          `${wizardName}Steps.${wizardSteps[2].name}.data`,
+          {},
+        );
+        registrationStartedAt.current = startedAt;
+        registrationDeadline.current = startedAt
+          + addHostRegistrationTimeoutSecs(Boolean(installOptions.isSshRegistration)) * 1000;
       } else if (
         updatedHost.bootStatus === BootStatus.REGISTERING &&
         data.items.find(
@@ -449,6 +574,13 @@ export default function Step3({ wizardName = "clusterCreation" }: Step3Props) {
   };
 
   const loadHosts = () => {
+    const restoredHosts = restoredConfirmData.hostsStatus || restoredConfirmData.hosts;
+    if (Array.isArray(restoredHosts) && restoredHosts.length) {
+      hostsRef.current = restoredHosts;
+      setHosts(restoredHosts);
+      setOtherRegHosts(restoredConfirmData.otherRegHosts || []);
+      return;
+    }
     const hostInfo = get(
       state,
       `${wizardName}Steps.${wizardSteps[2].name}.data.targetHosts`,
@@ -489,7 +621,16 @@ export default function Step3({ wizardName = "clusterCreation" }: Step3Props) {
     });
     setHosts(updatedHosts);
     registrationStartedAt.current = null;
+    registrationResumeStarted.current = false;
+    registrationDeadline.current = null;
     bootstrapStarted.current = false;
+    bootstrapPollStarted.current = false;
+    bootstrapRequestId.current = null;
+    persistConfirmData({
+      bootstrapRequestId: null,
+      registrationDeadline: null,
+      registrationStartedAt: null,
+    });
   };
 
   const startHostCheckLocal = (hostsList: Host[]) => {
@@ -498,6 +639,10 @@ export default function Step3({ wizardName = "clusterCreation" }: Step3Props) {
       !hostsList.every((host) => host.bootStatus === BootStatus.FAILED)
     ) {
       disableNext();
+      persistConfirmData({
+        hostCheckCompleted: false,
+        hostCheckStarted: true,
+      });
       startHostCheck(getRegisteredHosts(hostsList));
     }
   };
@@ -760,6 +905,14 @@ export default function Step3({ wizardName = "clusterCreation" }: Step3Props) {
       return null;
     }
 
+    if (shouldSkipHostChecks) {
+      return (
+        <Alert variant="warning" className="mt-2">
+          Host checks were skipped. JDK compatibility is checked independently.
+        </Alert>
+      );
+    }
+
     if (isHostCheckRunning) {
       return (
         <Alert variant="info" className="mt-2">
@@ -845,15 +998,25 @@ export default function Step3({ wizardName = "clusterCreation" }: Step3Props) {
     }
   };
 
-  const moveToNextStep = () => {
+  const moveToNextStep = async () => {
+    confirmDataRef.current = {
+      ...confirmDataRef.current,
+      bootstrapRequestId: bootstrapRequestId.current,
+      hostCheckResult,
+      hosts,
+      hostsStatus: hostsRef.current,
+      otherRegHosts,
+      registrationDeadline: registrationDeadline.current,
+      registrationStartedAt: registrationStartedAt.current,
+    };
     dispatch({
       type: ActionTypes.STORE_INFORMATION,
       payload: {
         step: currentStep.name,
-        data: { hosts, otherRegHosts, hostsStatus: hostsRef.current },
+        data: confirmDataRef.current,
       },
     });
-    flushStateToDb("next");
+    await Promise.resolve(flushStateToDb("next"));
     handleNextImperitive();
   };
 
@@ -871,7 +1034,7 @@ export default function Step3({ wizardName = "clusterCreation" }: Step3Props) {
               setShowHostCheck(false);
             }}
             successCallback={() => {
-              startHostCheck(getRegisteredHosts(hostsRef.current));
+              startHostCheckLocal(hostsRef.current);
             }}
             loading={isHostCheckRunning}
             hostCheckResult={hostCheckResult}
@@ -1029,8 +1192,8 @@ export default function Step3({ wizardName = "clusterCreation" }: Step3Props) {
           flushStateToDb("cancel");
         }}
         isBackEnabled={serviceCheckStarted.current && !isHostCheckRunning}
-        onBack={() => {
-          flushStateToDb("back")
+        onBack={async () => {
+          await Promise.resolve(flushStateToDb("back"));
           handleBackImperitive();
         }}
       />

--- a/ambari-web/latest/src/screens/ClusterWizard/Step4.tsx
+++ b/ambari-web/latest/src/screens/ClusterWizard/Step4.tsx
@@ -36,6 +36,10 @@ import { getStepData } from "../../Utils/Utility";
 import { ContextWrapper } from ".";
 import { AppContext } from "../../store/context";
 import Spinner from "../../components/Spinner";
+import {
+  deriveAddServiceFlow,
+  nextAddServiceStep,
+} from "../Services/AddServiceWizard/addServiceNavigation";
 
 type Service = {
   displayName: string;
@@ -47,6 +51,11 @@ type Service = {
   required: string[];
   isIgnored?: boolean;
   isHiddenOnDisplay: boolean;
+  hasClient?: boolean;
+  hasConfigs?: boolean;
+  hasMaster?: boolean;
+  hasNonMastersWithCustomAssignment?: boolean;
+  hasSlave?: boolean;
 };
 
 type ErrorType = {
@@ -68,7 +77,7 @@ export default function Step4({ wizardName = "clusterCreation" }) {
     serviceContextLoading = false,
     handleBackImperitive,
     installedServices: installedServicesProps = [],
-    stepWizardUtilities: { currentStep, handleNextImperitive },
+    stepWizardUtilities: { currentStep, handleNextImperitive, jumpToStep },
   }: any = useContext(Context);
   const { services: servicesContext } = useContext(AppContext);
   let installedServices = installedServicesProps;
@@ -128,6 +137,25 @@ export default function Step4({ wizardName = "clusterCreation" }) {
     setServices(updatedServices);
   };
 
+  const saveServicesAndContinue = async () => {
+    const flow = deriveAddServiceFlow(services);
+    dispatch({
+      type: ActionTypes.STORE_INFORMATION,
+      payload: {
+        step: currentStep.name,
+        data: { services, addServiceFlow: flow },
+      },
+    });
+    if (wizardName === "addService") {
+      const nextStep = nextAddServiceStep(1, flow);
+      await Promise.resolve(flushStateToDb("jump", nextStep));
+      jumpToStep(nextStep);
+    } else {
+      await Promise.resolve(flushStateToDb("next"));
+      handleNextImperitive();
+    }
+  };
+
   const validateSelectedServices = () => {
     const selectedServices = Object.values(services).filter(
       (service) => service.selected === true
@@ -154,17 +182,7 @@ export default function Step4({ wizardName = "clusterCreation" }) {
     if (newErrorStack.length > 0) {
       setShowModal(true);
     } else {
-      dispatch({
-        type: ActionTypes.STORE_INFORMATION,
-        payload: {
-          step: currentStep.name,
-          data: {
-            services,
-          },
-        },
-      });
-      flushStateToDb("next");
-      handleNextImperitive();
+      void saveServicesAndContinue();
     }
   };
 
@@ -282,6 +300,10 @@ export default function Step4({ wizardName = "clusterCreation" }) {
         );
         const transformedData: { [key: string]: any } = {};
         chooseServices.items.forEach((service: any) => {
+          const components = get(service, "components", []).map(
+            (component: any) => component.StackServiceComponents || {},
+          );
+          const configTypes = get(service, "StackServices.config_types");
           transformedData[service.StackServices.service_name] = {
             displayName: service.StackServices.display_name,
             serviceName: service.StackServices.service_name,
@@ -299,6 +321,21 @@ export default function Step4({ wizardName = "clusterCreation" }) {
             ),
             isHiddenOnDisplay: excludeServicesOnDisplay.includes(
               service.StackServices.service_name
+            ),
+            hasClient: components.some((component: any) => component.is_client),
+            hasConfigs: configTypes == null
+              ? true
+              : (Array.isArray(configTypes)
+                  ? configTypes.length > 0
+                  : Object.keys(configTypes).length > 0),
+            hasMaster: components.some((component: any) => component.is_master),
+            hasNonMastersWithCustomAssignment: components.some((component: any) =>
+              !component.is_master
+              && !component.is_client
+              && component.cardinality !== "ALL",
+            ),
+            hasSlave: components.some((component: any) =>
+              component.is_slave || component.component_category === "SLAVE",
             ),
           };
         });
@@ -564,29 +601,10 @@ export default function Step4({ wizardName = "clusterCreation" }) {
               onClose={() => {
                 if (errorStack[0].modalType === ModalType.MISSING_SERVICE) {
                   handleCloseLimitiedFunctionalityModal();
-                  dispatch({
-                    type: ActionTypes.STORE_INFORMATION,
-                    payload: {
-                      step: currentStep.name,
-                      data: {
-                        services,
-                      },
-                    },
-                  });
-                  flushStateToDb("next");
-                  handleNextImperitive();
+                  void saveServicesAndContinue();
                 } else {
                   handleCloseAddServiceModal();
                 }
-                dispatch({
-                  type: ActionTypes.STORE_INFORMATION,
-                  payload: {
-                    step: currentStep.name,
-                    data: {
-                      services,
-                    },
-                  },
-                });
               }}
               onCancel={() => setShowModal(false)}
               title={renderModalTitle(
@@ -609,11 +627,9 @@ export default function Step4({ wizardName = "clusterCreation" }) {
         onNext={() => {
           validateSelectedServices();
         }}
-        onCancel={() => {
-          flushStateToDb("cancel");
-        }}
-        onBack={() => {
-          flushStateToDb("back");
+        onCancel={() => void flushStateToDb("cancel")}
+        onBack={async () => {
+          await Promise.resolve(flushStateToDb("back"));
           handleBackImperitive();
         }}
         isNextEnabled={!nextDisabled}

--- a/ambari-web/latest/src/screens/ClusterWizard/Step5.test.tsx
+++ b/ambari-web/latest/src/screens/ClusterWizard/Step5.test.tsx
@@ -1,0 +1,108 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { createContext } from "react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ContextWrapper } from ".";
+
+const mocks = vi.hoisted(() => ({
+  flushStateToDb: vi.fn(),
+  handleNextImperitive: vi.fn(),
+}));
+
+vi.mock("../../components/AssignMasters", () => ({
+  default: ({
+    setHasValidationIssues,
+  }: {
+    setHasValidationIssues: (hasIssues: boolean) => void;
+  }) => (
+    <button onClick={() => setHasValidationIssues(true)}>REPORT ISSUE</button>
+  ),
+}));
+vi.mock("../../components/AssignMastersAddable", () => ({
+  default: () => null,
+}));
+vi.mock("../../components/StepWizard/WizardFooter", () => ({
+  default: ({ onNext }: { onNext: () => void }) => (
+    <button onClick={onNext}>NEXT</button>
+  ),
+}));
+
+import Step5 from "./Step5";
+
+describe("Assign Masters validation", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.flushStateToDb.mockResolvedValue(undefined);
+  });
+
+  it("requires Continue Anyway before advancing with matching issues", async () => {
+    const value = {
+      state: {
+        clusterCreationSteps: {
+          SERVICES: { data: { services: { HDFS: { selected: true } } } },
+          VERSION: {
+            data: {
+              selectedVersion: { stack_name: "HDP", stack_version: "3.1" },
+            },
+          },
+          HOSTS: {
+            data: {
+              hosts: [{ name: "host1.example.com", bootStatus: "REGISTERED" }],
+            },
+          },
+        },
+      },
+      dispatch: vi.fn(),
+      flushStateToDb: mocks.flushStateToDb,
+      installedHosts: [],
+      installedServices: [],
+      stepWizardUtilities: {
+        currentStep: { canGoBack: true, name: "MASTERS" },
+        handleNextImperitive: mocks.handleNextImperitive,
+        handleBackImperitive: vi.fn(),
+        jumpToStep: vi.fn(),
+      },
+    };
+    const WizardContext = createContext(value);
+
+    render(
+      <ContextWrapper.Provider value={{ Context: WizardContext }}>
+        <WizardContext.Provider value={value}>
+          <Step5 />
+        </WizardContext.Provider>
+      </ContextWrapper.Provider>,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "REPORT ISSUE" }));
+    fireEvent.click(screen.getByRole("button", { name: "NEXT" }));
+
+    expect(mocks.flushStateToDb).not.toHaveBeenCalled();
+    expect(mocks.handleNextImperitive).not.toHaveBeenCalled();
+    fireEvent.click(
+      screen.getByRole("button", { name: "Continue Anyway" }),
+    );
+
+    await waitFor(() => {
+      expect(mocks.flushStateToDb).toHaveBeenCalledWith("next");
+      expect(mocks.handleNextImperitive).toHaveBeenCalledOnce();
+    });
+  });
+});
+

--- a/ambari-web/latest/src/screens/ClusterWizard/Step5.tsx
+++ b/ambari-web/latest/src/screens/ClusterWizard/Step5.tsx
@@ -26,6 +26,11 @@ import { BootStatus } from "./Step3";
 import { ContextWrapper } from ".";
 import AssignMastersAddable from "../../components/AssignMastersAddable";
 import { Card, CardBody } from "react-bootstrap";
+import Modal from "../../components/Modal";
+import {
+  nextAddServiceStep,
+  previousAddServiceStep,
+} from "../Services/AddServiceWizard/addServiceNavigation";
 
 function Step5({ wizardName = "clusterCreation" }) {
   const { Context } = useContext(ContextWrapper);
@@ -35,9 +40,17 @@ function Step5({ wizardName = "clusterCreation" }) {
     flushStateToDb,
     installedHosts,
     installedServices,
-    stepWizardUtilities: { handleNextImperitive, currentStep, handleBackImperitive },
+    stepWizardUtilities: {
+      handleNextImperitive,
+      currentStep,
+      handleBackImperitive,
+      jumpToStep,
+    },
   } = useContext(Context) as any;
-  const [canProcced, setCanProceed] = useState(true);
+  const [canProcced, setCanProceed] = useState(wizardName === "addService");
+  const [hasValidationIssues, setHasValidationIssues] = useState(false);
+  const [showValidationIssuesModal, setShowValidationIssuesModal] =
+    useState(false);
   const servicesData: any = get(
     state,
     `${wizardName}Steps.SERVICES.data.services`,
@@ -48,6 +61,11 @@ function Step5({ wizardName = "clusterCreation" }) {
   const services = Object.keys(servicesData).filter((service) => {
     return servicesData[service].selected;
   });
+  const addServiceFlow = get(
+    state,
+    "addServiceSteps.SERVICES.data.addServiceFlow",
+    {},
+  );
   const hostsData = get(
     state,
     `${wizardName}Steps.${wizardSteps[3].name}.data.hosts`,
@@ -93,6 +111,7 @@ function Step5({ wizardName = "clusterCreation" }) {
           installedServices={installedServices}
           setCanProceed={setCanProceed}
           parentState={state}
+          setHasValidationIssues={setHasValidationIssues}
           dispatch={(data: any) => {
             dispatch({
               type: ActionTypes.STORE_INFORMATION,
@@ -104,20 +123,46 @@ function Step5({ wizardName = "clusterCreation" }) {
           }}
         />
       )}
+      <Modal
+        isOpen={showValidationIssuesModal}
+        onClose={() => setShowValidationIssuesModal(false)}
+        modalTitle="Validation Issues"
+        modalBody="The master assignments contain validation issues. Continue anyway?"
+        options={{ okButtonText: "Continue Anyway" }}
+        successCallback={async () => {
+          setShowValidationIssuesModal(false);
+          await Promise.resolve(flushStateToDb("next"));
+          handleNextImperitive();
+        }}
+      />
       <WizardFooter
         step={currentStep}
         lifted
         isNextEnabled={canProcced}
-        onNext={() => {
-          flushStateToDb("next");
-          handleNextImperitive();
+        onNext={async () => {
+          if (wizardName === "addService") {
+            const nextStep = nextAddServiceStep(2, addServiceFlow);
+            await Promise.resolve(flushStateToDb("jump", nextStep));
+            jumpToStep(nextStep);
+          } else if (hasValidationIssues) {
+            setShowValidationIssuesModal(true);
+          } else {
+            await Promise.resolve(flushStateToDb("next"));
+            handleNextImperitive();
+          }
         }}
         onCancel={() => {
           flushStateToDb("cancel");
         }}
-        onBack={() => {
-          flushStateToDb("back");
-          handleBackImperitive();
+        onBack={async () => {
+          if (wizardName === "addService") {
+            const previousStep = previousAddServiceStep(2, addServiceFlow);
+            await Promise.resolve(flushStateToDb("jump", previousStep));
+            jumpToStep(previousStep);
+          } else {
+            await Promise.resolve(flushStateToDb("back"));
+            handleBackImperitive();
+          }
         }}
       />
     </>

--- a/ambari-web/latest/src/screens/ClusterWizard/Step6.tsx
+++ b/ambari-web/latest/src/screens/ClusterWizard/Step6.tsx
@@ -32,6 +32,10 @@ import useServiceComponents from "./hooks/useServiceComponents";
 import WizardFooter from "../../components/StepWizard/WizardFooter";
 import { ActionTypes } from "./clusterStore/types";
 import { ContextWrapper } from ".";
+import {
+  nextAddServiceStep,
+  previousAddServiceStep,
+} from "../Services/AddServiceWizard/addServiceNavigation";
 import { getStepData } from "../../Utils/Utility";
 import modalManager from "../../store/ModalManager";
 import Modal from "../../components/Modal";
@@ -59,6 +63,7 @@ function Step6({ wizardName = "clusterCreation" }: Step6Props) {
       currentStep,
       handleNextImperitive,
       handleBackImperitive,
+      jumpToStep,
     },
   }: any = useContext(Context);
   const initialServiceComponents = get(
@@ -80,6 +85,11 @@ function Step6({ wizardName = "clusterCreation" }: Step6Props) {
   } = useServiceComponents(wizardName, initialServiceComponents);
 
   const [nextEnabled, setNextEnabled] = useState(false);
+  const addServiceFlow = get(
+    state,
+    "addServiceSteps.SERVICES.data.addServiceFlow",
+    {},
+  );
 
   const enableNext = () => {
     setNextEnabled(true);
@@ -429,6 +439,30 @@ function Step6({ wizardName = "clusterCreation" }: Step6Props) {
     return changedComponents;
   };
 
+  const saveAssignmentsAndContinue = async () => {
+    dispatch({
+      type: ActionTypes.STORE_INFORMATION,
+      payload: {
+        step: currentStep.name,
+        data: {
+          serviceComponents:
+            wizardName === "addHost"
+              ? getAdditionalServiceComponents()
+              : serviceComponents,
+          allServiceComponentsList,
+        },
+      },
+    });
+    if (wizardName === "addService") {
+      const nextStep = nextAddServiceStep(3, addServiceFlow);
+      await Promise.resolve(flushStateToDb("jump", nextStep));
+      jumpToStep(nextStep);
+    } else {
+      await Promise.resolve(flushStateToDb("next"));
+      handleNextImperitive();
+    }
+  };
+
   const showValidationIssuesModal = () => {
     if (validationErrors.length > 0) {
       modalManager.show(
@@ -449,22 +483,7 @@ function Step6({ wizardName = "clusterCreation" }: Step6Props) {
           }}
           successCallback={() => {
             modalManager.hide();
-            // Proceed to next step
-            dispatch({
-              type: ActionTypes.STORE_INFORMATION,
-              payload: {
-                step: currentStep.name,
-                data: {
-                  serviceComponents:
-                    wizardName === "addHost"
-                      ? getAdditionalServiceComponents()
-                      : serviceComponents,
-                  allServiceComponentsList,
-                },
-              },
-            });
-            flushStateToDb("next");
-            handleNextImperitive();
+            void saveAssignmentsAndContinue();
           }}
           onClose={() => {
             modalManager.hide();
@@ -472,22 +491,7 @@ function Step6({ wizardName = "clusterCreation" }: Step6Props) {
         />
       );
     } else {
-      // No validation issues, proceed normally
-      dispatch({
-        type: ActionTypes.STORE_INFORMATION,
-        payload: {
-          step: currentStep.name,
-          data: {
-            serviceComponents:
-              wizardName === "addHost"
-                ? getAdditionalServiceComponents()
-                : serviceComponents,
-            allServiceComponentsList,
-          },
-        },
-      });
-      flushStateToDb("next");
-      handleNextImperitive();
+      void saveAssignmentsAndContinue();
     }
   };
 
@@ -653,9 +657,15 @@ function Step6({ wizardName = "clusterCreation" }: Step6Props) {
         onCancel={() => {
           flushStateToDb("cancel");
         }}
-        onBack={() => {
-          flushStateToDb("back");
-          handleBackImperitive();
+        onBack={async () => {
+          if (wizardName === "addService") {
+            const previousStep = previousAddServiceStep(3, addServiceFlow);
+            await Promise.resolve(flushStateToDb("jump", previousStep));
+            jumpToStep(previousStep);
+          } else {
+            await Promise.resolve(flushStateToDb("back"));
+            handleBackImperitive();
+          }
         }}
         step={currentStep}
       />

--- a/ambari-web/latest/src/screens/ClusterWizard/Step7/index.tsx
+++ b/ambari-web/latest/src/screens/ClusterWizard/Step7/index.tsx
@@ -21,7 +21,7 @@ import WizardApi from "../../../api/wizardApi";
 import Spinner from "../../../components/Spinner";
 import CredentialsTab, { processDataForCredentialsTab } from "./CredentialsTab";
 import AccountsTab from "./AccountsTab";
-import { Nav, Row, Tab } from "react-bootstrap";
+import { Button, Modal as BootstrapModal, Nav, Row, Tab } from "react-bootstrap";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import {
   faAlignJustify,
@@ -77,6 +77,11 @@ import DependentConfigurationsModal from "../../../components/DependentConfigura
 import { ServiceContext } from "../../../store/ServiceContext";
 import { serviceNameModelMapping } from "../../../constants";
 import { fetchComponentHostNamesByComponent } from "../../CommonConfigs/ConfigUtils";
+import {
+  nextAddServiceStep,
+  previousAddServiceStep,
+} from "../../Services/AddServiceWizard/addServiceNavigation";
+import { shouldWarnBeforeSkippingPreInstallChecks } from "../preInstallChecks";
 
 type PropTypes = {
   wizardName?: string;
@@ -84,7 +89,7 @@ type PropTypes = {
 
 export default function Step7({ wizardName = "clusterCreation" }: PropTypes) {
   const { Context } = useContext(ContextWrapper);
-  const { clusterName } = useContext(AppContext);
+  const { clusterName, supports } = useContext(AppContext);
   const { allServiceModels } = useContext(ServiceContext);
   const {
     state,
@@ -98,6 +103,11 @@ export default function Step7({ wizardName = "clusterCreation" }: PropTypes) {
     const stepData = get(state, `${wizardName}Steps.${stepName}.data`, {});
     return get(stepData, dataKey, "");
   };
+  const addServiceFlow = get(
+    state,
+    "addServiceSteps.SERVICES.data.addServiceFlow",
+    {},
+  );
   const [themes, setThemes] = useState<any>(
     getStepData("CONFIGURATION", "themes") || {}
   );
@@ -124,6 +134,11 @@ export default function Step7({ wizardName = "clusterCreation" }: PropTypes) {
 
   const [configPropertiesLoaded, setConfigPropertiesLoaded] = useState(false);
   const [propertyValues, setPropertyValues] = useState<any>({});
+  const [preInstallChecksWereRun, setPreInstallChecksWereRun] = useState(
+    Boolean(getStepData("CONFIGURATION", "preInstallChecksWereRun")),
+  );
+  const [showPreInstallChecks, setShowPreInstallChecks] = useState(false);
+  const [showSkippedChecksWarning, setShowSkippedChecksWarning] = useState(false);
 
   const hostsData = get(
     state,
@@ -184,13 +199,20 @@ export default function Step7({ wizardName = "clusterCreation" }: PropTypes) {
         themes,
         configs,
         stackLevelConfigs,
+        preInstallChecksWereRun,
       },
     };
     dispatch({
       type: ActionTypes.STORE_INFORMATION,
       payload: data,
     });
-  }, [JSON.stringify(configProperties), configs, themes, stackLevelConfigs]);
+  }, [
+    JSON.stringify(configProperties),
+    configs,
+    themes,
+    stackLevelConfigs,
+    preInstallChecksWereRun,
+  ]);
 
   const initialServiceComponents = get(
     state,
@@ -2185,14 +2207,37 @@ export default function Step7({ wizardName = "clusterCreation" }: PropTypes) {
     };
   };
 
-  const handleNext = () => {
-    if (tabMapping[selectedTab].nextTab && wizardName === "clusterCreation") {
-      flushStateToDb("next");
-      setSelectedTab(tabMapping?.[selectedTab]?.nextTab as string);
+  const continueAfterConfiguration = async () => {
+    if (wizardName === "addService") {
+      const nextStep = nextAddServiceStep(4, addServiceFlow);
+      await Promise.resolve(flushStateToDb("jump", nextStep));
+      jumpToStep(nextStep);
     } else {
-      flushStateToDb("next");
+      await Promise.resolve(flushStateToDb("next"));
       handleNextImperitive();
     }
+  };
+
+  const runPreInstallChecks = () => {
+    setPreInstallChecksWereRun(true);
+    setShowSkippedChecksWarning(false);
+    setShowPreInstallChecks(true);
+  };
+
+  const handleNext = async () => {
+    if (tabMapping[selectedTab].nextTab && wizardName === "clusterCreation") {
+      setSelectedTab(tabMapping?.[selectedTab]?.nextTab as string);
+      return;
+    }
+    if (shouldWarnBeforeSkippingPreInstallChecks(
+      wizardName,
+      Boolean(supports.preInstallChecks),
+      preInstallChecksWereRun,
+    )) {
+      setShowSkippedChecksWarning(true);
+      return;
+    }
+    await continueAfterConfiguration();
   };
 
   const addServiceTabMapping = () => {
@@ -2225,6 +2270,45 @@ export default function Step7({ wizardName = "clusterCreation" }: PropTypes) {
 
   return (
     <>
+      <BootstrapModal
+        show={showSkippedChecksWarning}
+        onHide={() => setShowSkippedChecksWarning(false)}
+      >
+        <BootstrapModal.Header closeButton>
+          <BootstrapModal.Title>Skipping Pre Install Checks</BootstrapModal.Title>
+        </BootstrapModal.Header>
+        <BootstrapModal.Body>
+          Skipping Pre Install Checks is not recommended.
+        </BootstrapModal.Body>
+        <BootstrapModal.Footer>
+          <Button variant="secondary" onClick={runPreInstallChecks}>
+            Run Pre Install Checks
+          </Button>
+          <Button
+            variant="primary"
+            onClick={() => {
+              setShowSkippedChecksWarning(false);
+              void continueAfterConfiguration();
+            }}
+          >
+            Ignore and Proceed
+          </Button>
+        </BootstrapModal.Footer>
+      </BootstrapModal>
+      <BootstrapModal
+        show={showPreInstallChecks}
+        onHide={() => setShowPreInstallChecks(false)}
+      >
+        <BootstrapModal.Header closeButton>
+          <BootstrapModal.Title>Pre Install Checks</BootstrapModal.Title>
+        </BootstrapModal.Header>
+        <BootstrapModal.Body />
+        <BootstrapModal.Footer>
+          <Button variant="primary" onClick={() => setShowPreInstallChecks(false)}>
+            Close
+          </Button>
+        </BootstrapModal.Footer>
+      </BootstrapModal>
       <div>
         {/* Dependent Configurations Warning Banner for Add Service */}
         {wizardName === "addService" && getDependentConfigsSummary() && (
@@ -2292,15 +2376,28 @@ export default function Step7({ wizardName = "clusterCreation" }: PropTypes) {
       <WizardFooter
         isNextEnabled={isNextEnabled}
         lifted
-        onNext={handleNext}
+        onNext={() => void handleNext()}
         onCancel={() => {
           flushStateToDb("cancel");
         }}
-        onBack={() => {
-          flushStateToDb("back");
-          jumpToStep(6);
+        onBack={async () => {
+          if (wizardName === "addService") {
+            const previousStep = previousAddServiceStep(4, addServiceFlow);
+            await Promise.resolve(flushStateToDb("jump", previousStep));
+            jumpToStep(previousStep);
+          } else {
+            await Promise.resolve(flushStateToDb("back"));
+            jumpToStep(6);
+          }
         }}
         step={currentStep}
+        sideItems={
+          wizardName === "clusterCreation" && supports.preInstallChecks ? (
+            <Button size="sm" variant="outline-secondary" onClick={runPreInstallChecks}>
+              Pre Install Checks
+            </Button>
+          ) : null
+        }
       />
       
       {/* Dependent Configurations Modal */}

--- a/ambari-web/latest/src/screens/ClusterWizard/Step8.test.tsx
+++ b/ambari-web/latest/src/screens/ClusterWizard/Step8.test.tsx
@@ -1,0 +1,380 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { createContext, type ContextType, type ReactNode } from "react";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { AppContext } from "../../store/context";
+import { ContextWrapper } from ".";
+
+const mocks = vi.hoisted(() => ({
+  addRequestToCreateComponent: vi.fn(),
+  applyClusterConfigs: vi.fn(),
+  createCluster: vi.fn(),
+  createSelectedServices: vi.fn(),
+  deleteCluster: vi.fn(),
+  deleteRepositoryVersion: vi.fn(),
+  dispatch: vi.fn(),
+  flushStateToDb: vi.fn(),
+  getKerberosDescriptorArtifact: vi.fn(),
+  getKerberosDescriptorProperties: vi.fn(),
+  getAllClusters: vi.fn(),
+  getAllVersionDefinitions: vi.fn(),
+  getServices: vi.fn(),
+  handleBackImperitive: vi.fn(),
+  handleNextImperitive: vi.fn(),
+  kerberosMode: {
+    error: "",
+    isLoaded: true,
+    isManualKerberos: false,
+    kdcType: "mit-kdc",
+    reload: vi.fn(),
+  },
+  postVersionDefinitionFile: vi.fn(),
+  print: vi.fn(),
+  registerHostToCluster: vi.fn(),
+  saveAndEditKerberosData: vi.fn(),
+  saveAs: vi.fn(),
+  saveKerberosData: vi.fn(),
+  downloadKerberosIdentitiesCsv: vi.fn(),
+  updateRepoOSInfo: vi.fn(),
+  updateService: vi.fn(),
+}));
+
+vi.mock("../../api/chooseServicesApi", () => ({
+  ChooseServicesApi: { getServices: mocks.getServices },
+}));
+vi.mock("../../api/versionsApi", () => ({
+  default: {
+    deleteRepositoryVersion: mocks.deleteRepositoryVersion,
+    getAllVersionDefinitions: mocks.getAllVersionDefinitions,
+    postVersionDefinitionFile: mocks.postVersionDefinitionFile,
+    updateRepoOSInfo: mocks.updateRepoOSInfo,
+  },
+}));
+vi.mock("../../api/clusterApi", () => ({
+  default: {
+    deleteCluster: mocks.deleteCluster,
+    getAllClusters: mocks.getAllClusters,
+  },
+}));
+vi.mock("../../api/clusterDeployment", () => ({
+  default: {
+    addRequestToCreateComponent: mocks.addRequestToCreateComponent,
+    applyClusterConfigs: mocks.applyClusterConfigs,
+    createCluster: mocks.createCluster,
+    createSelectedServices: mocks.createSelectedServices,
+    registerHostToCluster: mocks.registerHostToCluster,
+  },
+}));
+vi.mock("../../api/serviceApi", () => ({
+  ServiceApi: { updateService: mocks.updateService },
+}));
+vi.mock("../../api/configGroupApi", () => ({
+  default: { addConfigGroup: vi.fn(), updateConfigGroup: vi.fn() },
+}));
+vi.mock("../../api/kerberosApi", () => ({
+  default: {
+    downloadKerberosIdentitiesCsv: mocks.downloadKerberosIdentitiesCsv,
+    getKerberosDescriptorArtifact: mocks.getKerberosDescriptorArtifact,
+    getKerberosDescriptorProperties: mocks.getKerberosDescriptorProperties,
+    saveAndEditKerberosData: mocks.saveAndEditKerberosData,
+    saveKerberosData: mocks.saveKerberosData,
+  },
+}));
+vi.mock("../../hooks/useKerberosMode", () => ({
+  default: () => mocks.kerberosMode,
+}));
+vi.mock("../../hooks/useKDCSessionState", () => ({
+  default: () => ({
+    getKDCSessionState: (callback: () => void | Promise<void>) => callback(),
+  }),
+}));
+vi.mock("file-saver", () => ({ saveAs: mocks.saveAs }));
+vi.mock("../../components/StepWizard/WizardFooter", () => ({
+  default: ({
+    isNextEnabled,
+    onNext,
+    sideItems,
+    step,
+  }: {
+    isNextEnabled: boolean;
+    onNext: () => void;
+    sideItems: ReactNode;
+    step: { nextLabel: string };
+  }) => (
+    <>
+      {sideItems}
+      <button disabled={!isNextEnabled} onClick={onNext}>
+        {step.nextLabel}
+      </button>
+    </>
+  ),
+}));
+
+import Step8 from "./Step8";
+
+const clusterCreationSteps = {
+    NAME: { data: { clusterName: "cluster1" } },
+    VERSION: {
+      data: {
+        operatingSystems: { "HDP-3.0": [] },
+        selectedStack: { id: "HDP-3.0", stack_name: "HDP", stack_version: "3.0" },
+        selectedVersion: { id: "HDP-3.0", stack_version: "3.0" },
+        versionDefinitionSource: {
+          type: "url",
+          payload: { VersionDefinition: { version_url: "https://repo.invalid/vdf.xml" } },
+        },
+      },
+    },
+    HOSTS: { data: { installedHosts: [] } },
+    HOST_STATUS: {
+      data: { hosts: [{ bootStatus: "REGISTERED", name: "host1" }] },
+    },
+    SERVICES: {
+      data: {
+        services: {
+          HDFS: {
+            installed: false,
+            selected: true,
+            serviceName: "HDFS",
+          },
+        },
+      },
+    },
+    MASTERS: { data: { mastersData: [] } },
+    SLAVES_AND_CLIENTS: { data: { serviceComponents: [] } },
+    CONFIGURATION: {
+      data: {
+        configProperties: {
+          HDFS: {
+            "core-site": {
+              properties: {
+                authentication: {
+                  fileName: "core-site.xml",
+                  isSecureConfig: true,
+                  propertyAttributes: { type: "string" },
+                  propertyName: "hadoop.security.authentication",
+                  type: "core-site",
+                  value: "custom-kerberos",
+                },
+              },
+            },
+          },
+          MISC: { "Users and Groups": { properties: {} } },
+        },
+      },
+    },
+    REVIEW: { data: {} },
+};
+
+function wizardState(wizardName: "clusterCreation" | "addService") {
+  return {
+    [`${wizardName}Steps`]: structuredClone(clusterCreationSteps),
+  };
+}
+
+function renderStep({
+  isKerberosEnabled = false,
+  wizardName = "clusterCreation",
+}: {
+  isKerberosEnabled?: boolean;
+  wizardName?: "clusterCreation" | "addService";
+} = {}) {
+  const contextValue = {
+    dispatch: mocks.dispatch,
+    flushStateToDb: mocks.flushStateToDb,
+    state: wizardState(wizardName),
+    installedServices: [],
+    stepWizardUtilities: {
+      currentStep: { name: "REVIEW" },
+      handleBackImperitive: mocks.handleBackImperitive,
+      handleNextImperitive: mocks.handleNextImperitive,
+      jumpToStep: vi.fn(),
+    },
+  };
+  const WizardContext = createContext(contextValue);
+  return render(
+    <AppContext.Provider value={{
+      clusterName: "cluster1",
+      cluster: { stack: "HDP", versionNum: "3.0" },
+      isKerberosEnabled,
+    } as ContextType<typeof AppContext>}>
+      <ContextWrapper.Provider value={{ Context: WizardContext }}>
+        <WizardContext.Provider value={contextValue}>
+          <Step8 wizardName={wizardName} />
+        </WizardContext.Provider>
+      </ContextWrapper.Provider>
+    </AppContext.Provider>,
+  );
+}
+
+describe("cluster deployment Review", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    Object.defineProperty(window, "print", {
+      configurable: true,
+      value: mocks.print,
+    });
+    mocks.flushStateToDb.mockResolvedValue(undefined);
+    mocks.getAllClusters.mockResolvedValue({ items: [] });
+    mocks.getAllVersionDefinitions.mockResolvedValue({ items: [] });
+    mocks.getServices.mockResolvedValue({
+      items: [{ StackServices: { service_name: "HDFS" }, components: [] }],
+    });
+    mocks.postVersionDefinitionFile.mockResolvedValue({
+      resources: [{
+        VersionDefinition: {
+          id: "101",
+          stack_name: "HDP",
+          stack_version: "3.0",
+        },
+      }],
+    });
+    mocks.updateRepoOSInfo.mockResolvedValue({});
+    mocks.createSelectedServices.mockResolvedValue({});
+    mocks.downloadKerberosIdentitiesCsv.mockResolvedValue(
+      "principal,keytab\nservice/host@EXAMPLE.COM,/etc/security/keytabs/service.keytab",
+    );
+    mocks.getKerberosDescriptorArtifact.mockResolvedValue({ artifact_data: {} });
+    mocks.getKerberosDescriptorProperties.mockResolvedValue({
+      KerberosDescriptor: {
+        kerberos_descriptor: {
+          identities: [],
+          services: [{
+            name: "HDFS",
+            configurations: [{
+              "core-site": { "hadoop.security.authentication": "kerberos" },
+            }],
+          }],
+        },
+      },
+    });
+    mocks.kerberosMode.error = "";
+    mocks.kerberosMode.isLoaded = true;
+    mocks.kerberosMode.isManualKerberos = false;
+    mocks.kerberosMode.kdcType = "mit-kdc";
+    mocks.applyClusterConfigs.mockResolvedValue({});
+    mocks.registerHostToCluster.mockResolvedValue({});
+    mocks.updateService.mockResolvedValue({ Requests: { id: 41 } });
+  });
+
+  afterEach(() => cleanup());
+
+  it("retains a custom VDF source, blocks install on failure, and resumes completed stages", async () => {
+    mocks.createCluster
+      .mockRejectedValueOnce(new Error("Cluster creation failed"))
+      .mockResolvedValueOnce({});
+    renderStep();
+    await screen.findByRole("button", { name: "DEPLOY" });
+
+    fireEvent.click(screen.getByRole("button", { name: "DEPLOY" }));
+    expect(await screen.findByText("Cluster creation failed")).toBeTruthy();
+    expect(mocks.updateService).not.toHaveBeenCalled();
+    expect(mocks.postVersionDefinitionFile).toHaveBeenCalledWith(
+      { VersionDefinition: { version_url: "https://repo.invalid/vdf.xml" } },
+      {},
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "DEPLOY" }));
+    await waitFor(() => expect(mocks.handleNextImperitive).toHaveBeenCalledOnce());
+    expect(mocks.postVersionDefinitionFile).toHaveBeenCalledOnce();
+    expect(mocks.createCluster).toHaveBeenCalledTimes(2);
+    expect(mocks.updateService).toHaveBeenCalledOnce();
+    expect(mocks.flushStateToDb).toHaveBeenLastCalledWith(
+      "next",
+      -1,
+      "CLUSTER_INSTALLING_3",
+    );
+  });
+
+  it("prints Review and downloads the Blueprint archive", async () => {
+    renderStep();
+    await screen.findByRole("button", { name: "DEPLOY" });
+
+    fireEvent.click(screen.getByRole("button", { name: "Print Review" }));
+    expect(mocks.print).toHaveBeenCalledOnce();
+
+    fireEvent.click(screen.getByRole("button", { name: "Generate Blueprint" }));
+    await waitFor(() => expect(mocks.saveAs).toHaveBeenCalledWith(
+      expect.any(Blob),
+      "cluster1-blueprint.zip",
+    ));
+  });
+
+  it("prefetches identities and updates the existing descriptor for managed Kerberos", async () => {
+    renderStep({ isKerberosEnabled: true, wizardName: "addService" });
+
+    expect(await screen.findByText("Kerberos KDC type: mit-kdc")).toBeTruthy();
+    expect(mocks.downloadKerberosIdentitiesCsv).toHaveBeenCalledWith("cluster1");
+
+    fireEvent.click(screen.getByRole("button", { name: "DEPLOY" }));
+    await waitFor(() => expect(mocks.saveAndEditKerberosData).toHaveBeenCalledOnce());
+    expect(mocks.saveAndEditKerberosData).toHaveBeenCalledWith(
+      "cluster1",
+      expect.objectContaining({
+        artifact_data: expect.objectContaining({
+          services: [expect.objectContaining({
+            configurations: [{
+              "core-site": {
+                "hadoop.security.authentication": "custom-kerberos",
+              },
+            }],
+          })],
+        }),
+      }),
+    );
+    await waitFor(() => expect(mocks.handleNextImperitive).toHaveBeenCalledOnce());
+  });
+
+  it("creates the descriptor early and explains principal ownership for manual Kerberos", async () => {
+    mocks.kerberosMode.isManualKerberos = true;
+    mocks.kerberosMode.kdcType = "none";
+    mocks.getKerberosDescriptorArtifact.mockRejectedValueOnce({
+      response: { status: 404 },
+    });
+
+    renderStep({ isKerberosEnabled: true, wizardName: "addService" });
+
+    expect(await screen.findByText(/you must create and distribute principals and keytabs/)).toBeTruthy();
+    expect(mocks.saveKerberosData).toHaveBeenCalledOnce();
+    expect(mocks.saveAndEditKerberosData).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole("button", { name: "Download Kerberos CSV" }));
+    await waitFor(() => expect(mocks.saveAs).toHaveBeenCalledOnce());
+  });
+
+  it("blocks deployment when descriptor validation fails and allows preparation retry", async () => {
+    mocks.getKerberosDescriptorProperties
+      .mockResolvedValueOnce({ KerberosDescriptor: { kerberos_descriptor: {} } })
+      .mockResolvedValue({
+        KerberosDescriptor: {
+          kerberos_descriptor: { identities: [], services: [] },
+        },
+      });
+    renderStep({ isKerberosEnabled: true, wizardName: "addService" });
+
+    expect(await screen.findByText("Ambari returned an invalid Kerberos descriptor.")).toBeTruthy();
+    expect((screen.getByRole("button", { name: "DEPLOY" }) as HTMLButtonElement).disabled).toBe(true);
+
+    fireEvent.click(screen.getByRole("button", { name: "Retry Kerberos Preparation" }));
+    await waitFor(() => {
+      expect((screen.getByRole("button", { name: "DEPLOY" }) as HTMLButtonElement).disabled).toBe(false);
+    });
+  });
+});

--- a/ambari-web/latest/src/screens/ClusterWizard/Step8.tsx
+++ b/ambari-web/latest/src/screens/ClusterWizard/Step8.tsx
@@ -18,7 +18,7 @@
 
 //@ts-nocheck
 import { useContext, useEffect, useRef, useState } from "react";
-import { Card, Stack } from "react-bootstrap";
+import { Alert, Button, Card, Spinner as BootstrapSpinner, Stack } from "react-bootstrap";
 import {
   cloneDeep,
   every,
@@ -41,15 +41,20 @@ import VersionsApi from "../../api/versionsApi";
 import WizardFooter from "../../components/StepWizard/WizardFooter";
 import ClusterDeploymentApi from "../../api/clusterDeployment";
 import ClusterApi from "../../api/clusterApi";
-import ExecuteTasksModal from "../../components/ExecuteTasksModal";
 import { ServiceApi } from "../../api/serviceApi";
 import { ActionTypes } from "./clusterStore/types";
 import { ContextWrapper } from ".";
-import { HostsApi } from "../../api/hostsApi";
 import useKDCSessionState from "../../hooks/useKDCSessionState";
 import KerberosApi from "../../api/kerberosApi";
 import { getConfigTagFromFileName } from "../CommonConfigs/ConfigUtils";
 import { AppContext } from "../../store/context";
+import { runDeploymentPlan } from "./deploymentQueue";
+import ConfigGroupApi from "../../api/configGroupApi";
+import { previousAddServiceStep } from "../Services/AddServiceWizard/addServiceNavigation";
+import useKerberosMode from "../../hooks/useKerberosMode";
+import { saveAs } from "file-saver";
+import JSZip from "jszip";
+import { buildBlueprintExport } from "./blueprintExport";
 
 type Step8Props = {
   wizardName?: string;
@@ -73,31 +78,64 @@ function Step8({ wizardName = "clusterCreation" }: Step8Props) {
     items: [],
   });
   const [completedOperationsCount, setCompletedOperationsCount] = useState(0);
-  const [failedOperationsCount, setFailedOperationsCount] = useState(0);
-  const [showExecutionModal, setShowExecutionModal] = useState(false);
+  const [totalOperationsCount, setTotalOperationsCount] = useState(0);
   const [isNextEnabled, setIsNextEnabled] = useState(true);
   const [deploymentTriggered, setDeploymentTriggered] = useState(false);
+  const [deploymentError, setDeploymentError] = useState("");
+  const [deploymentStage, setDeploymentStage] = useState("Ready to deploy");
+  const [exportError, setExportError] = useState("");
+  const [isExportingBlueprint, setIsExportingBlueprint] = useState(false);
   const getStepData = (stepName: string, dataKey: string) => {
     const stepData = get(state, `${wizardName}Steps.${stepName}.data`, {});
     return get(stepData, dataKey, "");
   };
+  const isAddHostWizard = () => wizardName === "addHost";
+  const isAddServiceWizard = () => wizardName === "addService";
 
   const {
-      clusterName = "",
-      cluster: { stack, versionNum },
-    } = useContext(AppContext);
+    clusterName = "",
+    cluster: { stack, versionNum },
+    isKerberosEnabled,
+  } = useContext(AppContext);
   const { getKDCSessionState } = useKDCSessionState(() => {});
+  const {
+    error: kerberosModeError,
+    isLoaded: isKerberosModeLoaded,
+    isManualKerberos,
+    kdcType,
+    reload: reloadKerberosMode,
+  } = useKerberosMode();
   const versionStepData = get(state, `${wizardName}Steps.VERSION.data`, {});
   const VERSION = versionNum || get(versionStepData, "selectedVersion.stack_version", "");
   const STACK = stack || get(versionStepData, "selectedStack.stack_name", "");
-  const [isGoingToNextStep, setIsGoingToNextStep] = useState(false);
+  const restoredReview = get(state, `${wizardName}Steps.REVIEW.data`, {});
+  const addServiceFlow = get(
+    state,
+    "addServiceSteps.SERVICES.data.addServiceFlow",
+    {},
+  );
+  const reviewDataRef = useRef<Record<string, any>>(restoredReview);
+  const completedOperationIds = useRef<Set<string>>(
+    new Set(restoredReview.completedOperationIds || []),
+  );
+  const deploymentArtifacts = useRef<Record<string, any>>({
+    repositoryVersionId: restoredReview.repositoryVersionId,
+    stackName: restoredReview.stackName,
+    stackVersion: restoredReview.stackVersion,
+  });
 
   // Kerberos-related state variables
   const [kerberosDescriptor, setKerberosDescriptor] = useState<any>(null);
-  const [isKerberosEnabled, setIsKerberosEnabled] = useState<boolean>(false);
-  const [isManualKerberos, setIsManualKerberos] = useState<boolean>(false);
-  const [isClusterDescriptorExists, setIsClusterDescriptorExists] =
-    useState<boolean>(false);
+  const [isKerberosDescriptorReady, setIsKerberosDescriptorReady] =
+    useState(false);
+  const [isKerberosPreparationRunning, setIsKerberosPreparationRunning] =
+    useState(false);
+  const [kerberosPreparationError, setKerberosPreparationError] = useState("");
+  const [kerberosCsv, setKerberosCsv] = useState<string | null>(null);
+  const [kerberosCsvError, setKerberosCsvError] = useState("");
+  const [isKerberosCsvLoading, setIsKerberosCsvLoading] = useState(false);
+  const [kerberosPreparationAttempt, setKerberosPreparationAttempt] = useState(0);
+  const descriptorExistsRef = useRef(false);
 
   /**
    * This function updates stack/service/component level kerberos descriptor identities (principal and keytab)
@@ -228,7 +266,7 @@ function Step8({ wizardName = "clusterCreation" }: Step8Props) {
       );
 
       if (!isConfigUpdated) {
-        kerberosDescriptor.services.forEach((service: any) => {
+        (kerberosDescriptor.services || []).forEach((service: any) => {
           isConfigUpdated = updateResourceIdentityConfigs(service, config);
           if (!isConfigUpdated) {
             (service.components || []).forEach((component: any) => {
@@ -245,59 +283,25 @@ function Step8({ wizardName = "clusterCreation" }: Step8Props) {
 
   /**
    * Updates kerberosDescriptorConfigs
-   * @param {boolean} instant - whether to execute immediately or add to ajax queue
    */
-  const updateKerberosDescriptorMethod = async (
-    instant = false
-  ): Promise<void> => {
-    try {
-      // Use the loaded kerberos descriptor
-      const kerberosDescriptorConfigs = kerberosDescriptor;
-      const descriptorExists = isClusterDescriptorExists;
-
-      if (!kerberosDescriptorConfigs) {
-        console.warn("No kerberos descriptor configs found");
-        return;
-      }
-
-      // Remove identity references before sending to server
-      const cleanedDescriptor = removeIdentityReferences(
-        cloneDeep(kerberosDescriptorConfigs)
-      );
-
-      const payload = {
-        artifact_data: cleanedDescriptor,
-      };
-
-      if (instant) {
-        // Execute immediately
-        await KerberosApi.saveAndEditKerberosData(
-          getStepData("NAME", "clusterName")||clusterName,
-          payload
-        );
-      } else {
-        // Add to deployment promises queue
-        const kerberosPromise = KerberosApi.saveAndEditKerberosData(
-          getStepData("NAME", "clusterName")||clusterName,
-          payload
-        );
-
-        pushTask(
-          kerberosPromise
-            .then(() => {
-              incrementSuccessCount();
-            })
-            .catch(() => {
-              incrementSuccessCount();
-            })
-        );
-      }
-    } catch (error) {
-      console.error("Error updating kerberos descriptor:", error);
-      if (!instant) {
-        incrementSuccessCount();
-      }
+  const saveKerberosDescriptor = async (descriptor: any): Promise<void> => {
+    if (!descriptor) {
+      throw new Error("Ambari did not return a Kerberos descriptor.");
     }
+    const payload = {
+      artifact_data: removeIdentityReferences(cloneDeep(descriptor)),
+    };
+    const resolvedClusterName = getStepData("NAME", "clusterName") || clusterName;
+    if (descriptorExistsRef.current) {
+      await KerberosApi.saveAndEditKerberosData(resolvedClusterName, payload);
+    } else {
+      await KerberosApi.saveKerberosData(resolvedClusterName, payload);
+      descriptorExistsRef.current = true;
+    }
+  };
+
+  const updateKerberosDescriptorMethod = async (): Promise<void> => {
+    await saveKerberosDescriptor(kerberosDescriptor);
   };
 
   /**
@@ -308,7 +312,7 @@ function Step8({ wizardName = "clusterCreation" }: Step8Props) {
    */
   const removeIdentityReferences = (kerberosDescriptor: any): any => {
     const notReference = (identity: any) =>
-      !identity.reference && !identity.name.startsWith("/");
+      !identity.reference && !identity.name?.startsWith("/");
 
     if (kerberosDescriptor.services) {
       kerberosDescriptor.services.forEach((service: any) => {
@@ -328,73 +332,191 @@ function Step8({ wizardName = "clusterCreation" }: Step8Props) {
     return kerberosDescriptor;
   };
 
-  /**
-   * Initialize Kerberos-related data and state
-   */
-  const initializeKerberosData = async (): Promise<void> => {
+  const kerberosErrorMessage = (error: any, fallback: string) =>
+    error?.response?.data?.message || error?.message || fallback;
+
+  const descriptorConfigs = () => {
+    const configProperties = getStepData("CONFIGURATION", "configProperties");
+    const secureConfigs: any[] = [];
+    Object.values(configProperties || {}).forEach((service: any) => {
+      Object.values(service || {}).forEach((configType: any) => {
+        Object.values(configType?.properties || {}).forEach((property: any) => {
+          if (!property?.isSecureConfig) return;
+          secureConfigs.push({
+            ...property,
+            filename: property.filename || property.fileName || property.type,
+            name: property.name || property.propertyName,
+          });
+        });
+      });
+    });
+    return secureConfigs;
+  };
+
+  const loadKerberosCsv = async () => {
+    const resolvedClusterName = getStepData("NAME", "clusterName") || clusterName;
+    setIsKerberosCsvLoading(true);
+    setKerberosCsvError("");
     try {
-      const clusterName = getStepData("NAME", "clusterName")||clusterName;
-
-      // For new cluster creation, assume Kerberos is not enabled initially
-      // This will be determined during the actual deployment process
-      if (!clusterName || wizardName === "clusterCreation") {
-        setIsKerberosEnabled(false);
-        setIsManualKerberos(false);
-        setIsClusterDescriptorExists(false);
-        return;
-      }
-
-      // For existing clusters (Add Service/Add Host), check if Kerberos is enabled
-      try {
-        const securityType = await KerberosApi.getSecurityType(clusterName);
-        const isKerberosEnabledValue =
-          securityType?.Clusters?.security_type === "KERBEROS";
-        setIsKerberosEnabled(isKerberosEnabledValue);
-
-        // For existing clusters, assume it's not manual Kerberos unless specified
-        setIsManualKerberos(false);
-
-        // Load kerberos descriptor if available
-        if (isKerberosEnabledValue) {
-          try {
-            const descriptor =
-              await KerberosApi.getKerberosDescriptorProperties(
-                "true",
-                clusterName
-              );
-            setKerberosDescriptor(
-              descriptor?.KerberosDescriptor?.kerberos_descriptor
-            );
-            setIsClusterDescriptorExists(
-              !!descriptor?.KerberosDescriptor?.kerberos_descriptor
-            );
-          } catch (error) {
-            console.warn("Could not load kerberos descriptor:", error);
-            setIsClusterDescriptorExists(false);
-          }
-        } else {
-          setIsClusterDescriptorExists(false);
-        }
-      } catch (error) {
-        console.warn("Could not check security type:", error);
-        setIsKerberosEnabled(false);
-        setIsManualKerberos(false);
-        setIsClusterDescriptorExists(false);
-      }
-    } catch (error) {
-      console.error("Error initializing Kerberos data:", error);
-      setIsKerberosEnabled(false);
-      setIsManualKerberos(false);
-      setIsClusterDescriptorExists(false);
+      const csv = await KerberosApi.downloadKerberosIdentitiesCsv(
+        resolvedClusterName,
+      );
+      setKerberosCsv(String(csv));
+      return String(csv);
+    } catch (error: any) {
+      setKerberosCsvError(String(kerberosErrorMessage(
+        error,
+        "Ambari could not load the Kerberos principals and keytabs CSV.",
+      )));
+      throw error;
+    } finally {
+      setIsKerberosCsvLoading(false);
     }
   };
 
-  // Initialize Kerberos data on component mount
   useEffect(() => {
-    if (!isAddHostWizard()) {
-      initializeKerberosData();
+    let active = true;
+    const requiresDescriptor = isAddServiceWizard() && isKerberosEnabled;
+    if (!requiresDescriptor) {
+      setIsKerberosDescriptorReady(true);
+      setIsKerberosPreparationRunning(false);
+      setKerberosPreparationError("");
+      return () => {
+        active = false;
+      };
     }
-  }, []);
+    if (!isKerberosModeLoaded) {
+      setIsKerberosPreparationRunning(true);
+      return () => {
+        active = false;
+      };
+    }
+    if (kerberosModeError || !kdcType) {
+      setIsKerberosDescriptorReady(false);
+      setIsKerberosPreparationRunning(false);
+      setKerberosPreparationError(
+        kerberosModeError || "Ambari did not return the Kerberos KDC type.",
+      );
+      return () => {
+        active = false;
+      };
+    }
+
+    const prepareKerberos = async () => {
+      const resolvedClusterName = getStepData("NAME", "clusterName") || clusterName;
+      setIsKerberosPreparationRunning(true);
+      setIsKerberosDescriptorReady(false);
+      setKerberosPreparationError("");
+      try {
+        const response = await KerberosApi.getKerberosDescriptorProperties(
+          "true",
+          resolvedClusterName,
+        );
+        const descriptor = response?.KerberosDescriptor?.kerberos_descriptor;
+        if (!descriptor || typeof descriptor !== "object" || !Array.isArray(descriptor.services)) {
+          throw new Error("Ambari returned an invalid Kerberos descriptor.");
+        }
+        const updatedDescriptor = cloneDeep(descriptor);
+        updateKerberosDescriptor(updatedDescriptor, descriptorConfigs());
+
+        try {
+          await KerberosApi.getKerberosDescriptorArtifact(resolvedClusterName);
+          descriptorExistsRef.current = true;
+        } catch (error: any) {
+          if (error?.response?.status === 404) {
+            descriptorExistsRef.current = false;
+          } else {
+            throw error;
+          }
+        }
+
+        if (isManualKerberos) {
+          await saveKerberosDescriptor(updatedDescriptor);
+        }
+        if (!active) return;
+        setKerberosDescriptor(updatedDescriptor);
+        setIsKerberosDescriptorReady(true);
+      } catch (error: any) {
+        if (!active) return;
+        setKerberosPreparationError(String(kerberosErrorMessage(
+          error,
+          "Ambari could not prepare the Kerberos descriptor.",
+        )));
+      } finally {
+        if (active) setIsKerberosPreparationRunning(false);
+      }
+
+      if (!active) return;
+      try {
+        await loadKerberosCsv();
+      } catch {
+        // CSV download errors are visible but do not prevent deployment.
+      }
+    };
+
+    void prepareKerberos();
+    return () => {
+      active = false;
+    };
+  }, [
+    clusterName,
+    isKerberosEnabled,
+    isKerberosModeLoaded,
+    isManualKerberos,
+    kdcType,
+    kerberosModeError,
+    kerberosPreparationAttempt,
+    wizardName,
+  ]);
+
+  const retryKerberosPreparation = () => {
+    if (kerberosModeError) reloadKerberosMode();
+    setKerberosPreparationAttempt((value) => value + 1);
+  };
+
+  const downloadKerberosCsv = async () => {
+    try {
+      const csv = kerberosCsv ?? await loadKerberosCsv();
+      saveAs(new Blob([csv], { type: "text/csv" }), "kerberos.csv");
+    } catch {
+      // loadKerberosCsv renders the recoverable error.
+    }
+  };
+
+  const downloadBlueprint = async () => {
+    setIsExportingBlueprint(true);
+    setExportError("");
+    try {
+      const resolvedClusterName = getStepData("NAME", "clusterName") || clusterName;
+      const selectedServices = filter(
+        getStepData("SERVICES", "services"),
+        (service: any) => service.selected && !service.installed,
+      ).map((service: any) => service.serviceName);
+      const { blueprint, clusterTemplate } = buildBlueprintExport({
+        clusterName: resolvedClusterName,
+        configProperties: getStepData("CONFIGURATION", "configProperties"),
+        hosts: getHosts(),
+        masterAssignments: getStepData("MASTERS", "mastersData") || [],
+        selectedServiceNames: selectedServices,
+        serviceComponents: serviceComponents.items,
+        slaveAssignments: getStepData("SLAVES_AND_CLIENTS", "serviceComponents") || [],
+        stackName: STACK,
+        stackVersion: VERSION,
+      });
+      const zip = new JSZip();
+      zip.file("blueprint.json", JSON.stringify(blueprint, null, 2));
+      zip.file("clustertemplate.json", JSON.stringify(clusterTemplate, null, 2));
+      const archive = await zip.generateAsync({ type: "blob" });
+      saveAs(archive, `${resolvedClusterName}-blueprint.zip`);
+    } catch (error: any) {
+      setExportError(String(kerberosErrorMessage(
+        error,
+        "The Blueprint archive could not be generated.",
+      )));
+    } finally {
+      setIsExportingBlueprint(false);
+    }
+  };
 
   function renderRepos() {
     const operatingSystems = getStepData("VERSION", "operatingSystems");
@@ -405,7 +527,11 @@ function Step8({ wizardName = "clusterCreation" }: Step8Props) {
     const allRepos = addedOs.map((currentOs: any) => {
       return currentOs.repos.map((repo: any) => {
         return (
-          <Stack direction="vertical" className="m-3">
+          <Stack
+            key={`${currentOs.os}-${repo.id}`}
+            direction="vertical"
+            className="m-3"
+          >
             <div className="text-info">
               {currentOs.os}({repo.id})
             </div>
@@ -416,15 +542,6 @@ function Step8({ wizardName = "clusterCreation" }: Step8Props) {
     });
     return allRepos;
   }
-  useEffect(() => {
-    if (isGoingToNextStep) {
-      setTimeout(() => {
-        flushStateToDb("next");
-      }, 2000);
-    }
-  }, [isGoingToNextStep]);
-  const deploymentPromises = useRef<Promise<any>[]>([]);
-
   async function getServiceComponents() {
     const servicesAndComponents: ServicesResponse =
       await ChooseServicesApi.getServices(STACK, VERSION);
@@ -434,16 +551,6 @@ function Step8({ wizardName = "clusterCreation" }: Step8Props) {
   useEffect(() => {
     getServiceComponents();
   }, []);
-
-  useEffect(() => {
-    if (
-      completedOperationsCount &&
-      deploymentPromises.current.length &&
-      completedOperationsCount === deploymentPromises.current.length
-    ) {
-      setIsNextEnabled(false);
-    }
-  }, [completedOperationsCount, failedOperationsCount]);
 
   function getNewHosts() {
     return getStepData("HOST_STATUS", "hosts")?.filter(
@@ -613,7 +720,11 @@ function Step8({ wizardName = "clusterCreation" }: Step8Props) {
     }
     return selectedServices.map((selectedService) => {
       return selectedService.shouldShow ? (
-        <Stack direction="vertical" className="mt-2">
+        <Stack
+          key={selectedService.service_name}
+          direction="vertical"
+          className="mt-2"
+        >
           <div className="my-2">
             <b>
               <i>{selectedService.service_name}</i>
@@ -621,7 +732,11 @@ function Step8({ wizardName = "clusterCreation" }: Step8Props) {
           </div>
           {selectedService.service_components.map((serviceComponent: any) => {
             return (
-              <Stack direction="horizontal" className="mt-2">
+              <Stack
+                key={serviceComponent.componentName}
+                direction="horizontal"
+                className="mt-2"
+              >
                 <div className="text-info">{serviceComponent.displayName}:</div>
                 <div className="ms-2">{serviceComponent.componentValue}</div>
               </Stack>
@@ -635,8 +750,8 @@ function Step8({ wizardName = "clusterCreation" }: Step8Props) {
   // const createCluster=()=>{
   //   const stackVersion=
   // }
-  async function postVersionDefinition(data: any) {
-    const versionInfo = await VersionsApi.postVersionDefinitionFile(data);
+  async function postVersionDefinition(data: any, headers = {}) {
+    const versionInfo = await VersionsApi.postVersionDefinitionFile(data, headers);
     return versionInfo;
   }
 
@@ -679,13 +794,6 @@ function Step8({ wizardName = "clusterCreation" }: Step8Props) {
     return {};
   }
 
-  const incrementSuccessCount = () => {
-    setCompletedOperationsCount((comp) => comp + 1);
-  };
-  const incrementFailureCount = () => {
-    setFailedOperationsCount((comp) => comp + 1);
-  };
-
   function createCluster() {
     const selectedStackVersion = getStepData("VERSION", "selectedStack.id");
     const clusterName = getStepData("NAME", "clusterName");
@@ -696,7 +804,7 @@ function Step8({ wizardName = "clusterCreation" }: Step8Props) {
     });
   }
 
-  async function createSelectedServices(versionId: string) {
+  async function createSelectedServices(versionId?: string) {
     const selectedServices = filter(
       getStepData("SERVICES", "services"),
       function (service: any) {
@@ -708,7 +816,7 @@ function Step8({ wizardName = "clusterCreation" }: Step8Props) {
         const serviceInfoObj = {
           service_name: selectedService.serviceName,
         };
-        if (!isAddServiceWizard()) {
+        if (!isAddServiceWizard() && versionId) {
           serviceInfoObj["desired_repository_version_id"] = versionId;
         }
         return {
@@ -716,16 +824,11 @@ function Step8({ wizardName = "clusterCreation" }: Step8Props) {
         };
       }
     );
-    return ClusterDeploymentApi.createSelectedServices(
-      getStepData("NAME", "clusterName"),
+    if (!selectedServicesBody.length) return;
+    await ClusterDeploymentApi.createSelectedServices(
+      getStepData("NAME", "clusterName") || clusterName,
       selectedServicesBody
-    )
-      .then(() => {
-        incrementSuccessCount();
-      })
-      .catch(() => {
-        incrementFailureCount();
-      });
+    );
   }
 
   function getServiceComponentsForService(serviceName: string) {
@@ -742,7 +845,6 @@ function Step8({ wizardName = "clusterCreation" }: Step8Props) {
   }
 
   async function createComponents() {
-    const componentsPromise = [];
     const selectedServices = filter(
       getStepData("SERVICES", "services"),
       function (service: any) {
@@ -753,6 +855,7 @@ function Step8({ wizardName = "clusterCreation" }: Step8Props) {
       const matchedServiceComponents = getServiceComponentsForService(
         selectedService.serviceName
       );
+      if (!matchedServiceComponents?.length) continue;
       const requestBody = {
         components: matchedServiceComponents.map((serviceComponent: any) => {
           return {
@@ -763,25 +866,12 @@ function Step8({ wizardName = "clusterCreation" }: Step8Props) {
           };
         }),
       };
-      componentsPromise.push(
-        new Promise((resolve, reject) => {
-          setTimeout(() => {
-            ClusterDeploymentApi.addRequestToCreateComponent(
-              getStepData("NAME", "clusterName")||clusterName,
-              selectedService.serviceName,
-              requestBody
-            )
-              .then(() => {
-                incrementSuccessCount();
-              })
-              .catch(() => {
-                incrementFailureCount();
-              });
-          }, deploymentPromises.current.length * 0.7 * 1000);
-        })
+      await ClusterDeploymentApi.addRequestToCreateComponent(
+        getStepData("NAME", "clusterName") || clusterName,
+        selectedService.serviceName,
+        requestBody
       );
     }
-    return componentsPromise;
   }
 
   async function registerHostsToComponent(
@@ -811,22 +901,10 @@ function Step8({ wizardName = "clusterCreation" }: Step8Props) {
         ],
       },
     };
-    return new Promise((resolve, reject) => {
-      setTimeout(() => {
-        resolve(
-          ClusterDeploymentApi.registerHostToCluster(
-            getStepData("NAME", "clusterName")||clusterName,
-            data
-          )
-            .then(() => {
-              incrementSuccessCount();
-            })
-            .catch(() => {
-              incrementFailureCount();
-            })
-        );
-      }, deploymentPromises.current.length * 0.7 * 1000);
-    });
+    await ClusterDeploymentApi.registerHostToCluster(
+      getStepData("NAME", "clusterName") || clusterName,
+      data
+    );
   }
 
   async function createMasterHostComponents() {
@@ -837,7 +915,7 @@ function Step8({ wizardName = "clusterCreation" }: Step8Props) {
         return !service.installed && service.selected;
       }
     );
-    const registerPromises = [];
+    const registrations: Array<{ hostNames: string[]; component: string }> = [];
     forEach(selectedServices, (service: any) => {
       const selectedServiceComponents = getServiceComponentsForService(
         service.serviceName
@@ -890,7 +968,7 @@ function Step8({ wizardName = "clusterCreation" }: Step8Props) {
             ),
             "hostName"
           );
-          registerPromises.push(registerHostsToComponent(hostNames, component));
+          registrations.push({ hostNames, component });
         }
       } else {
         hostNames = map(
@@ -905,66 +983,29 @@ function Step8({ wizardName = "clusterCreation" }: Step8Props) {
           ),
           "hostName"
         );
-        registerPromises.push(registerHostsToComponent(hostNames, component));
+        registrations.push({ hostNames, component });
       }
     });
-    return registerPromises;
+    for (const registration of registrations) {
+      await registerHostsToComponent(
+        registration.hostNames,
+        registration.component,
+      );
+    }
   }
 
   function saveClusterStatus(clusterStatusLocal) {
+    reviewDataRef.current = {
+      ...reviewDataRef.current,
+      clusterStatus: clusterStatusLocal,
+    };
     dispatch({
       type: ActionTypes.STORE_INFORMATION,
       payload: {
-        step: currentStep.name,
-        data: {
-          clusterStatus: clusterStatusLocal,
-        },
+        step: "REVIEW",
+        data: reviewDataRef.current,
       },
     });
-  }
-
-  async function installComponents() {
-    const data = {
-      context: "Install Components",
-      HostRoles: { state: "INSTALLED" },
-      urlParams: "",
-      level: "HOST_COMPONENT",
-      query: `HostRoles/host_name.in(${getNewHosts()
-        .map((host) => get(host, "name", ""))
-        .join(",")})`,
-    };
-
-    const clusterName = getStepData("NAME", "clusterName")||clusterName;
-
-    try {
-      const response = await HostsApi.updateHostComponents(
-        clusterName,
-        data.urlParams,
-        data
-      );
-      const requestId = response.Requests.id;
-      const responseStatus = {
-        status: "PENDING",
-        requestId,
-        isInstallError: false,
-        isCompleted: false,
-        oldRequestsId: getStepData("REVIEW", "clusterStatus").oldRequestsId
-          ? [...previousRequests, requestId]
-          : [requestId],
-      };
-      saveClusterStatus(responseStatus);
-      setIsGoingToNextStep(true);
-      setTimeout(() => {
-        handleNextImperitive();
-      }, 2000);
-    } catch (err) {
-      const responseStatus = {
-        status: "PENDING",
-        isInstallError: true,
-        isCompleted: false,
-      };
-      saveClusterStatus(responseStatus);
-    }
   }
 
   async function installServices() {
@@ -991,7 +1032,7 @@ function Step8({ wizardName = "clusterCreation" }: Step8Props) {
       urlParams
     );
     const installStartTime = Date.now();
-    if (servicesInit.Requests) {
+    if (servicesInit.Requests?.id != null) {
       const previousRequests = getStepData(
         "REVIEW",
         "clusterStatus"
@@ -1008,10 +1049,14 @@ function Step8({ wizardName = "clusterCreation" }: Step8Props) {
           : [requestId],
       };
       saveClusterStatus(clusterStatus);
-      setIsGoingToNextStep(true);
-      setTimeout(() => {
-        handleNextImperitive();
-      }, 2000);
+      await Promise.resolve(flushStateToDb(
+        "next",
+        -1,
+        `${isAddServiceWizard() ? "ADD_SERVICES" : "CLUSTER"}_INSTALLING_3`,
+      ));
+      handleNextImperitive();
+    } else {
+      throw new Error("Ambari did not return an installation request ID.");
     }
   }
 
@@ -1027,25 +1072,37 @@ function Step8({ wizardName = "clusterCreation" }: Step8Props) {
         },
       };
     });
-    return new Promise((resolve, reject) => {
-      setTimeout(() => {
-        resolve(
-          ClusterDeploymentApi.registerHostToCluster(
-            getStepData("NAME", "clusterName")||clusterName,
-            requestPayload
-          )
-            .then(() => {
-              incrementSuccessCount();
-            })
-            .catch(() => {
-              incrementFailureCount();
-            })
-        );
-      }, deploymentPromises.current.length * 0.7 * 1000);
-    });
+    if (!requestPayload.length) return;
+    await ClusterDeploymentApi.registerHostToCluster(
+      getStepData("NAME", "clusterName") || clusterName,
+      requestPayload
+    );
   }
 
-  async function createConfigurationGroups() {}
+  async function createConfigurationGroups() {
+    const configurationData = getStepData("CONFIGURATION", "configGroupData");
+    const storedGroups = get(configurationData, "items", configurationData);
+    const configGroups = Array.isArray(storedGroups) ? storedGroups : [];
+    for (const group of configGroups) {
+      const value = group.ConfigGroup || group;
+      if (value.is_default || (!value.is_for_update && !value.is_temporary)) {
+        continue;
+      }
+      const payload = group.ConfigGroup ? group : { ConfigGroup: value };
+      if (value.is_for_update && value.id != null) {
+        await ConfigGroupApi.updateConfigGroup(
+          getStepData("NAME", "clusterName") || clusterName,
+          String(value.id),
+          payload,
+        );
+      } else {
+        await ConfigGroupApi.addConfigGroup(
+          getStepData("NAME", "clusterName") || clusterName,
+          [payload],
+        );
+      }
+    }
+  }
 
   function getClientsMap(flag: string, value?: string) {
     const serviceComponentItems = serviceComponents.items;
@@ -1082,8 +1139,7 @@ function Step8({ wizardName = "clusterCreation" }: Step8Props) {
   }
 
   async function createAdditionalHostComponents() {
-    // const masterHosts = flatten(map(getStepData("MASTERS", "mastersData"),"masterServices"));
-    const additionalComponentPromises = [];
+    const registrations: Array<{ hostNames: string[]; component: string }> = [];
     const registeredHosts = filter(getStepData("HOST_STATUS", "hosts"), [
       "bootStatus",
       "REGISTERED",
@@ -1109,12 +1165,10 @@ function Step8({ wizardName = "clusterCreation" }: Step8Props) {
       forEach(servicesRequiredOnAllHosts, (component: any) => {
         const requiredComponent = get(component, "StackServiceComponents", {});
         if (registeredHosts.length) {
-          additionalComponentPromises.push(
-            registerHostsToComponent(
-              map(registeredHosts, "name"),
-              requiredComponent.component_name
-            )
-          );
+          registrations.push({
+            hostNames: map(registeredHosts, "name"),
+            component: requiredComponent.component_name,
+          });
         }
       });
     }
@@ -1123,7 +1177,12 @@ function Step8({ wizardName = "clusterCreation" }: Step8Props) {
     // if(isHiveSelected){
     //   const hiveDb=
     // }
-    return additionalComponentPromises;
+    for (const registration of registrations) {
+      await registerHostsToComponent(
+        registration.hostNames,
+        registration.component,
+      );
+    }
   }
 
   async function createSlaveAndClientsHostComponents() {
@@ -1263,7 +1322,7 @@ function Step8({ wizardName = "clusterCreation" }: Step8Props) {
      * </code>
      */
     const clientsToMasterMap = getClientsMap("is_master");
-    const clientSlavePromises = [];
+    const registrations: Array<{ hostNames: string[]; component: string }> = [];
     const clientsToSlaveMap = getClientsMap("component_category", "SLAVE");
     forEach(slaveHosts, (_slave) => {
       let hostNames: any = [];
@@ -1288,9 +1347,10 @@ function Step8({ wizardName = "clusterCreation" }: Step8Props) {
                 }),
                 "hostName"
               );
-              clientSlavePromises.push(
-                registerHostsToComponent(hostNames, _slave.componentName)
-              );
+              registrations.push({
+                hostNames,
+                component: _slave.componentName,
+              });
             } else {
               hostNames = map(
                 filter(_slave.hosts, (slaveHost) => {
@@ -1301,9 +1361,10 @@ function Step8({ wizardName = "clusterCreation" }: Step8Props) {
                 }),
                 "hostName"
               );
-              clientSlavePromises.push(
-                registerHostsToComponent(hostNames, _slave.componentName)
-              );
+              registrations.push({
+                hostNames,
+                component: _slave.componentName,
+              });
             }
           }
         } else {
@@ -1316,9 +1377,10 @@ function Step8({ wizardName = "clusterCreation" }: Step8Props) {
             }),
             "hostName"
           );
-          clientSlavePromises.push(
-            registerHostsToComponent(hostNames, _slave.componentName)
-          );
+          registrations.push({
+            hostNames,
+            component: _slave.componentName,
+          });
         }
       } else {
         clients.forEach(function (_client: any) {
@@ -1367,23 +1429,30 @@ function Step8({ wizardName = "clusterCreation" }: Step8Props) {
             }
             if (!compOnAllHosts) {
               hostNames = uniq(hostNames);
-              clientSlavePromises.push(
-                registerHostsToComponent(hostNames, _client.component_name)
-              );
+              registrations.push({
+                hostNames,
+                component: _client.component_name,
+              });
             }
           } else {
             hostNames = uniq(hostNames);
-            clientSlavePromises.push(
-              registerHostsToComponent(hostNames, _client.component_name)
-            );
+            registrations.push({
+              hostNames,
+              component: _client.component_name,
+            });
           }
         });
       }
     });
-    return clientSlavePromises;
+    for (const registration of registrations) {
+      await registerHostsToComponent(
+        registration.hostNames,
+        registration.component,
+      );
+    }
   }
 
-  function applyConfigurationsToCluster() {
+  async function applyConfigurationsToCluster() {
     const applyConfigurationsPayload = [];
     const configurations = getStepData("CONFIGURATION", "configProperties");
     Object.keys(configurations).map((service: string) => {
@@ -1459,169 +1528,189 @@ function Step8({ wizardName = "clusterCreation" }: Step8Props) {
         },
       });
     });
-    return ClusterDeploymentApi.applyClusterConfigs(
+    if (!applyConfigurationsPayload.length) return;
+    await ClusterDeploymentApi.applyClusterConfigs(
       getStepData("NAME", "clusterName")||clusterName,
       applyConfigurationsPayload
-    )
-
-      .then(() => {
-        incrementSuccessCount();
-      })
-      .catch(() => {
-        incrementFailureCount();
-      });
+    );
   }
 
-  const pushTask = (task) => {
-    deploymentPromises.current.push(task);
+  const deploymentStatePrefix = isAddServiceWizard()
+    ? "ADD_SERVICES"
+    : "CLUSTER";
+
+  const saveReviewData = async (
+    data: Record<string, any>,
+    clusterState = `${deploymentStatePrefix}_DEPLOY_PREP_2`,
+  ) => {
+    reviewDataRef.current = { ...reviewDataRef.current, ...data };
+    dispatch({
+      type: ActionTypes.STORE_INFORMATION,
+      payload: {
+        step: "REVIEW",
+        data: reviewDataRef.current,
+      },
+    });
+    await Promise.resolve(flushStateToDb("checkpoint", -1, clusterState));
   };
 
-  const startDeployForAddHost = async () => {
-    try {
-      pushTask(registerHostsToCluster());
-      for (const slaveComponentPromise of await createSlaveAndClientsHostComponents()) {
-        pushTask(slaveComponentPromise);
-      }
-      setShowExecutionModal(true);
-      for (const deploymentPromise of deploymentPromises.current) {
-        await deploymentPromise;
-      }
-    } catch (err) {
-      console.log("Could not deploy Cluster", err);
+  const deleteExistingClusters = async () => {
+    const response = await ClusterApi.getAllClusters();
+    await Promise.all(get(response, "items", []).map((item: any) =>
+      ClusterApi.deleteCluster(item.Clusters.cluster_name),
+    ));
+  };
+
+  const deleteExistingVersions = async () => {
+    const response = await VersionsApi.getAllVersionDefinitions();
+    await Promise.all(get(response, "items", []).map((item: any) =>
+      VersionsApi.deleteRepositoryVersion(
+        item.VersionDefinition.stack_name,
+        item.VersionDefinition.stack_version,
+        item.VersionDefinition.id,
+      ),
+    ));
+  };
+
+  const createRepositoryVersion = async () => {
+    const selectedStack = getStepData("VERSION", "selectedStack");
+    const source = getStepData("VERSION", "versionDefinitionSource");
+    const payload = source?.payload || {
+      VersionDefinition: { available: selectedStack.id },
+    };
+    const response = await postVersionDefinition(payload, source?.headers);
+    const versionDefinition = get(
+      response,
+      "resources.0.VersionDefinition",
+      {},
+    );
+    if (
+      !versionDefinition.id
+      || !versionDefinition.stack_name
+      || !versionDefinition.stack_version
+    ) {
+      throw new Error("Ambari did not return the created repository version.");
     }
+    deploymentArtifacts.current.repositoryVersionId = versionDefinition.id;
+    deploymentArtifacts.current.stackName = versionDefinition.stack_name;
+    deploymentArtifacts.current.stackVersion = versionDefinition.stack_version;
   };
 
-  const startDeploymentForAddService = async () => {
-    try {
-      pushTask(createSelectedServices());
-
-      // For manually enabled Kerberos descriptor was updated on transition to this step
-      if (isKerberosEnabled && !isManualKerberos) {
-        await updateKerberosDescriptorMethod();
-      }
-
-      pushTask(applyConfigurationsToCluster());
-      for (const componentPromise of await createComponents()) {
-        pushTask(componentPromise);
-      }
-      for (const masterComponentPromise of await createMasterHostComponents()) {
-        pushTask(masterComponentPromise);
-      }
-      for (const slaveComponentPromise of await createSlaveAndClientsHostComponents()) {
-        pushTask(slaveComponentPromise);
-      }
-      for (const additionalComponentPromise of await createAdditionalHostComponents()) {
-        pushTask(additionalComponentPromise);
-      }
-      setShowExecutionModal(true);
-      await Promise.all(deploymentPromises.current);
-    } catch (err) {
-      console.log("Could not deploy Cluster", err);
+  const updateRepositoryOperatingSystems = async () => {
+    const repositoryVersionId = deploymentArtifacts.current.repositoryVersionId;
+    if (!repositoryVersionId) {
+      throw new Error("The repository version was not created.");
     }
+    await VersionsApi.updateRepoOSInfo(
+      deploymentArtifacts.current.stackName || STACK,
+      deploymentArtifacts.current.stackVersion || VERSION,
+      repositoryVersionId,
+      await getUpdateRepoOSInfoBody(),
+    );
   };
 
-  const startDeploy = async () => {
+  const buildDeploymentStages = () => {
+    const commonOperations = [
+      { id: "create-services", label: "Creating services", run: () =>
+        createSelectedServices(deploymentArtifacts.current.repositoryVersionId) },
+      { id: "apply-configurations", label: "Applying configurations", run: applyConfigurationsToCluster },
+      { id: "create-components", label: "Creating service components", run: createComponents },
+      { id: "create-configuration-groups", label: "Saving configuration groups", run: createConfigurationGroups },
+      { id: "register-masters", label: "Assigning master components", run: createMasterHostComponents },
+      { id: "register-slaves-clients", label: "Assigning slave and client components", run: createSlaveAndClientsHostComponents },
+      { id: "register-required-components", label: "Assigning required components", run: createAdditionalHostComponents },
+    ];
+
+    if (isAddServiceWizard()) {
+      const kerberosOperations = isKerberosEnabled && !isManualKerberos
+        ? [{
+            id: "update-kerberos-descriptor",
+            label: "Updating the Kerberos descriptor",
+            run: updateKerberosDescriptorMethod,
+          }]
+        : [];
+      return [...commonOperations.slice(0, 1), ...kerberosOperations, ...commonOperations.slice(1)]
+        .map((operation) => ({ operations: [operation] }));
+    }
+
+    return [
+      { operations: [{ id: "delete-clusters", label: "Removing incomplete clusters", run: deleteExistingClusters }] },
+      { operations: [{ id: "delete-repository-versions", label: "Removing incomplete repository versions", run: deleteExistingVersions }] },
+      { operations: [{ id: "create-repository-version", label: "Creating the repository version", run: createRepositoryVersion }] },
+      { operations: [{ id: "update-repositories", label: "Saving repositories", run: updateRepositoryOperatingSystems }] },
+      { operations: [{ id: "create-cluster", label: "Creating the cluster", run: createCluster }] },
+      ...commonOperations.slice(0, 3).map((operation) => ({ operations: [operation] })),
+      { operations: [{ id: "register-hosts", label: "Adding hosts to the cluster", run: registerHostsToCluster }] },
+      ...commonOperations.slice(3).map((operation) => ({ operations: [operation] })),
+    ];
+  };
+
+  const waitForKdcSession = () => new Promise<void>((resolve, reject) => {
+    void getKDCSessionState(resolve, reject).catch(reject);
+  });
+
+  const deploy = async () => {
+    if (deploymentTriggered) return;
+    if (isAddServiceWizard() && isKerberosEnabled && !isKerberosDescriptorReady) {
+      setKerberosPreparationError(
+        "The Kerberos descriptor must be prepared before deployment.",
+      );
+      return;
+    }
+    setDeploymentTriggered(true);
+    setIsNextEnabled(false);
+    setDeploymentError("");
+
     try {
-      const versionStepData = getStepData("VERSION", "selectedStack");
-      const versionData = {
-        isXMLdata: false,
-        data: {
-          VersionDefinition: {
-            available: versionStepData.id,
-          },
+      await saveReviewData({
+        completedOperationIds: [...completedOperationIds.current],
+        deploymentStage: "Preparing deployment",
+      });
+      const stages = buildDeploymentStages();
+      const operations = stages.flatMap((stage) => stage.operations);
+      setTotalOperationsCount(operations.length);
+      setCompletedOperationsCount(
+        operations.filter((operation) => completedOperationIds.current.has(operation.id)).length,
+      );
+
+      await runDeploymentPlan(
+        stages,
+        completedOperationIds.current,
+        async ({ completed, operation }) => {
+          setCompletedOperationsCount(completed);
+          setDeploymentStage(operation.label);
+          await saveReviewData({
+            completedOperationIds: [...completedOperationIds.current],
+            deploymentStage: operation.label,
+            ...deploymentArtifacts.current,
+          });
         },
-      };
-      const versionInfoResponse = await postVersionDefinition(versionData.data);
-      if (versionInfoResponse) {
-        const versionInfo = {
-          stackName:
-            versionInfoResponse.resources[0].VersionDefinition.stack_name,
-          id: versionInfoResponse.resources[0].VersionDefinition.id,
-          stackVersion:
-            versionInfoResponse.resources[0].VersionDefinition.stack_version,
-        };
-        if (
-          versionInfo.id &&
-          versionInfo.stackName &&
-          versionInfo.stackVersion
-        ) {
-          const selectedStack = STACK;
-          const selectedVersion = VERSION;
-          const repoId = versionInfo.id;
-          const payload = await getUpdateRepoOSInfoBody();
-          await VersionsApi.updateRepoOSInfo(
-            selectedStack,
-            selectedVersion,
-            repoId,
-            payload
-          );
-          pushTask(
-            createCluster().then(async () => {
-              incrementSuccessCount();
-              pushTask(createSelectedServices(versionInfo.id));
-              pushTask(applyConfigurationsToCluster());
-              for (const componentPromise of await createComponents()) {
-                pushTask(componentPromise);
-              }
-              pushTask(registerHostsToCluster());
-              for (const masterComponentPromise of await createMasterHostComponents()) {
-                pushTask(masterComponentPromise);
-              }
-              for (const slaveComponentPromise of await createSlaveAndClientsHostComponents()) {
-                pushTask(slaveComponentPromise);
-              }
-              for (const additionalComponentPromise of await createAdditionalHostComponents()) {
-                pushTask(additionalComponentPromise);
-              }
-              setShowExecutionModal(true);
-              await Promise.all(deploymentPromises.current);
-            })
-          );
-        }
+      );
+
+      if (isAddServiceWizard()) {
+        await waitForKdcSession();
       }
-    } catch (err) {
-      console.log("Could not deploy Cluster", err);
+      setDeploymentStage("Starting component installation");
+      await installServices();
+    } catch (error: any) {
+      const message = error?.response?.data?.message
+        || error?.message
+        || "Ambari could not prepare the cluster deployment.";
+      setDeploymentError(String(message));
+      setDeploymentStage("Deployment preparation failed");
+      setDeploymentTriggered(false);
+      setIsNextEnabled(true);
+      try {
+        await saveReviewData({
+          completedOperationIds: [...completedOperationIds.current],
+          deploymentStage: "Deployment preparation failed",
+          deploymentError: String(message),
+          ...deploymentArtifacts.current,
+        });
+      } catch {
+        // The visible deployment error remains retryable if checkpoint persistence is unavailable.
+      }
     }
-  };
-  const prepareDeployment = async () => {
-    const existingCluster = await ClusterApi.getAllClusters();
-    const deletionPromises: any = [];
-    if (get(existingCluster, "items", []).length) {
-      forEach(get(existingCluster, "items", []), (cluster) => {
-        deletionPromises.push(
-          ClusterApi.deleteCluster(cluster.Clusters.cluster_name)
-        );
-      });
-    }
-    await Promise.all(deletionPromises);
-    handleExistingVersions();
-  };
-  const handleExistingVersions = async () => {
-    const existingVersions = await VersionsApi.getAllVersionDefinitions();
-    const deletionPromises: any = [];
-    if (existingVersions.items.length) {
-      forEach(existingVersions.items, (version) => {
-        deletionPromises.push(
-          VersionsApi.deleteRepositoryVersion(
-            version.VersionDefinition.stack_name,
-            version.VersionDefinition.stack_version,
-            version.VersionDefinition.id
-          )
-        );
-      });
-    }
-    await Promise.all(deletionPromises);
-    setTimeout(() => {
-      startDeploy();
-    }, 2000);
-  };
-
-  const isAddHostWizard = () => {
-    return wizardName === "addHost";
-  };
-
-  const isAddServiceWizard = () => {
-    return wizardName === "addService";
   };
 
   if (!!!serviceComponents.items.length) {
@@ -1629,29 +1718,6 @@ function Step8({ wizardName = "clusterCreation" }: Step8Props) {
   }
   return (
     <>
-      <ExecuteTasksModal
-        isOpen={showExecutionModal}
-        onClose={() => {
-          setShowExecutionModal(false);
-        }}
-        successCallback={() => {
-          if (wizardName === "clusterCreation") {
-            installServices();
-          } else {
-            getKDCSessionState(() => {
-              if (isAddHostWizard()) {
-                installComponents();
-              } else {
-                installServices();
-              }
-            });
-          }
-          flushStateToDb("next");
-        }}
-        totalCount={deploymentPromises.current.length}
-        successCount={completedOperationsCount}
-        failedCount={failedOperationsCount}
-      />
       <div className="step-title">Review</div>
       <div className="d-flex flex-column">
         <small className="light-text step-description">
@@ -1662,6 +1728,80 @@ function Step8({ wizardName = "clusterCreation" }: Step8Props) {
             Hosts that are assigned master components are shown with{" "}
             <span className="text-info">✵</span>.
           </small>
+        ) : null}
+        {isAddServiceWizard() && isKerberosEnabled && isKerberosPreparationRunning ? (
+          <Alert variant="info" className="mt-3 d-flex align-items-center gap-2">
+            <BootstrapSpinner animation="border" size="sm" />
+            Preparing the Kerberos descriptor
+          </Alert>
+        ) : null}
+        {kerberosPreparationError ? (
+          <Alert variant="danger" className="mt-3">
+            <div>{kerberosPreparationError}</div>
+            <Button
+              className="mt-2"
+              size="sm"
+              variant="outline-danger"
+              disabled={isKerberosPreparationRunning}
+              onClick={retryKerberosPreparation}
+            >
+              Retry Kerberos Preparation
+            </Button>
+          </Alert>
+        ) : null}
+        {isAddServiceWizard() && isKerberosEnabled && isKerberosDescriptorReady ? (
+          <Alert variant={isManualKerberos ? "warning" : "secondary"} className="mt-3">
+            {isManualKerberos ? (
+              <div>
+                Because Kerberos was manually installed on the cluster, you must
+                create and distribute principals and keytabs after this operation.
+              </div>
+            ) : (
+              <div>Kerberos KDC type: {kdcType}</div>
+            )}
+            <Button
+              className="mt-2"
+              size="sm"
+              variant="outline-primary"
+              disabled={isKerberosCsvLoading || deploymentTriggered}
+              onClick={() => void downloadKerberosCsv()}
+            >
+              {isKerberosCsvLoading ? "Loading CSV" : "Download Kerberos CSV"}
+            </Button>
+          </Alert>
+        ) : null}
+        {kerberosCsvError ? (
+          <Alert variant="warning" className="mt-3">
+            <div>{kerberosCsvError}</div>
+            <Button
+              className="mt-2"
+              size="sm"
+              variant="outline-warning"
+              disabled={isKerberosCsvLoading}
+              onClick={() => void loadKerberosCsv().catch(() => undefined)}
+            >
+              Retry CSV
+            </Button>
+          </Alert>
+        ) : null}
+        {exportError ? (
+          <Alert variant="danger" className="mt-3">
+            {exportError}
+          </Alert>
+        ) : null}
+        {deploymentError ? (
+          <Alert variant="danger" className="mt-3">
+            {deploymentError}
+          </Alert>
+        ) : null}
+        {deploymentTriggered ? (
+          <Alert variant="info" className="mt-3 d-flex align-items-center gap-2">
+            <BootstrapSpinner animation="border" size="sm" />
+            {deploymentStage}
+            {totalOperationsCount
+              ? ` (${completedOperationsCount}/${totalOperationsCount})`
+              : ""}
+          </Alert>
         ) : null}
         <Card className="mt-4">
           <Card.Body>
@@ -1692,31 +1832,50 @@ function Step8({ wizardName = "clusterCreation" }: Step8Props) {
         </Card>
       </div>
       <WizardFooter
-        isNextEnabled={isNextEnabled}
+        isNextEnabled={
+          isNextEnabled
+          && (!isAddServiceWizard()
+            || !isKerberosEnabled
+            || isKerberosDescriptorReady)
+        }
         lifted
         step={{ ...currentStep, nextLabel: "DEPLOY" }}
-        onNext={() => {
-          if (!deploymentTriggered) {
-            setDeploymentTriggered(false);
-            deploymentPromises.current = [];
-            if (isAddHostWizard()) {
-              startDeployForAddHost();
-            } else if (isAddServiceWizard()) {
-              startDeploymentForAddService();
-            } else {
-              prepareDeployment();
-            }
-            setIsNextEnabled(false);
+        isCancelEnabled={!deploymentTriggered}
+        isBackEnabled={!deploymentTriggered}
+        onNext={() => void deploy()}
+        onCancel={() => void flushStateToDb("cancel")}
+        onBack={async () => {
+          if (isAddServiceWizard()) {
+            const previousStep = previousAddServiceStep(5, addServiceFlow);
+            await Promise.resolve(flushStateToDb("jump", previousStep));
+            jumpToStep(previousStep);
+          } else {
+            await Promise.resolve(flushStateToDb("back"));
+            handleBackImperitive();
           }
-          // startDeploy();
         }}
-        onCancel={() => {
-          flushStateToDb("cancel");
-        }}
-        onBack={() => {
-          flushStateToDb("back");
-          handleBackImperitive();
-        }}
+        sideItems={(
+          <>
+            <Button
+              className="me-2"
+              size="sm"
+              variant="outline-secondary"
+              disabled={deploymentTriggered}
+              onClick={() => window.print()}
+            >
+              Print Review
+            </Button>
+            <Button
+              className="me-2"
+              size="sm"
+              variant="outline-primary"
+              disabled={deploymentTriggered || isExportingBlueprint}
+              onClick={() => void downloadBlueprint()}
+            >
+              {isExportingBlueprint ? "Generating Blueprint" : "Generate Blueprint"}
+            </Button>
+          </>
+        )}
       />
     </>
   );

--- a/ambari-web/latest/src/screens/ClusterWizard/Step9.tsx
+++ b/ambari-web/latest/src/screens/ClusterWizard/Step9.tsx
@@ -16,51 +16,53 @@
  * limitations under the License.
  */
 
-import {
-  cloneDeep,
-  every,
-  filter,
-  find,
-  flatten,
-  forEach,
-  get,
-  isEmpty,
-  map,
-  set,
-  some,
-  uniq,
-} from "lodash";
 import { useContext, useEffect, useRef, useState } from "react";
-import LogApi from "../../api/logApi";
-import { HostsApi } from "../../api/hostsApi";
-import {
-  commandDetail,
-  getFormattedStringFromArray,
-  isFinished,
-  role,
-} from "../../Utils/Utility";
-import { ServiceApi } from "../../api/serviceApi";
-import { RequestApi } from "../../api/requestApi";
-import { Card, ProgressBar, Stack } from "react-bootstrap";
-import Table from "../../components/Table";
-import classNames from "classnames";
-import usePagination from "../../hooks/usePagination";
-import Paginator from "../../components/Paginator";
-import BackgroundOperations from "../BackgroundOperations";
-import { ProgressStatus, ViewLevel } from "../../constants";
-import WizardFooter from "../../components/StepWizard/WizardFooter";
-import { ActionTypes } from "./clusterStore/types";
-import DefaultButton from "../../components/DefaultButton";
-import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { faUndo } from "@fortawesome/free-solid-svg-icons";
-import { ContextWrapper } from ".";
-import { messages } from "../messages";
-import usePolling from "../../hooks/usePolling";
+import { Alert, Button, ProgressBar, Spinner, Table } from "react-bootstrap";
+import { get } from "lodash";
+import { useBlocker } from "react-router-dom";
 import { AppContext } from "../../store/context";
+import { ContextWrapper } from ".";
+import WizardFooter from "../../components/StepWizard/WizardFooter";
+import BackgroundOperations from "../BackgroundOperations";
+import { ViewLevel } from "../../constants";
+import { RequestApi } from "../../api/requestApi";
+import { HostsApi } from "../../api/hostsApi";
+import { ServiceApi } from "../../api/serviceApi";
+import { ActionTypes } from "./clusterStore/types";
+import {
+  canEnterSummary,
+  canRetryInstallation,
+  failedTaskStatuses,
+  InstallWizardName,
+  InstallationPhase,
+  mergeInstallTasks,
+  requestFailed,
+  requestFinished,
+  requestIdFrom,
+  terminalTaskStatuses,
+  wizardCheckpoint,
+} from "./installationProgress";
 
 type Step9Props = {
-  wizardName?: string;
+  wizardName?: InstallWizardName;
 };
+
+function errorMessage(error: any): string {
+  const message = error?.response?.data?.message
+    || error?.response?.data
+    || error?.message
+    || "Ambari could not continue deployment.";
+  return typeof message === "string" ? message : JSON.stringify(message);
+}
+
+function phaseLabel(phase: InstallationPhase): string {
+  switch (phase) {
+    case "INSTALL": return "Installing services and components";
+    case "KEYTABS": return "Regenerating Kerberos keytabs";
+    case "START": return "Starting services and running service checks";
+    default: return "Deployment complete";
+  }
+}
 
 function Step9({ wizardName = "clusterCreation" }: Step9Props) {
   const { Context } = useContext(ContextWrapper);
@@ -70,1360 +72,546 @@ function Step9({ wizardName = "clusterCreation" }: Step9Props) {
     flushStateToDb,
     stepWizardUtilities: { currentStep, handleNextImperitive },
   }: any = useContext(Context);
-  const getStepData = (stepName: string, dataKey: string) => {
-    const stepData = get(state, `${wizardName}Steps.${stepName}.data`, {});
-    return get(stepData, dataKey, "");
-  };
-  const currentStepName = "INSTALL_START_TEST";
-  const [hosts, setHosts] = useState(
-    getStepData(currentStepName, "hosts") || []
+  const { isKerberosEnabled, supports } = useContext(AppContext);
+  const stepPrefix = `${wizardName}Steps`;
+  const getStepData = (stepName: string, dataKey = "") => get(
+    state,
+    `${stepPrefix}.${stepName}.data${dataKey ? `.${dataKey}` : ""}`,
+    dataKey ? undefined : {},
   );
-  const isPolling = useRef(getStepData(currentStepName, "isPolling") || false);
-  const parseHostInfoRef = useRef(
-    getStepData(currentStepName, "parseHostInfoRef") || false
+
+  const clusterName = getStepData("NAME", "clusterName") || "";
+  const reviewStatus = getStepData("REVIEW", "clusterStatus") || {};
+  const restoredInstall = getStepData("INSTALL_START_TEST") || {};
+  const initialStatus = restoredInstall.clusterStatus || reviewStatus;
+  const initialPhase: InstallationPhase = restoredInstall.phase
+    || initialStatus.phase
+    || (initialStatus.status === "STARTED" ? "COMPLETE" : "INSTALL");
+  const initialTerminal = canEnterSummary(wizardName, initialStatus.status || "");
+  const registeredHosts = (getStepData("HOST_STATUS", "hosts") || [])
+    .filter((host: any) => host.bootStatus === "REGISTERED");
+  const initialHosts = restoredInstall.hostInfo?.length
+    ? restoredInstall.hostInfo
+    : registeredHosts.map((host: any) => ({
+      name: host.name,
+      status: initialStatus.status === "STARTED" ? "success" : "pending",
+      progress: initialStatus.status === "STARTED" ? 100 : 0,
+      message: initialStatus.status === "STARTED"
+        ? "Install and start completed"
+        : "Waiting",
+      logTasks: [],
+    }));
+
+  const [hosts, setHosts] = useState<any[]>(initialHosts);
+  const [clusterStatus, setClusterStatus] = useState<any>(initialStatus);
+  const [phase, setPhase] = useState<InstallationPhase>(initialPhase);
+  const [working, setWorking] = useState(!initialTerminal);
+  const [terminal, setTerminal] = useState(initialTerminal);
+  const [pollError, setPollError] = useState("");
+  const [operationError, setOperationError] = useState(
+    initialStatus.operationError || "",
   );
-  const hostsWithHeartbeatLostRef = useRef<any>(
-    getStepData(currentStepName, "hostsWithHeartbeatLostRef") || []
-  );
-  const [progress, setProgress] = useState<string>(
-    getStepData(currentStepName, "progress") || "0"
-  );
-  const [status, setStatus] = useState(
-    getStepData(currentStepName, "status") || ""
-  );
-  const overallProgressStatus = useRef(
-    getStepData(currentStepName, "overallProgressStatus") || "0"
-  );
-  const [, setApiPolledData] = useState<any>();
-  const [isBackgroundOperationsModalOpen, setIsBackgroundOperationsModalOpen] =
-    useState(false);
   const [selectedHost, setSelectedHost] = useState("");
-  const currentOpenTaskId = useRef(
-    getStepData(currentStepName, "currentOpenTaskId") || 0
-  );
-  const logTasksChangesCounter = useRef(
-    getStepData(currentStepName, "logTasksChangesCounter") || 0
-  );
-  const performServiceCheck = useRef(false);
-  const clusterStatusRef = useRef<any>(
-    getStepData(currentStepName, "clusterStatusRef") || {}
-  );
-  const apiPolledDataRef = useRef<any>(
-    getStepData(currentStepName, "apiPolledDataRef")
-  );
-  const {isKerberosEnabled}=useContext(AppContext);
-  const hostsRef = useRef<any>(getStepData(currentStepName, "hostsRef") || []);
-  const statusRef = useRef(
-    getStepData(currentStepName, "logTasksChangesCounter") || ""
-  );
-  const launchedStartServices = useRef(
-    getStepData(currentStepName, "launchedStartServices") || false
-  );
-  const { stopPolling } = usePolling(
-    getRequestStatus,
-    3000
-  );
-  const requestId=useRef<string | number>("");
+  const [selectedRequestId, setSelectedRequestId] = useState<
+    string | number | null
+  >(null);
 
-  const [showRetry, setShowRetry] = useState(true);
-  const [selectedFilter, setSelectedFilter] = useState<{
-    label: string;
-    statusKey: string[];
-  }>({
-    label: "",
-    statusKey: [],
-  });
-  useEffect(() => {
-    setProgress(overallProgressStatus.current);
-  }, [overallProgressStatus.current]);
+  const active = useRef(false);
+  const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const requestInFlight = useRef(false);
+  const hostsRef = useRef<any[]>(initialHosts);
+  const clusterStatusRef = useRef<any>(initialStatus);
+  const phaseRef = useRef<InstallationPhase>(initialPhase);
+  const requestIdRef = useRef<string | number | undefined>(initialStatus.requestId);
 
-  // Sync progress when status changes to failed
-  useEffect(() => {
-    if (status === "failed" && progress !== "100") {
-      overallProgressStatus.current = "100";
-      setProgress("100");
-    }
-  }, [status, progress]);
-  const [clusterStatusState, setClusterStatusState] = useState<any>(
-    getStepData(currentStepName, "clusterStatusState") || {}
+  const blocker = useBlocker(({ currentLocation, nextLocation }) =>
+    working && currentLocation.pathname !== nextLocation.pathname,
   );
 
-  // Monitor hosts and cluster status for retry button visibility (works for all wizard types)
-  useEffect(() => {
-    const clusterStatus = getClusterStatus();
-    const hasFailedHosts = some(hosts, ["status", "failed"]);
-    const shouldShowRetry =
-      clusterStatus?.status === "INSTALL FAILED" || hasFailedHosts;
-    setShowRetry(shouldShowRetry);
-  }, [hosts, clusterStatusState]);
-
-  const getClusterStatus = () => {
-    if (isEmpty(clusterStatusRef.current)) {
-      return getStepData("REVIEW", "clusterStatus");
-    }
-    return clusterStatusRef.current;
-  };
-
-  const setClusterStatus = (clusterStatus: any) => {
-    if (clusterStatus.requestId) {
-      clusterStatusRef.current = {
-        ...clusterStatus,
-        oldRequestsId: uniq([
-          ...(clusterStatusRef.current.oldRequestsId || []),
-          clusterStatus.requestId,
-        ]),
-      };
-    } else {
-      clusterStatusRef.current = {
-        ...clusterStatusRef.current,
-        ...clusterStatus,
-      };
-    }
-    if (!isEmpty(clusterStatus)) {
-      clusterStatusRef.current = {
-        ...clusterStatus,
-        oldRequestsId: uniq([
-          ...(clusterStatusRef.current.oldRequestsId || []),
-          clusterStatus.requestId,
-        ]),
-      };
-    }
+  const persist = (
+    nextHosts: any[],
+    nextStatus: any,
+    nextPhase: InstallationPhase,
+  ) => {
     dispatch({
       type: ActionTypes.STORE_INFORMATION,
       payload: {
-        step: currentStep.name || "INSTALL_TEST__START",
+        step: "INSTALL_START_TEST",
         data: {
-          hostInfo: hosts,
-          clusterStatus: getClusterStatus(),
-          hosts,
-          isPolling: isPolling?.current,
-          parseHostInfoRef: parseHostInfoRef?.current,
-          hostsWithHeartbeatLostRef: hostsWithHeartbeatLostRef?.current,
-          progress,
-          status,
-          overallProgressStatus: overallProgressStatus?.current,
-          currentOpenTaskId: currentOpenTaskId?.current,
-          logTasksChangesCounter: logTasksChangesCounter?.current,
-          clusterStatusRef: clusterStatusRef?.current,
-          apiPolledDataRef: apiPolledDataRef?.current,
-          hostsRef: hostsRef?.current,
-          statusRef: statusRef?.current,
-          launchedStartService: launchedStartServices?.current,
-          clusterStatusState: clusterStatus,
+          hostInfo: nextHosts,
+          clusterStatus: nextStatus,
+          phase: nextPhase,
         },
       },
     });
   };
 
-  const filters = [
-    {
-      label: "All",
-      statusKey: ["in_progress", "pending", "failed", "warning", "success"],
-    },
-    {
-      label: "In Progress",
-      statusKey: ["in_progress", "pending"],
-    },
-    {
-      label: "Warning",
-      statusKey: ["warning"],
-    },
-    {
-      label: "Success",
-      statusKey: ["success"],
-    },
-    {
-      label: "Fail",
-      statusKey: ["failed"],
-    },
-  ];
+  const updateDeploymentState = (
+    nextStatus: any,
+    nextPhase: InstallationPhase,
+    nextHosts = hostsRef.current,
+  ) => {
+    hostsRef.current = nextHosts;
+    clusterStatusRef.current = nextStatus;
+    phaseRef.current = nextPhase;
+    requestIdRef.current = nextStatus.requestId;
+    setHosts(nextHosts);
+    setClusterStatus(nextStatus);
+    setPhase(nextPhase);
+    persist(nextHosts, nextStatus, nextPhase);
+  };
 
-  const {
-    currentItems,
-    changePage,
-    currentPage,
-    maxPage,
-    itemsPerPage,
-    setItemsPerPage,
-  } = usePagination(hosts);
+  const schedulePoll = (delay = 0) => {
+    if (!active.current || requestIdRef.current == null) return;
+    if (timer.current) clearTimeout(timer.current);
+    timer.current = setTimeout(() => void pollCurrentRequest(), delay);
+  };
 
-  useEffect(() => {
-    setSelectedFilter(filters[0]);
-  }, []);
-
-  // Determine when to show retry button based on cluster status (matching Ember implementation)
-  useEffect(() => {
-    const clusterStatus = getClusterStatus();
-    const shouldShowRetry = clusterStatus?.status === "INSTALL FAILED";
-    setShowRetry(shouldShowRetry);
-  }, [clusterStatusState]);
-
-  useEffect(() => {
-    setClusterStatusState(clusterStatusRef.current);
-  }, [clusterStatusRef.current]);
-
-  useEffect(() => {
-    if (
-      some(hosts, ["status", "failed"]) ||
-      some(hosts, ["status", "heartbeat_lost"])
-    ) {
-      statusRef.current = "failed";
-    } else if (some(hosts, ["status", "warning"])) {
-      statusRef.current = "warning";
-    } else if (
-      progress === "100" &&
-      getClusterStatus().status !== "INSTALL FAILED"
-    ) {
-      statusRef.current = "success";
-    }
-    setStatus(statusRef.current);
-  }, [hostsRef.current, progress]);
-
-  function getProgressBarColor(status: string) {
-    switch (status.toLowerCase()) {
-      case "pending":
-      case "in_progress":
-        return "info";
-      case "failed":
-      case "fail":
-      case "failure":
-      case "install failed":
-        return "danger";
-      case "success":
-      case "installed":
-        return "success";
-      case "warning":
-        return "warning";
-      default:
-        return "info";
-    }
-  }
-
-  // useEffect(() => {
-  //   if (hosts.length&&!logsLoadedOnce.current) {
-  //     logsLoadedOnce.current=true;
-  //     loadLogData(false);
-  //   }
-  // }, [hosts.length]);
-
-  // Reset status and message of all hosts when retry install (matching Ember's resetHostsForRetry)
-  function resetHostsForRetry() {
-    const hostsCopy = cloneDeep(hostsRef.current);
-    for (let host of hostsCopy) {
-      host.status = "pending";
-      host.message = "Waiting";
-      host.progress = "0";
-      host.isNoTasksForInstall = false;
-      host.logTasks = [];
-    }
-    hostsRef.current = hostsCopy;
-    setHosts(hostsCopy);
-  }
-  async function retry() {
-    const clusterStatus = getClusterStatus();
-    if (
-      clusterStatus.status === "INSTALL FAILED" ||
-      some(hosts, ["status", "failed"])
-    ) {
-      try {
-
-        // Reset hosts for retry (matching Ember's resetHostsForRetry)
-        resetHostsForRetry();
-
-        // Reset polling flags
-        isPolling.current = false;
-        parseHostInfoRef.current = false;
-        launchedStartServices.current = false;
-
-        // Reset progress and status
-        overallProgressStatus.current = "0";
-        setProgress("0");
-        statusRef.current = "info";
-        setStatus("info");
-
-        // Start installation services again
-        await installServices(true);
-
-        // Enable polling
-        isPolling.current = true;
-
-        // Start polling again
-        startPolling();
-      } catch (error) {
-        console.error("Error during retry:", error);
-        // Set failed status if retry fails
-        const failedStatus = {
-          status: "INSTALL FAILED",
-          isInstallError: true,
-          isCompleted: false,
-        };
-        setClusterStatus(failedStatus);
-      }
-    }
-  }
-  function hostHasClientsOnly(jsonError: any) {
-    const hostsCopy = cloneDeep(hostsRef.current);
-    forEach(hostsCopy, (host: any) => {
-      let OnlyClients = true;
-      const tasks = host.logTasks;
-      forEach(tasks, (task: any) => {
-        const allServiceComponents = getStepData(
-          "SLAVES_AND_CLIENTS",
-          "allServiceComponentsList"
-        );
-        const component: any = find(allServiceComponents, [
-          "component_name",
-          task.Tasks.role,
-        ]);
-        if (!(component && component?.is_client)) {
-          OnlyClients = false;
-        }
-      });
-      if (OnlyClients || jsonError) {
-        set(host, "status", "success");
-        set(host, "progress", "100");
-      }
-    });
-    hostsRef.current = hostsCopy;
-    setHosts(hostsCopy);
-  }
-
-  function isAddHostWizard() {
-    return wizardName === "addHost";
-  }
-  function isAddServiceWizard() {
-    return wizardName === "addService";
-  }
-
-  function getNewHosts() {
-    return getStepData("HOST_STATUS", "hosts")?.filter(
-      (host: any) => host.bootStatus === "REGISTERED"
-    );
-  }
-
-  function startPolling() {
-    //Disable Next
-    //Start Polling from hook
-    doPolling();
-  }
-
-  async function getRequestStatus() {
-      // if (!restartCheckRef.current) pausePolling();
-    const clusterName = getStepData("NAME", "clusterName");
-
-  
-      const requestStatus: any = await RequestApi.getRequestStatus(
-        clusterName,
-        requestId.current as string
-      );
-      const { Requests } = requestStatus;
-      if (isFinished(Requests.request_status)) {
-        if (Requests.request_status === ProgressStatus.COMPLETED) {
-          stopPolling();
-          launchStartServices();
-        }
-      }
-    }
-  //@ts-ignore
-  async function loadDoServiceChecksFlag() {
-    try {
-      const data = await ServiceApi.ambariService(
-        "?fields=RootServiceComponents/properties/skip.service.checks"
-      );
-      var properties = get(data, "RootServiceComponents.properties");
-      if (properties && properties.hasOwnProperty("skip.service.checks")) {
-        performServiceCheck.current =
-          properties["skip.service.checks"] === "true";
-      }
-    } catch (err) {}
-  }
-  async function launchStartServices() {
-    let data: any = {};
-    if (isAddHostWizard()) {
-      const slaves = getStepData(
-        "SLAVES_AND_CLIENTS",
-        "allServiceComponentsList"
-      )
-        .filter(
-          (c: any) =>
-            get(c, "is_client") === false && get(c, "is_master") === false
-        )
-        .map((c: any) => get(c, "component_name"));
-      data = {
-        context: get(messages, "requestInfo.startHostComponents"),
-        HostRoles: { state: "STARTED" },
-        urlParams: "",
-        query: `HostRoles/component_name.in(${slaves.join(
-          ","
-        )})&HostRoles/state=INSTALLED&HostRoles/host_name.in(${getNewHosts()
-          .map((host: any) => get(host, "name", ""))
-          .join(",")})`,
-      };
-    } else if (isAddServiceWizard()) {
-      let servicesList: string[] = map(
-        filter(getStepData("SERVICES", "services"), function (service: any) {
-          return !service.installed && service.selected;
-        }),
-        "serviceName"
-      );
-      if (servicesList.includes("OOZIE")) {
-        servicesList = [...servicesList, "HDFS", "YARN", "MAPREDUCE2"];
-      }
-      data = {
-        context: "Start Added Services",
-        ServiceInfo: { state: "STARTED" },
-        urlParams:
-          "ServiceInfo/state=INSTALLED&ServiceInfo/service_name.in(" +
-          servicesList.join(",") +
-          ")&params/run_smoke_test=true&params/reconfigure_client=false",
-      };
-    } else {
-      data = {
-        context: "Start Services",
-        ServiceInfo: { state: "STARTED" },
-        urlParams: `ServiceInfo/state=INSTALLED&params/run_smoke_test=" +
-            ${!performServiceCheck.current} +
-            "&params/reconfigure_client=false`,
-      };
-    }
-    const clusterName = getStepData("NAME", "clusterName");
-    const updateStatus = isAddHostWizard()
-      ? await HostsApi.updateHostComponents(clusterName, data.urlParams, data)
-      : await ServiceApi.updateService(clusterName, data, data.urlParams);
-    let clusterStatus = {};
-    if (updateStatus) {
-      // Handle different response structures for requestId
-      let requestId;
-      if (updateStatus?.data?.Requests?.id) {
-        requestId = updateStatus.data.Requests.id;
-      } else if (updateStatus?.Requests?.id) {
-        requestId = updateStatus.Requests.id;
-      } else if (updateStatus?.id) {
-        requestId = updateStatus.id;
-      }
-
-      clusterStatus = {
-        status: "INSTALLED",
+  const setRequest = async (
+    requestId: string | number,
+    nextPhase: InstallationPhase,
+    status: string,
+  ) => {
+    const nextStatus = {
+      ...clusterStatusRef.current,
+      status,
+      requestId,
+      oldRequestsId: Array.from(new Set([
+        ...(clusterStatusRef.current.oldRequestsId || []),
         requestId,
-        isStartError: false,
-        isCompleted: false,
-      };
-      hostHasClientsOnly(false);
-      //Save Cluster Status
-      setClusterStatus(clusterStatus);
-    } else {
-      hostHasClientsOnly(true);
-      clusterStatus = {
-        status: "STARTED",
-        isStartError: false,
-        isCompleted: true,
-      };
-      setClusterStatus(clusterStatus);
-      setStatus("success");
-      overallProgressStatus.current = "100";
-    }
-    if (updateStatus) {
-      startPolling();
-    }
-  }
-
-  async function regenerate() {
-    const clusterName = getStepData("NAME", "clusterName");
-    const payload = {
-      Clusters: {
-        security_type: "KERBEROS",
-      },
+      ])),
+      isCompleted: false,
+      operationError: "",
+      phase: nextPhase,
     };
+    setOperationError("");
+    setPollError("");
+    setTerminal(false);
+    setWorking(true);
+    updateDeploymentState(nextStatus, nextPhase);
+    await Promise.resolve(flushStateToDb(
+      "checkpoint",
+      -1,
+      wizardCheckpoint(
+        wizardName,
+        nextPhase === "INSTALL" ? "INSTALLING" : "STARTING",
+      ),
+    ));
+    schedulePoll();
+  };
+
+  const completeSuccess = async (status = "STARTED") => {
+    const completedHosts = hostsRef.current.map((host) => ({
+      ...host,
+      status: host.status === "failed" ? "warning" : "success",
+      progress: 100,
+      message: host.status === "failed"
+        ? "Deployment completed with warnings"
+        : status === "START_SKIPPED"
+          ? "Install completed; component start was skipped"
+          : "Install and start completed",
+    }));
+    const nextStatus = {
+      ...clusterStatusRef.current,
+      status,
+      isCompleted: true,
+      phase: "COMPLETE",
+      operationError: "",
+    };
+    updateDeploymentState(nextStatus, "COMPLETE", completedHosts);
+    setWorking(false);
+    setTerminal(true);
+    await Promise.resolve(flushStateToDb("default"));
+  };
+
+  const completeFailure = async (
+    failedPhase: InstallationPhase,
+    message = "",
+  ) => {
+    const nextStatus = {
+      ...clusterStatusRef.current,
+      status: failedPhase === "INSTALL" ? "INSTALL FAILED" : "START FAILED",
+      isCompleted: true,
+      failedPhase,
+      phase: failedPhase,
+      operationError: message,
+    };
+    updateDeploymentState(nextStatus, failedPhase);
+    setOperationError(message);
+    setWorking(false);
+    setTerminal(true);
+    await Promise.resolve(flushStateToDb("default"));
+  };
+
+  const launchKeytabRegeneration = async () => {
     try {
-      const params = "regenerate_keytabs=all";
-      const requestData = await RequestApi.regenerateKeytabs(
+      const response = await RequestApi.regenerateKeytabs(
         clusterName,
-        payload,
-        params
+        { Clusters: { security_type: "KERBEROS" } },
+        "regenerate_keytabs=all",
       );
-      requestId.current = requestData.Requests.id;
-    } catch (error) {
-      console.log("Error regenerating keytabs: ", error);
-    }
-  }
-
-  async function isAllComponentsInstalled() {
-    try {
-      const jsonData = await HostsApi.getHostStatus(
-        getStepData("NAME", "clusterName")
-      );
-      const hostsCopy = cloneDeep(hostsRef.current);
-      const clusterStatus = {
-        status: "INSTALL FAILED",
-        isStartError: true,
-        isCompleted: false,
-      };
-      let usedHostWithHeartbeatLost = false;
-      const hostsWithHeartbeatLost: any = [];
-      const mastersData: any = getStepData("MASTERS", "mastersData");
-      const allMasterServices = flatten(map(mastersData, "masterServices"));
-      let usedHosts = map(
-        filter(allMasterServices, ["isInstalled", false]),
-        "hostName"
-      );
-      //Include Hosts from Client and slave components as well
-      usedHosts = uniq(usedHosts);
-      filter(jsonData.items, ["Hosts.host_state", "HEARTBEAT_LOST"]).forEach(
-        function (host) {
-          const hostComponentObj = {
-            hostName: host.Hosts.host_name,
-          };
-          const componentsArr: any[] = [];
-          host.host_components.forEach(function (_hostComponent: any) {
-            const componentName = role(
-              _hostComponent.HostRoles.component_name,
-              false
-            );
-            componentsArr.push(componentName);
-          });
-          //@ts-expect-error
-          hostComponentObj.componentNames = getFormattedStringFromArray(
-            componentsArr,
-            ""
-          );
-          hostsWithHeartbeatLost.push(hostComponentObj);
-          if (
-            !usedHostWithHeartbeatLost &&
-            usedHosts.includes(host.Hosts.host_name)
-          ) {
-            usedHostWithHeartbeatLost = true;
-          }
-        }
-      );
-      hostsWithHeartbeatLostRef.current = hostsWithHeartbeatLost;
-      if (usedHostWithHeartbeatLost) {
-        hostsCopy.forEach(function (host: any) {
-          if (find(hostsWithHeartbeatLost, ["hostName", host.name])) {
-            set(host, "status", "heartbeat_lost");
-          } else if (host.status !== "failed" && host.status !== "warning") {
-            set(host, "message", "Install completed. Start aborted");
-          }
-          host.set("progress", "100");
-        });
-        overallProgressStatus.current = "100";
-        hostsRef.current = hostsCopy;
-        setHosts(hostsCopy);
-        //Save Cluster Status, needs to be updated
-        setClusterStatus(clusterStatus);
-      } else if (getClusterStatus().status === "PENDING" && isPolling.current) {
-        //Check for Skip
-        if (!launchedStartServices.current) {
-          launchedStartServices.current = true;
-          if(isKerberosEnabled){
-           await regenerate();
-          }
-          else{
-          launchStartServices();
-          }
-        }
+      if (!active.current) return;
+      const requestId = requestIdFrom(response);
+      if (requestId == null) {
+        throw new Error("Ambari did not return a keytab request ID.");
       }
-    } catch (err) {
-      const clusterStatus = {
-        status: "INSTALL FAILED",
-        isStartError: true,
-        isCompleted: false,
-      };
-      overallProgressStatus.current = "100";
-      const hostsCopy = cloneDeep(hosts);
-      hostsCopy.forEach(function (host: any) {
-        if (host.status !== "failed" && host.get("status") !== "warning") {
-          set(host, "message", "Install completed. Start aborted");
-          set(host, "progress", "100");
-        }
-      });
-      //Save Cluster Status
-      setClusterStatus(clusterStatus);
+      await setRequest(requestId, "KEYTABS", "INSTALLED");
+    } catch (error: any) {
+      if (active.current) await completeFailure("KEYTABS", errorMessage(error));
     }
-  }
-  async function loadCurrentTaskLog() {
-    const taskId = currentOpenTaskId.current;
-    const clusterStatus: any = getClusterStatus();
-    const requestId = clusterStatus?.oldRequestsId?.at(-1);
-    getStepData("NAME", "clusterName");
-    if (taskId) {
+  };
+
+  const loadSkipServiceChecks = async (): Promise<boolean> => {
+    try {
+      const response = await ServiceApi.ambariService(
+        "?fields=RootServiceComponents/properties/skip.service.checks",
+      );
+      return get(
+        response,
+        "RootServiceComponents.properties.skip.service.checks",
+      ) === "true";
+    } catch {
+      return false;
+    }
+  };
+
+  const selectedServices = () => Object.values(
+    getStepData("SERVICES", "services") || {},
+  ).filter((service: any) => service.selected && !service.installed)
+    .map((service: any) => service.serviceName);
+
+  const launchStart = async () => {
+    if (supports.skipComponentStartAfterInstall) {
+      await completeSuccess("START_SKIPPED");
       return;
     }
     try {
-      const data = await RequestApi.getTask(
-        getStepData("NAME", "clusterName"),
-        requestId,
-        taskId as any
+      let serviceNames = selectedServices();
+      let urlParams: string;
+      let context: string;
+      if (wizardName === "addService") {
+        if (serviceNames.includes("OOZIE")) {
+          serviceNames = Array.from(new Set([
+            ...serviceNames,
+            "HDFS",
+            "YARN",
+            "MAPREDUCE2",
+          ]));
+        }
+        urlParams = "ServiceInfo/state=INSTALLED"
+          + `&ServiceInfo/service_name.in(${serviceNames.join(",")})`
+          + "&params/run_smoke_test=true&params/reconfigure_client=false";
+        context = "Start Added Services";
+      } else {
+        const skipServiceChecks = await loadSkipServiceChecks();
+        urlParams = "ServiceInfo/state=INSTALLED"
+          + `&params/run_smoke_test=${!skipServiceChecks}`
+          + "&params/reconfigure_client=false";
+        context = "Start Services";
+      }
+      const response = await ServiceApi.updateService(
+        clusterName,
+        { context, ServiceInfo: { state: "STARTED" } },
+        urlParams,
       );
-      if (taskId) {
-        const host: any = find(hosts, ["name", data.Tasks.host_name]);
-        if (host) {
-          const currentTask = host.logTasks;
-          if (currentTask) {
-            currentTask.Tasks.stderr = data.Tasks.stderr;
-            currentTask.Tasks.stdout = data.Tasks.stdout;
-            currentTask.Tasks.output_log = data.Tasks.output_log;
-            currentTask.Tasks.error_log = data.Tasks.error_log;
-          }
-        }
-      }
-      logTasksChangesCounter.current += 1;
-    } catch (err) {
-      currentOpenTaskId.current = 0;
-    }
-  }
-  function doPolling() {
-    getLogsByRequest(true);
-  }
-  function parseHostInfoPolling() {
-    const result = parseHostInfoRef.current;
-    if (!isPolling.current) {
-      const clusterStatus: any = getClusterStatus();
-
-      if (clusterStatus.status === "INSTALL FAILED") {
-        isAllComponentsInstalled();
-      }
-      return;
-    }
-    if (result !== true) {
-      window.setTimeout(function () {
-        if (currentOpenTaskId.current) {
-          loadCurrentTaskLog();
-        }
-        doPolling();
-      }, 3000);
-    }
-  }
-  function changeParseHostInfo(value: boolean) {
-    parseHostInfoRef.current = value;
-    parseHostInfoPolling();
-  }
-  function replacePolledData(polledData: any) {
-    apiPolledDataRef.current = polledData;
-    setApiPolledData(polledData);
-  }
-  function setLogTasksStatePerHost(tasksPerHost: any, host: any) {
-    tasksPerHost.forEach(function (_task: any) {
-      var task = find(host.logTasks, ["Tasks.id", _task.Tasks.id]);
-      if (task) {
-        task.Tasks.status = _task.Tasks.status;
-        task.Tasks.start_time = _task.Tasks.start_time;
-        task.Tasks.end_time = _task.Tasks.end_time;
-        task.Tasks.exit_code = _task.Tasks.exit_code;
-      } else {
-        host.logTasks.push(_task);
-      }
-    });
-  }
-  function onSuccessPerHost(actions: any, contentHost: any) {
-    let status = getClusterStatus()?.status;
-    if (
-      every(actions, ["Tasks.status", "COMPLETED"]) &&
-      (status === "INSTALLED" || status === "STARTED")
-    ) {
-      set(contentHost, "status", "success");
-    }
-  }
-  function isMasterFailed(polledData: any) {
-    let result = false;
-    map(
-      filter(filter(polledData, ["Tasks.command", "INSTALL"]), [
-        "Tasks.status",
-        "FAILED",
-      ]),
-      "Tasks.role"
-    ).forEach(function (role) {
-      const slaveComponents = getStepData(
-        "SLAVES_AND_CLIENTS",
-        "serviceComponents"
-      );
-      const checkedSlaveComponents = map(
-        filter(flatten(map(slaveComponents, "checkboxes")), ["checked", true]),
-        "label"
-      );
-      if (checkedSlaveComponents.includes(role)) {
-        result = true;
-      }
-    });
-    return result;
-  }
-  async function installServices(isRetry = false) {
-    const statusCopy = cloneDeep(clusterStatusRef.current);
-    let data;
-    if (isRetry) {
-      data = {
-        context: "Install Components",
-        HostRoles: { state: "INSTALLED" },
-        urlParams:
-          "HostRoles/desired_state=INSTALLED&HostRoles/state!=INSTALLED",
-      };
-    } else {
-      data = {
-        context: "Install Services",
-        HostRoles: { state: "INSTALLED" },
-        urlParams: "ServiceInfo/state=INIT",
-      };
-    }
-    statusCopy.status = "PENDING";
-    setClusterStatus(statusCopy);
-    try {
-      let updateResponse;
-      if (isRetry) {
-        updateResponse = await HostsApi.updateHostComponents(
-          getStepData("NAME", "clusterName"),
-          data.urlParams,
-          data
-        );
-      } else {
-        updateResponse = await ServiceApi.updateService(
-          getStepData("NAME", "clusterName"),
-          data,
-          data.urlParams as string
-        );
-      }
-      // Handle different response structures
-      let requestId;
-      if (updateResponse?.data?.Requests?.id) {
-        requestId = updateResponse.data.Requests.id;
-      } else if (updateResponse?.Requests?.id) {
-        requestId = updateResponse.Requests.id;
-      } else if (updateResponse?.id) {
-        requestId = updateResponse.id;
-      } else {
-        throw new Error("No requestId found in API response");
-      }
-
-      const updatedStatus = {
-        status: "PENDING",
-        requestId,
-        isInstallError: false,
-        isCompleted: false,
-      };
-      setClusterStatus(updatedStatus);
-    } catch (err) {
-      console.error("Error in installServices:", err);
-      const updatedStatus = {
-        status: "INSTALL FAILED",
-        isInstallError: true,
-        isCompleted: false,
-      };
-      setClusterStatus(updatedStatus);
-    }
-  }
-  function onErrorPerHost(actions: any, contentHost: any) {
-    let status = getClusterStatus()?.status;
-    if (!actions) return;
-    if (
-      some(actions, ["Tasks.status", "FAILED"]) ||
-      some(actions, ["Tasks.status", "ABORTED"]) ||
-      some(actions, ["Tasks.status", "TIMEDOUT"])
-    ) {
-      set(contentHost, "status", "warning");
-    }
-    if (
-      (status === "PENDING" && some(actions, ["Tasks.status", "FAILED"])) ||
-      isMasterFailed(actions)
-    ) {
-      contentHost.status !== "heartbeat_lost"
-        ? set(contentHost, "status", "failed")
-        : "";
-    }
-  }
-  function displayMessage(task: any) {
-    let normalizedRole = role(task.role, false);
-    /* istanbul ignore next */
-    switch (task.command) {
-      case "INSTALL":
-        switch (task.status) {
-          case "PENDING":
-            return "Preparing to install " + normalizedRole;
-          case "QUEUED":
-            return "Waiting to install " + normalizedRole;
-          case "IN_PROGRESS":
-            return "Installing " + normalizedRole;
-          case "COMPLETED":
-            return "Successfully Installed " + normalizedRole;
-          case "FAILED":
-            return "Failed to install" + normalizedRole;
-        }
-        break;
-      case "UNINSTALL":
-        switch (task.status) {
-          case "PENDING":
-            return "Preparing to uninstall " + normalizedRole;
-          case "QUEUED":
-            return "Waiting to uninstall " + normalizedRole;
-          case "IN_PROGRESS":
-            return "Uninstalling " + normalizedRole;
-          case "COMPLETED":
-            return "Successfully uninstalled " + normalizedRole;
-          case "FAILED":
-            return "Failed to uninstall" + normalizedRole;
-        }
-
-        break;
-      case "START":
-        switch (task.status) {
-          case "PENDING":
-            return "Preparing to start " + normalizedRole;
-          case "QUEUED":
-            return "Waiting to start " + normalizedRole;
-          case "IN_PROGRESS":
-            return "Starting " + normalizedRole;
-          case "COMPLETED":
-            return "Started Successfully " + normalizedRole;
-          case "FAILED":
-            return "Failed to start" + normalizedRole;
-        }
-        break;
-      case "STOP":
-        switch (task.status) {
-          case "PENDING":
-            return "Preparing to stop " + normalizedRole;
-          case "QUEUED":
-            return "Waiting to stop " + normalizedRole;
-          case "IN_PROGRESS":
-            return "Stopping " + normalizedRole;
-          case "COMPLETED":
-            return "Successfully stopped " + normalizedRole;
-          case "FAILED":
-            return "Failed to stop" + normalizedRole;
-        }
-        break;
-      //@ts-ignore
-      case "CUSTOM_COMMAND":
-        normalizedRole = commandDetail(
-          task.command_detail,
-          task.request_input,
-          task.ops_display_name
-        );
-      case "EXECUTE":
-      case "SERVICE_CHECK":
-        switch (task.status) {
-          case "PENDING":
-            return "Preparing to execute " + normalizedRole;
-          case "QUEUED":
-            return "Waiting to execute " + normalizedRole;
-          case "IN_PROGRESS":
-            return "Executing " + normalizedRole;
-          case "COMPLETED":
-            return "Successfully executed " + normalizedRole;
-          case "FAILED":
-            return "Failed to execute" + normalizedRole;
-        }
-        break;
-      case "ABORT":
-        switch (task.status) {
-          case "PENDING":
-            return "Preparing to abort " + normalizedRole;
-          case "QUEUED":
-            return "Waiting to abort " + normalizedRole;
-          case "IN_PROGRESS":
-            return "Aborted " + normalizedRole;
-          case "COMPLETED":
-            return "Successfully aborted " + normalizedRole;
-          case "FAILED":
-            return "Failed to abort" + normalizedRole;
-        }
-        break;
-    }
-    return "";
-  }
-  function progressPerHost(actions: any, contentHost: any) {
-    let progress = 0;
-    let actionsPerHost = actions.length;
-    let completedActions = 0;
-    let queuedActions = 0;
-    let inProgressActions = 0;
-    let installProgressFactor = 33;
-    actions.forEach(function (action: any) {
-      if (
-        ["COMPLETED", "FAILED", "ABORTED", "TIMEDOUT"].includes(
-          action.Tasks.status
-        )
-      ) {
-        completedActions += +[
-          "COMPLETED",
-          "FAILED",
-          "ABORTED",
-          "TIMEDOUT",
-        ].includes(action.Tasks.status);
-      }
-      if (action.Tasks.status === "QUEUED") {
-        queuedActions += +(action.Tasks.status === "QUEUED");
-      }
-      if (action.Tasks.status === "IN_PROGRESS") {
-        inProgressActions += +(action.Tasks.status === "IN_PROGRESS");
-      }
-    });
-    /** for the install phase (PENDING), % completed per host goes up to 33%; floor(100 / 3)
-     * for the start phase (INSTALLED), % completed starts from 34%
-     * when task in queued state means it's completed on 9%
-     * in progress - 35%
-     * completed - 100%
-     */
-    const clusterStatus: any = getClusterStatus();
-    switch (clusterStatus.status) {
-      case "PENDING":
-        progress = actionsPerHost
-          ? Math.ceil(
-              ((queuedActions * 0.09 +
-                inProgressActions * 0.35 +
-                completedActions) /
-                actionsPerHost) *
-                installProgressFactor
-            )
-          : installProgressFactor;
-        break;
-      case "INSTALLED":
-        progress = actionsPerHost
-          ? 33 +
-            Math.floor(
-              ((queuedActions * 0.09 +
-                inProgressActions * 0.35 +
-                completedActions) /
-                actionsPerHost) *
-                67
-            )
-          : 100;
-        break;
-      default:
-        progress = 100;
-        break;
-    }
-    set(contentHost, "progress", progress.toString());
-    return progress;
-  }
-  function onInProgressPerHost(actions: any, contentHost: any) {
-    let runningAction = find(actions, ["Tasks.status", "IN_PROGRESS"]);
-    if (runningAction === undefined || runningAction === null) {
-      runningAction = find(actions, ["Tasks.status", "QUEUED"]);
-    }
-    if (runningAction === undefined || runningAction === null) {
-      runningAction = find(actions, ["Tasks.status", "PENDING"]);
-    }
-    if (runningAction !== null && runningAction !== undefined) {
-      set(contentHost, "status", "in_progress");
-      set(contentHost, "message", displayMessage(runningAction.Tasks));
-    }
-  }
-  function isSuccess(polledData: any) {
-    return every(polledData, ["Tasks.status", "COMPLETED"]);
-  }
-  function isServicesStarted(polledData: any) {
-    const clusterStatus: any = getClusterStatus();
-    const requestId = clusterStatus?.oldRequestsId?.at(-1);
-    let updatedClusterStatus: any = {};
-    if (
-      !some(polledData, ["Tasks.status", "PENDING"]) &&
-      !some(polledData, ["Tasks.status", "QUEUED"]) &&
-      !some(polledData, ["Tasks.status", "IN_PROGRESS"])
-    ) {
-      overallProgressStatus.current = "100";
-      updatedClusterStatus = {
-        status: "INSTALLED",
-        requestId,
-        isCompleted: true,
-      };
-      if (isSuccess(polledData)) {
-        updatedClusterStatus.status = "STARTED";
-      } else {
-        updatedClusterStatus.status = "START FAILED"; // 'START FAILED' implies to step10 that installation was successful but start failed
-      }
-      //Save Cluster Status
-      setClusterStatus(updatedClusterStatus);
-      // this.saveInstalledHosts(this);
-      return true;
-    }
-    return false;
-  }
-  function setIsServicesInstalled(polledData: any) {
-    const clusterStatus: any = getClusterStatus();
-    let updatedClusterStatus: any = {};
-    const requestId = clusterStatus?.oldRequestsId?.at(-1);
-    const inferredStatus = statusRef.current;
-    if (
-      !some(polledData, ["Tasks.status", "PENDING"]) &&
-      !some(polledData, ["Tasks.status", "QUEUED"]) &&
-      !some(polledData, ["Tasks.status", "IN_PROGRESS"])
-    ) {
-      updatedClusterStatus = {
-        status: "PENDING",
-        requestId,
-        isCompleted: false,
-      };
-      if (inferredStatus === "failed") {
-        updatedClusterStatus.status = "INSTALL FAILED";
-        setClusterStatus(updatedClusterStatus);
-        overallProgressStatus.current = "100";
-        isPolling.current = false;
-        const hostsCopy = cloneDeep(hostsRef.current);
-        hostsCopy.forEach(function (host: any) {
-          set(host, "progress", "100");
-        });
-        hostsRef.current = hostsCopy;
-        setHosts(hostsCopy);
-        isAllComponentsInstalled().then(function () {
-          changeParseHostInfo(false);
-        });
+      if (!active.current) return;
+      const requestId = requestIdFrom(response);
+      if (requestId == null) {
+        await completeSuccess();
         return;
       }
-      overallProgressStatus.current = "33";
-      setProgress("33");
-      isAllComponentsInstalled().then(function () {
-        changeParseHostInfo(true);
-      });
-      return;
+      await setRequest(requestId, "START", "INSTALLED");
+    } catch (error: any) {
+      if (active.current) await completeFailure("START", errorMessage(error));
     }
-    changeParseHostInfo(false);
-  }
-  function setFinishState(polledData: any) {
-    const clusterStatus: any = getClusterStatus();
-    if (clusterStatus.status === "INSTALLED") {
-      changeParseHostInfo(isServicesStarted(polledData));
-      return;
-    } else if (clusterStatus.status === "PENDING") {
-      setIsServicesInstalled(polledData);
-      return;
-    } else if (
-      clusterStatus.status === "INSTALL FAILED" ||
-      clusterStatus.status === "START FAILED" ||
-      clusterStatus.status === "STARTED"
-    ) {
-      overallProgressStatus.current = "100";
-      changeParseHostInfo(true);
-      return;
-    }
-    changeParseHostInfo(true);
-  }
-  useEffect(() => {}, [hostsRef.current]);
-  function setParseHostInfo(polledData: any) {
-    let totalProgress = 0;
-    let tasksData = polledData.tasks || [];
-    const clusterStatus: any = getClusterStatus();
-    const requestId = clusterStatus?.oldRequestsId?.at(-1);
-    forEach(tasksData, (taskData) => {
-      set(taskData, "Tasks.request_id", requestId);
-    });
-    if (
-      polledData.Requests &&
-      polledData.Requests.id &&
-      polledData.Requests.id != requestId
-    ) {
-      // We don't want to use non-current requestId's tasks data to
-      // determine the current install status.
-      // Also, we don't want to keep polling if it is not the
-      // current requestId.
-      changeParseHostInfo(false);
-      return;
-    }
-    replacePolledData(tasksData);
-    const tasksHostMap: any = {};
-    tasksData.forEach(function (task: any) {
-      if (tasksHostMap[task.Tasks.host_name]) {
-        tasksHostMap[task.Tasks.host_name].push(task);
-      } else {
-        tasksHostMap[task.Tasks.host_name] = [task];
-      }
-    });
-    const hostsCopy = cloneDeep(hostsRef.current);
-    hostsCopy.forEach((_host: any) => {
-      const actionsPerHost = tasksHostMap[_host.name] || []; // retrieved from polled Data
-      if (actionsPerHost.length === 0) {
-        if (
-          clusterStatus.status === "PENDING" ||
-          clusterStatus.status === "INSTALL FAILED"
-        ) {
-          set(_host, "progress", "33");
-          set(_host, "isNoTasksForInstall", true);
-          set(_host, "status", "pending");
-        }
-        if (
-          clusterStatus.status === "INSTALLED" ||
-          clusterStatus.status === "FAILED"
-        ) {
-          set(_host, "progress", "100");
-          set(_host, "status", "success");
-        }
-      } else {
-        set(_host, "isNoTasksForInstall", false);
-      }
-      setLogTasksStatePerHost(actionsPerHost, _host);
-      onSuccessPerHost(actionsPerHost, _host); // every action should be a success
-      onErrorPerHost(actionsPerHost, _host); // any action should be a failure
-      onInProgressPerHost(actionsPerHost, _host); // current running action for a host
-      totalProgress += Number(progressPerHost(actionsPerHost, _host));
-      if (
-        _host.progress == 33 &&
-        _host.status != "failed" &&
-        _host.status != "warning"
-      ) {
-        set(_host, "message", "Install complete (Waiting to start)");
-        set(_host, "status", "pending");
-      }
-      if (
-        _host.progress == 100 &&
-        _host.status != "failed" &&
-        _host.status != "warning"
-      ) {
-        set(_host, "message", "Install and start completed");
-        set(_host, "status", "success");
-      }
-      if (_host.progress == 100 && _host.status == "failed") {
-        set(_host, "message", "Failed to install and start");
-        set(_host, "status", "failed");
-      }
-      if (_host.progress == 100 && _host.status == "warning") {
-        set(_host, "message", "Warnings encountered");
-        set(_host, "status", "warning");
-      }
-    });
-    logTasksChangesCounter.current += 1;
-    
-    // Calculate overall progress following Ember.js logic exactly
-    totalProgress = Math.floor(totalProgress / hostsCopy.length);
-    
-    // Update progress state immediately (following Ember.js pattern)
-    overallProgressStatus.current = totalProgress.toString();
-    setProgress(totalProgress.toString());
-    
-    setFinishState(tasksData);
-    hostsRef.current = hostsCopy;
-    setHosts(hostsCopy);
-  }
-  async function getLogsByRequest(polling: boolean) {
-    const clusterStatus: any = getClusterStatus();
-    const requestId = clusterStatus?.oldRequestsId?.at(-1);
-    try {
-      const requestStatus = await LogApi.getLogData(
-        getStepData("NAME", "clusterName"),
-        requestId
-      );
-      isPolling.current = polling;
-      setParseHostInfo(requestStatus);
-    } catch (err) {
-      loadLogData(true);
-    }
-  }
-  function loadLogData(startPolling: boolean) {
-    getLogsByRequest(startPolling);
-  }
-  function loadHosts(isRetry: boolean) {
-    const registeredHosts = filter(getStepData("HOST_STATUS", "hosts"), [
-      "bootStatus",
-      "REGISTERED",
-    ]);
-    const hostsWithInfo = [];
-    for (let host of registeredHosts) {
-      const hostInfo = {
-        name: host.name,
-        status: "pending",
-        logTasks: [],
-        message: "Waiting",
-        progress: 0,
-        isNoTasksForInstall: false,
-      };
-      hostsWithInfo.push(hostInfo);
-    }
-    hostsRef.current = hostsWithInfo;
-    setHosts(hostsWithInfo as any);
-    const clusterStatus = getClusterStatus();
-    if (
-      clusterStatus?.status !== "INSTALL FAILED" &&
-      clusterStatus !== "START FAILED" &&
-      !isRetry
-    ) {
-      isPolling.current = true;
-    }
-    loadLogData(isPolling.current);
-  }
-  let loadStep = (isRetry = false) => {
-    loadHosts(isRetry);
   };
-  useEffect(() => {
-    setHosts(hostsRef.current);
-  }, [hostsRef.current]);
 
-  useEffect(() => {
-    loadStep();
-  }, []);
-  const columns = [
-    {
-      header: "Host",
-      accessorKey: "name",
-    },
-    {
-      header: "Status",
-      id: "status",
-      cell: (info: any) => {
-        return (
-          <Stack direction="horizontal">
-            <ProgressBar
-              className="w-100"
-              striped
-              now={info.row.original.progress}
-              variant={getProgressBarColor(info.row.original.status)}
-            />
-            <div className="ms-2 text-nowrap">
-              {info.row.original.progress}%
-            </div>
-          </Stack>
-        );
-      },
-    },
-    {
-      header: "Message",
-      id: "message",
-      cell: ({ row: { original: data } }: any) => {
-        return (
-          <div
-            className={data.progress == 100 ? "" : "custom-link"}
-            onClick={() => {
-              if (data.progress != 100) {
-                setIsBackgroundOperationsModalOpen(true);
-                setSelectedHost(data.name);
-              }
-            }}
-          >
-            {data.message}
-          </div>
-        );
-      },
-    },
-  ];
-
-  function getClusterBarColor() {
-    if (some(hosts, ["status", "pending"])) {
-      return "info";
-    } else if (some(hosts, ["status", "warning"])) {
-      return "warning";
-    } else if (some(hosts, ["status", "failed"])) {
-      return "danger";
-    } else if (
-      every(hosts, ["status", "success"]) &&
-      getClusterStatus().status === "STARTED"
-    ) {
-      return "success";
+  const advanceAfterSuccess = async (completedPhase: InstallationPhase) => {
+    if (completedPhase === "INSTALL") {
+      if (isKerberosEnabled) {
+        await launchKeytabRegeneration();
+      } else {
+        await launchStart();
+      }
+    } else if (completedPhase === "KEYTABS") {
+      await launchStart();
+    } else if (completedPhase === "START") {
+      await completeSuccess();
     }
-    return "info";
+  };
+
+  const updateHostsFromTasks = (
+    tasks: any[],
+    currentPhase: InstallationPhase,
+    currentRequestId: string | number,
+  ) => {
+    const installOnly = supports.skipComponentStartAfterInstall;
+    const baseProgress = currentPhase === "INSTALL" ? 0 : 33;
+    const phaseWeight = currentPhase === "INSTALL"
+      ? installOnly ? 100 : 33
+      : currentPhase === "START" ? 67 : 0;
+    const nextHosts = hostsRef.current.map((host) => {
+      const hostTasks = tasks.filter((task) => task.Tasks?.host_name === host.name);
+      const mergedTasks = mergeInstallTasks(host.logTasks || [], hostTasks);
+      if (!hostTasks.length) {
+        return {
+          ...host,
+          progress: currentPhase === "KEYTABS" ? 33 : host.progress,
+          message: currentPhase === "KEYTABS" ? phaseLabel(currentPhase) : host.message,
+          logTasks: mergedTasks,
+        };
+      }
+      const completed = hostTasks.filter((task) =>
+        terminalTaskStatuses.has(task.Tasks?.status),
+      ).length;
+      const failed = hostTasks.some((task) =>
+        failedTaskStatuses.has(task.Tasks?.status),
+      );
+      const requestComplete = completed === hostTasks.length;
+      return {
+        ...host,
+        lastRequestId: currentRequestId,
+        logTasks: mergedTasks,
+        progress: Math.round(baseProgress + phaseWeight * (completed / hostTasks.length)),
+        status: failed
+          ? currentPhase === "INSTALL" ? "failed" : "warning"
+          : requestComplete ? "success" : "in_progress",
+        message: failed
+          ? `${phaseLabel(currentPhase)} failed`
+          : requestComplete
+            ? `${phaseLabel(currentPhase)} completed`
+            : phaseLabel(currentPhase),
+      };
+    });
+    hostsRef.current = nextHosts;
+    setHosts(nextHosts);
+    persist(nextHosts, clusterStatusRef.current, currentPhase);
+  };
+
+  async function pollCurrentRequest() {
+    const currentRequestId = requestIdRef.current;
+    if (!active.current || requestInFlight.current || currentRequestId == null) return;
+    requestInFlight.current = true;
+    setWorking(true);
+    setPollError("");
+    try {
+      const response = await RequestApi.getRequestStatus(
+        clusterName,
+        String(currentRequestId),
+      );
+      if (!active.current || requestIdRef.current !== currentRequestId) return;
+      const currentPhase = phaseRef.current;
+      const tasks = (response.tasks || []).map((task: any) => ({
+        ...task,
+        Tasks: { ...task.Tasks, request_id: currentRequestId },
+      }));
+      updateHostsFromTasks(tasks, currentPhase, currentRequestId);
+      if (!requestFinished(response)) {
+        schedulePoll(3000);
+        return;
+      }
+      if (requestFailed(response)) {
+        await completeFailure(currentPhase);
+      } else {
+        await advanceAfterSuccess(currentPhase);
+      }
+    } catch (error: any) {
+      if (active.current) {
+        setPollError(errorMessage(error));
+        setWorking(false);
+      }
+    } finally {
+      requestInFlight.current = false;
+    }
   }
+
+  const retryInstall = async () => {
+    if (!canRetryInstallation(clusterStatusRef.current.status)) return;
+    setTerminal(false);
+    setWorking(true);
+    setOperationError("");
+    try {
+      const response = await HostsApi.updateHostComponents(
+        clusterName,
+        "HostRoles/desired_state=INSTALLED&HostRoles/state!=INSTALLED",
+        {
+          context: "Retry Install Components",
+          HostRoles: { state: "INSTALLED" },
+          level: "HOST_COMPONENT",
+          query: "HostRoles/desired_state=INSTALLED&HostRoles/state!=INSTALLED",
+        },
+      );
+      const requestId = requestIdFrom(response);
+      if (requestId == null) {
+        throw new Error("Ambari did not return a retry request ID.");
+      }
+      await setRequest(requestId, "INSTALL", "PENDING");
+    } catch (error: any) {
+      await completeFailure("INSTALL", errorMessage(error));
+    }
+  };
+
+  useEffect(() => {
+    active.current = true;
+    if (!initialTerminal && requestIdRef.current != null) {
+      schedulePoll();
+    } else if (!initialTerminal) {
+      setPollError(
+        "The installation request ID is missing. Return to Review and deploy again.",
+      );
+      setWorking(false);
+    }
+    return () => {
+      active.current = false;
+      if (timer.current) clearTimeout(timer.current);
+    };
+  }, []);
+
+  useEffect(() => {
+    const warnBeforeUnload = (event: BeforeUnloadEvent) => {
+      if (!working) return;
+      event.preventDefault();
+    };
+    window.addEventListener("beforeunload", warnBeforeUnload);
+    return () => window.removeEventListener("beforeunload", warnBeforeUnload);
+  }, [working]);
+
+  const overallProgress = hosts.length
+    ? Math.round(hosts.reduce(
+      (sum, host) => sum + Number(host.progress || 0),
+      0,
+    ) / hosts.length)
+    : terminal ? 100 : 0;
+  const canContinue = canEnterSummary(wizardName, clusterStatus.status || "");
 
   return (
     <>
-      {isBackgroundOperationsModalOpen ? (
+      {selectedRequestId != null ? (
         <BackgroundOperations
           isExplicitClick
           rootLevel={ViewLevel.TASKS_LIST}
-          clusterName={getStepData("NAME", "clusterName")}
-          requestId={getClusterStatus().requestId}
+          clusterName={clusterName}
+          requestId={selectedRequestId}
           host={selectedHost}
-          isOpen={isBackgroundOperationsModalOpen}
-          onClose={() => {
-            setIsBackgroundOperationsModalOpen(false);
-          }}
+          isOpen
+          onClose={() => setSelectedRequestId(null)}
         />
       ) : null}
-      <div>
-        <div className="step-title">Install, Start and Test</div>
-        <div className="d-flex flex-column">
-          <small className="light-text">
-            Please wait while the selected services are installed and started.
-          </small>
-        </div>
-        <Card className="mt-4 p-2">
-          <Stack direction="horizontal">
-            <ProgressBar
-              className="w-100"
-              now={progress as any}
-              variant={getClusterBarColor()}
-            />
-            <div className="text-nowrap ms-3">{progress}% overall</div>
-          </Stack>
-          <div className="d-flex justify-content-between mt-2">
-            <div></div>
-            <div
-              style={{ fontSize: 12 }}
-              className="my-2 align-items-center d-flex justify-content-center"
-            >
-              Show :
-              {filters.map((hostFilter: any) => {
-                return (
-                  <Stack direction="horizontal">
-                    <div
-                      key={hostFilter.label}
-                      onClick={() => {
-                        setSelectedFilter(hostFilter);
-                      }}
-                      className={classNames("ms-1 p-1", {
-                        "bg-disabled":
-                          selectedFilter.label === hostFilter.label,
-                        rounded: selectedFilter.label === hostFilter.label,
-                        "text-white": selectedFilter.label === hostFilter.label,
-                        "custom-link":
-                          selectedFilter.label !== hostFilter.label,
-                      })}
-                    >
-                      {hostFilter.label}(
-                      {
-                        hosts.filter((host: any) => {
-                          return hostFilter.statusKey.includes(host.status);
-                        }).length
-                      }
-                      )
-                    </div>
-                    <div className="text-muted mx-2">|</div>
-                  </Stack>
-                );
-              })}
-            </div>
-            <div className="d-flex gap-2 flex-wrap">
-              {showRetry ? (
-                <DefaultButton
-                  onClick={() => {
-                    retry();
-                  }}
-                >
-                  <FontAwesomeIcon icon={faUndo} className="me-2" />
-                  RETRY
-                </DefaultButton>
-              ) : null}
-            </div>
-          </div>
-          <Table
-            columns={columns}
-            data={currentItems.filter((host: any) => {
-              return selectedFilter?.statusKey?.includes(host.status);
-            })}
-          />
-          <Paginator
-            currentPage={currentPage}
-            maxPage={maxPage}
-            changePage={changePage}
-            itemsPerPage={itemsPerPage}
-            setItemsPerPage={setItemsPerPage}
-            totalItems={hosts.length}
-          />
-        </Card>
-        <WizardFooter
-          isNextEnabled={true}
-          step={currentStep}
-          onNext={() => {
-            dispatch({
-              type: ActionTypes.STORE_INFORMATION,
-              payload: {
-                step: currentStep.name || "INSTALL_TEST__START",
-                data: {
-                  hostInfo: hosts,
-                  clusterStatus: getClusterStatus(),
-                },
-              },
-            });
-            flushStateToDb("next");
-            handleNextImperitive();
-          }}
-          onBack={() => {}}
+
+      {blocker.state === "blocked" ? (
+        <Alert variant="warning" className="d-flex justify-content-between">
+          <span>Installation is still running.</span>
+          <span>
+            <Button size="sm" variant="outline-secondary" onClick={() => blocker.reset()}>
+              Stay
+            </Button>{" "}
+            <Button size="sm" variant="danger" onClick={() => blocker.proceed()}>
+              Leave
+            </Button>
+          </span>
+        </Alert>
+      ) : null}
+
+      <div className="step-title">Install, Start and Test</div>
+      <p className="step-description mt-2">
+        Ambari is installing, starting, and validating the selected services.
+      </p>
+
+      {pollError ? (
+        <Alert variant="danger">
+          {pollError}{" "}
+          {requestIdRef.current != null ? (
+            <Button size="sm" variant="outline-danger" onClick={() => schedulePoll()}>
+              Retry Poll
+            </Button>
+          ) : null}
+        </Alert>
+      ) : null}
+      {operationError ? <Alert variant="danger">{operationError}</Alert> : null}
+
+      <div className="d-flex align-items-center gap-3 mt-3">
+        <ProgressBar
+          className="flex-grow-1"
+          now={overallProgress}
+          variant={clusterStatus.status?.includes("FAILED")
+            ? "danger"
+            : canContinue ? "success" : "info"}
         />
+        <span>{overallProgress}% overall</span>
       </div>
+      <div className="mt-2 text-muted d-flex align-items-center gap-2">
+        {working ? <Spinner animation="border" size="sm" /> : null}
+        {phaseLabel(phase)}
+      </div>
+
+      <Table responsive hover className="mt-3 mb-5">
+        <thead>
+          <tr>
+            <th>Host</th>
+            <th>Status</th>
+            <th>Progress</th>
+            <th>Tasks</th>
+          </tr>
+        </thead>
+        <tbody>
+          {hosts.map((host) => (
+            <tr key={host.name}>
+              <td>{host.name}</td>
+              <td>{host.message}</td>
+              <td>{host.progress}%</td>
+              <td>
+                <div>{(host.logTasks || []).length} task(s)</div>
+                {host.lastRequestId != null ? (
+                  <Button
+                    size="sm"
+                    variant="link"
+                    className="p-0"
+                    onClick={() => {
+                      setSelectedHost(host.name);
+                      setSelectedRequestId(host.lastRequestId);
+                    }}
+                  >
+                    View task logs
+                  </Button>
+                ) : null}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </Table>
+
+      <WizardFooter
+        isNextEnabled={canContinue}
+        isBackEnabled={false}
+        isCancelEnabled={!working}
+        lifted
+        step={currentStep}
+        sideItems={canRetryInstallation(clusterStatus.status) ? (
+          <Button
+            variant="outline-primary"
+            className="me-3"
+            disabled={working}
+            onClick={() => void retryInstall()}
+          >
+            RETRY
+          </Button>
+        ) : null}
+        onNext={async () => {
+          persist(hostsRef.current, clusterStatusRef.current, phaseRef.current);
+          await Promise.resolve(flushStateToDb(
+            "next",
+            -1,
+            wizardCheckpoint(wizardName, "INSTALLED"),
+          ));
+          handleNextImperitive();
+        }}
+        onCancel={() => {
+          if (!working) void flushStateToDb("cancel");
+        }}
+        onBack={() => {}}
+      />
     </>
   );
 }
+
 export default Step9;

--- a/ambari-web/latest/src/screens/ClusterWizard/blueprintExport.test.ts
+++ b/ambari-web/latest/src/screens/ClusterWizard/blueprintExport.test.ts
@@ -1,0 +1,91 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from "vitest";
+import { buildBlueprintExport } from "./blueprintExport";
+
+describe("cluster Blueprint export", () => {
+  it("groups equal host topologies and retains configs, clients, and ALL components", () => {
+    const result = buildBlueprintExport({
+      clusterName: "cluster1",
+      stackName: "HDP",
+      stackVersion: "3.0",
+      hosts: ["host1", { name: "host2" }],
+      selectedServiceNames: ["HDFS"],
+      masterAssignments: [{
+        host_name: "host1",
+        masterServices: [{ component: "NAMENODE", hostName: "host1" }],
+      }],
+      slaveAssignments: [
+        { hostname: "host1", checkboxes: [{ checked: true, label: "DATANODE" }] },
+        { hostname: "host2", checkboxes: [{ checked: true, label: "CLIENT" }] },
+      ],
+      serviceComponents: [{ components: [
+        { StackServiceComponents: { cardinality: "1", component_name: "NAMENODE", service_name: "HDFS" } },
+        { StackServiceComponents: { cardinality: "1+", component_name: "DATANODE", service_name: "HDFS" } },
+        { StackServiceComponents: { cardinality: "0+", component_name: "HDFS_CLIENT", is_client: true, service_name: "HDFS" } },
+        { StackServiceComponents: { cardinality: "ALL", component_name: "REQUIRED", service_name: "HDFS" } },
+      ] }],
+      configProperties: {
+        HDFS: {
+          "core-site": {
+            properties: {
+              auth: {
+                final: "true",
+                propertyAttributes: { type: "string" },
+                propertyName: "hadoop.security.authentication",
+                type: "core-site",
+                value: "kerberos",
+              },
+            },
+          },
+        },
+      },
+    });
+
+    expect(result.blueprint.Blueprints).toEqual({
+      blueprint_name: "cluster1",
+      stack_name: "HDP",
+      stack_version: "3.0",
+    });
+    expect(result.blueprint.configurations).toEqual([{
+      "core-site": {
+        properties: { "hadoop.security.authentication": "kerberos" },
+        properties_attributes: {
+          isFinal: { "hadoop.security.authentication": "true" },
+        },
+      },
+    }]);
+    expect(result.blueprint.host_groups).toEqual([
+      {
+        cardinality: "1",
+        components: [{ name: "DATANODE" }, { name: "NAMENODE" }, { name: "REQUIRED" }],
+        name: "host_group_0",
+      },
+      {
+        cardinality: "1",
+        components: [{ name: "HDFS_CLIENT" }, { name: "REQUIRED" }],
+        name: "host_group_1",
+      },
+    ]);
+    expect(result.clusterTemplate.host_groups[1]).toEqual({
+      name: "host_group_1",
+      hosts: [{ fqdn: "host2" }],
+    });
+  });
+});

--- a/ambari-web/latest/src/screens/ClusterWizard/blueprintExport.ts
+++ b/ambari-web/latest/src/screens/ClusterWizard/blueprintExport.ts
@@ -1,0 +1,210 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { flatten } from "lodash";
+import { formatValuesBeforeSave, minToInstall } from "./utils";
+
+type BlueprintExportInput = {
+  clusterName: string;
+  configProperties: UnknownRecord;
+  hosts: unknown[];
+  masterAssignments: unknown[];
+  selectedServiceNames: string[];
+  serviceComponents: unknown[];
+  slaveAssignments: unknown[];
+  stackName: string;
+  stackVersion: string;
+};
+
+type UnknownRecord = Record<string, unknown>;
+
+function asRecord(value: unknown): UnknownRecord {
+  return value !== null && typeof value === "object"
+    ? value as UnknownRecord
+    : {};
+}
+
+function stringValue(value: unknown): string {
+  return typeof value === "string" ? value : "";
+}
+
+function hostName(host: unknown): string {
+  return typeof host === "string"
+    ? host
+    : stringValue(asRecord(host).name)
+      || stringValue(asRecord(host).hostName)
+      || stringValue(asRecord(host).host_name);
+}
+
+function configType(property: UnknownRecord, sectionName: string) {
+  const fileName = stringValue(property.type)
+    || stringValue(property.fileName)
+    || stringValue(property.filename)
+    || sectionName;
+  return fileName.endsWith(".xml") ? fileName.slice(0, -4) : fileName;
+}
+
+export function buildBlueprintConfigurations(configProperties: UnknownRecord) {
+  const configurations = new Map<string, {
+    properties: Record<string, unknown>;
+    properties_attributes?: { isFinal: Record<string, string> };
+  }>();
+
+  Object.values(configProperties || {}).forEach((service) => {
+    Object.entries(asRecord(service)).forEach(([sectionName, section]) => {
+      Object.values(asRecord(asRecord(section).properties)).forEach((propertyValue) => {
+        const property = asRecord(propertyValue);
+        const name = stringValue(property.propertyName) || stringValue(property.name);
+        const type = configType(property, sectionName);
+        if (!name || !type || type === "hosts" || property.value == null) return;
+        const current = configurations.get(type) || { properties: {} };
+        try {
+          current.properties[name] = formatValuesBeforeSave(property);
+        } catch {
+          current.properties[name] = property.value;
+        }
+        if (String(property.final) === "true") {
+          current.properties_attributes ||= { isFinal: {} };
+          current.properties_attributes.isFinal[name] = "true";
+        }
+        configurations.set(type, current);
+      });
+    });
+  });
+
+  return [...configurations].map(([type, details]) => ({ [type]: details }));
+}
+
+export function buildBlueprintExport({
+  clusterName,
+  configProperties,
+  hosts,
+  masterAssignments,
+  selectedServiceNames,
+  serviceComponents,
+  slaveAssignments,
+  stackName,
+  stackVersion,
+}: BlueprintExportInput) {
+  const hostNames = [...new Set(hosts.map(hostName).filter(Boolean))];
+  const componentsByHost = new Map(
+    hostNames.map((name) => [name, new Set<string>()]),
+  );
+  const componentMetadata = flatten(
+    serviceComponents.map((service) => {
+      const components = asRecord(service).components;
+      return Array.isArray(components) ? components : [];
+    }),
+  ).map((component) => {
+    const componentRecord = asRecord(component);
+    return asRecord(componentRecord.StackServiceComponents || componentRecord);
+  });
+  const selectedComponents = componentMetadata.filter((component) =>
+    selectedServiceNames.includes(stringValue(component.service_name)),
+  );
+  const clientComponents = selectedComponents
+    .filter((component) => component.is_client === true)
+    .map((component) => stringValue(component.component_name))
+    .filter(Boolean);
+
+  masterAssignments.forEach((hostAssignmentValue) => {
+    const hostAssignment = asRecord(hostAssignmentValue);
+    const fallbackHost = stringValue(hostAssignment.host_name)
+      || stringValue(hostAssignment.hostName);
+    const masterServices = Array.isArray(hostAssignment.masterServices)
+      ? hostAssignment.masterServices
+      : [];
+    masterServices.forEach((componentValue) => {
+      const component = asRecord(componentValue);
+      const name = stringValue(component.hostName)
+        || stringValue(component.host_name)
+        || fallbackHost;
+      const componentName = stringValue(component.component);
+      if (componentsByHost.has(name) && componentName) {
+        componentsByHost.get(name)?.add(componentName);
+      }
+    });
+  });
+
+  slaveAssignments.forEach((hostAssignmentValue) => {
+    const hostAssignment = asRecord(hostAssignmentValue);
+    const name = stringValue(hostAssignment.hostname)
+      || stringValue(hostAssignment.hostName);
+    if (!componentsByHost.has(name)) return;
+    const checkboxes = Array.isArray(hostAssignment.checkboxes)
+      ? hostAssignment.checkboxes
+      : [];
+    checkboxes
+      .map(asRecord)
+      .filter((component) => component.checked === true)
+      .forEach((component) => {
+        const label = stringValue(component.label);
+        if (label === "CLIENT") {
+          clientComponents.forEach((client) => componentsByHost.get(name)?.add(client));
+        } else if (label) {
+          componentsByHost.get(name)?.add(label);
+        }
+      });
+  });
+
+  selectedComponents
+    .filter((component) => minToInstall(stringValue(component.cardinality)) === Infinity)
+    .forEach((component) => {
+      const componentName = stringValue(component.component_name);
+      if (!componentName) return;
+      hostNames.forEach((name) => componentsByHost.get(name)?.add(componentName));
+    });
+
+  const groupedHosts = new Map<string, string[]>();
+  componentsByHost.forEach((components, name) => {
+    const key = [...components].sort().join("\u0000");
+    groupedHosts.set(key, [...(groupedHosts.get(key) || []), name]);
+  });
+
+  const hostGroups = [...groupedHosts].map(([componentKey, grouped], index) => ({
+    name: `host_group_${index}`,
+    cardinality: String(grouped.length),
+    components: componentKey
+      ? componentKey.split("\u0000").map((name) => ({ name }))
+      : [],
+  }));
+  const clusterTemplateHostGroups = [...groupedHosts].map(([, grouped], index) => ({
+    name: `host_group_${index}`,
+    hosts: grouped.map((fqdn) => ({ fqdn })),
+  }));
+
+  return {
+    blueprint: {
+      configurations: buildBlueprintConfigurations(configProperties),
+      host_groups: hostGroups,
+      Blueprints: {
+        blueprint_name: clusterName,
+        stack_name: stackName,
+        stack_version: stackVersion,
+      },
+    },
+    clusterTemplate: {
+      blueprint: clusterName,
+      config_recommendation_strategy: "NEVER_APPLY",
+      provision_action: "INSTALL_AND_START",
+      configurations: [],
+      host_groups: clusterTemplateHostGroups,
+      Clusters: { cluster_name: clusterName },
+    },
+  };
+}

--- a/ambari-web/latest/src/screens/ClusterWizard/clusterStore/context.tsx
+++ b/ambari-web/latest/src/screens/ClusterWizard/clusterStore/context.tsx
@@ -19,6 +19,7 @@
 import React, {
   createContext,
   Dispatch,
+  useCallback,
   useEffect,
   useReducer,
   useRef,
@@ -30,7 +31,10 @@ import ClusterApi from "../../../api/clusterApi";
 import { get, isEmpty } from "lodash";
 import { redirectToAdminView } from "../../../Utils/adminViewRedirect";
 import { ClusterProgressStatus } from "../../../constants";
-import { useDebounce } from "../../../hooks/useDebounce";
+import { Alert, Button } from "react-bootstrap";
+import { claimWizard, releaseWizard } from "../../../Utils/wizardOwnership";
+import { resolveRecoveryStep } from "../wizardRecovery";
+import { AppContext } from "../../../store/context";
 
 interface ClusterCreationContextProps {
   state: State;
@@ -50,23 +54,44 @@ export const ClusterCreationProvider: React.FC<{
   stepWizardUtilities: any;
   children: React.ReactNode;
 }> = ({ stepWizardUtilities, children }) => {
-  const [state, dispatch] = useReducer(reducer, initialState);
+  const [state, reducerDispatch] = useReducer(reducer, initialState);
   const [currStepData, setCurrStepData] = useState({});
-  const debouncedPersist=useDebounce(flushCurrentData,500);
+  const [initializationError, setInitializationError] = useState<string | null>(null);
+  const [retryCount, setRetryCount] = useState(0);
+  const { loginName } = React.useContext(AppContext);
 
   const isDataPersisted = useRef(false);
+  const persistenceQueue = useRef<Promise<void>>(Promise.resolve());
+  const stateRef = useRef<State>(initialState);
+  const currStepDataRef = useRef<Record<string, any>>({});
 
-  useEffect(() => {
-    syncUserPersistedData();
+  const dispatch: Dispatch<Action> = (action) => {
+    stateRef.current = reducer(stateRef.current, action);
+    reducerDispatch(action);
+  };
+
+  const queuePersistence = useCallback((operation: () => Promise<any>) => {
+    const nextOperation = persistenceQueue.current
+      .catch(() => undefined)
+      .then(operation)
+      .then(() => undefined);
+    persistenceQueue.current = nextOperation.catch(() => undefined);
+    return nextOperation;
   }, []);
 
   useEffect(() => {
+    void syncUserPersistedData();
+  }, [retryCount]);
+
+  useEffect(() => {
     if (isDataPersisted.current) {
-      debouncedPersist();
+      void queuePersistence(() => flushCurrentData(state, currStepData));
     }
   }, [state.clusterCreationSteps, currStepData]);
 
   async function syncUserPersistedData() {
+    setInitializationError(null);
+    isDataPersisted.current = false;
     try {
       const persistedData = await ClusterApi.getPersistData("CLUSTER_CURRENT");
       if (!isEmpty(get(persistedData, "clusterCreationSteps", {}))) {
@@ -76,76 +101,93 @@ export const ClusterCreationProvider: React.FC<{
         });
       }
       const clusterState = await ClusterApi.getPersistData("CLUSTER_STATE");
-      if (
-        clusterState &&
-        get(clusterState, "progressStatus") === ClusterProgressStatus.PROVISIONING &&
-        get(clusterState, "stepName", "") !== ""
-      ) {
+      const classicStep = resolveRecoveryStep(
+        "clusterCreation",
+        get(clusterState, "clusterState"),
+      );
+      const activeStepName = get(clusterState, "stepName", "");
+      const storedStep = Object.keys(stepWizardUtilities.wizardSteps).find(
+        (stepNumber) =>
+          stepWizardUtilities.wizardSteps?.[stepNumber]?.name === activeStepName,
+      );
+      const activeStep = classicStep ?? (storedStep === undefined ? 0 : Number(storedStep));
+      if (clusterState && (classicStep !== undefined || activeStepName)) {
+        currStepDataRef.current = clusterState;
         setCurrStepData(clusterState);
-        try {
-          const activeStepName = clusterState.stepName;
-          let activeStepNumber = Object.keys(
-            stepWizardUtilities.wizardSteps
-          ).find((stepName) => {
-            return (
-              stepWizardUtilities.wizardSteps?.[stepName]?.name ===
-              activeStepName
-            );
-          });
-          stepWizardUtilities.jumpToStep(Number(activeStepNumber), true);
-        } catch (err) {
-          console.error("Error while jumping to step", err);
-        }
-      } else {
-        stepWizardUtilities.jumpToStep(0, true);
       }
-    } finally {
+      stepWizardUtilities.jumpToStep(activeStep, true);
+      if (loginName) {
+        await claimWizard(loginName, "clusterCreation");
+      }
       isDataPersisted.current = true;
+    } catch (error: any) {
+      setInitializationError(
+        error?.response?.data?.message
+          || error?.message
+          || "Ambari could not restore the cluster installation wizard.",
+      );
     }
   }
 
-  async function flushCurrentData() {
+  async function flushCurrentData(
+    stateSnapshot: State = stateRef.current,
+    stepSnapshot: Record<string, any> = currStepDataRef.current,
+  ) {
     await ClusterApi.postPersistData(
       JSON.stringify({
-        CLUSTER_CURRENT: JSON.stringify(state),
-        CLUSTER_STATE: JSON.stringify(currStepData),
+        CLUSTER_CURRENT: JSON.stringify(stateSnapshot),
+        CLUSTER_STATE: JSON.stringify(stepSnapshot),
       })
     );
   }
 
-  function flushOnCancel() {
-    ClusterApi.postPersistData(
+  async function flushOnCancel() {
+    await queuePersistence(() => flushCurrentData());
+    await releaseWizard();
+    redirectToAdminView();
+  }
+
+  async function flushOnComplete() {
+    await queuePersistence(() => ClusterApi.postPersistData(
       JSON.stringify({
         CLUSTER_CURRENT: JSON.stringify(initialState),
         CLUSTER_STATE: JSON.stringify({}),
       })
-    );
-    redirectToAdminView();
+    ));
+    await releaseWizard();
   }
 
-  async function flushOnStepChange(nextStep: number) {
+  async function flushOnStepChange(nextStep: number, clusterState?: string) {
     if (nextStep >= 0) {
-      let nextStepDetails = stepWizardUtilities.wizardSteps?.[nextStep];
+      const nextStepDetails = stepWizardUtilities.wizardSteps?.[nextStep];
+      const nextClusterCreationSteps = {
+        ...stateRef.current.clusterCreationSteps,
+      };
       if (nextStepDetails?.keysToRemove) {
         nextStepDetails.keysToRemove.forEach((key: string) => {
-          if (state?.clusterCreationSteps?.[key]) {
-            dispatch({
-              type: ActionTypes.REMOVE_KEY,
-              payload: { key },
-            });
-          }
+          delete nextClusterCreationSteps[key];
         });
       }
-      setCurrStepData({
+      const nextState = {
+        ...stateRef.current,
+        clusterCreationSteps: nextClusterCreationSteps,
+      };
+      dispatch({ type: ActionTypes.SYNC_STATE, payload: nextState });
+      const nextStepData = {
         progressStatus: ClusterProgressStatus.PROVISIONING,
         stepName: stepWizardUtilities?.wizardSteps?.[nextStep]?.name,
-      });
+        ...(clusterState ? { clusterState } : {}),
+      };
+      currStepDataRef.current = nextStepData;
+      setCurrStepData(nextStepData);
+      await queuePersistence(() => flushCurrentData(nextState, nextStepData));
     }
   }
 
-  function flushStateToDb(
+  async function flushStateToDb(
     operation: string = "default",
-    jumpStep: number = -1
+    jumpStep: number = -1,
+    clusterState?: string,
   ) {
     let activeStep = Object.keys(stepWizardUtilities.wizardSteps).find(
       (stepName) => {
@@ -157,19 +199,34 @@ export const ClusterCreationProvider: React.FC<{
     );
     switch (operation) {
       case "cancel":
-        flushOnCancel();
+        await flushOnCancel();
+        break;
+      case "complete":
+        await flushOnComplete();
         break;
       case "back":
-        flushOnStepChange(Number(activeStep) - 1);
+        await flushOnStepChange(Number(activeStep) - 1, clusterState);
         break;
       case "next":
-        flushOnStepChange(Number(activeStep) + 1);
+        await flushOnStepChange(Number(activeStep) + 1, clusterState);
         break;
       case "jump":
-        flushOnStepChange(jumpStep);
+        await flushOnStepChange(jumpStep, clusterState);
         break;
+      case "checkpoint": {
+        const nextStepData = {
+          ...currStepDataRef.current,
+          progressStatus: ClusterProgressStatus.PROVISIONING,
+          stepName: stepWizardUtilities.currentStep.name,
+          clusterState,
+        };
+        currStepDataRef.current = nextStepData;
+        setCurrStepData(nextStepData);
+        await queuePersistence(() => flushCurrentData(stateRef.current, nextStepData));
+        break;
+      }
       default:
-        flushCurrentData();
+        await queuePersistence(() => flushCurrentData());
     }
   }
 
@@ -182,7 +239,18 @@ export const ClusterCreationProvider: React.FC<{
         flushStateToDb,
       }}
     >
-      {children}
+      {initializationError ? (
+        <Alert variant="danger" className="m-4">
+          {initializationError}{" "}
+          <Button
+            size="sm"
+            variant="outline-danger"
+            onClick={() => setRetryCount((value) => value + 1)}
+          >
+            Retry
+          </Button>
+        </Alert>
+      ) : children}
     </ClusterCreationContext.Provider>
   );
 };

--- a/ambari-web/latest/src/screens/ClusterWizard/deploymentQueue.test.ts
+++ b/ambari-web/latest/src/screens/ClusterWizard/deploymentQueue.test.ts
@@ -1,0 +1,85 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it, vi } from "vitest";
+import { runDeploymentPlan } from "./deploymentQueue";
+
+describe("runDeploymentPlan", () => {
+  it("runs dependent stages in order and parallelizes only within a stage", async () => {
+    const events: string[] = [];
+    let releaseFirstBatch!: () => void;
+    const firstBatch = new Promise<void>((resolve) => {
+      releaseFirstBatch = resolve;
+    });
+    const run = (name: string, wait?: Promise<void>) => async () => {
+      events.push(`${name}:start`);
+      await wait;
+      events.push(`${name}:end`);
+    };
+    const plan = runDeploymentPlan([
+      {
+        parallel: true,
+        operations: [
+          { id: "delete-a", label: "delete a", run: run("a", firstBatch) },
+          { id: "delete-b", label: "delete b", run: run("b", firstBatch) },
+        ],
+      },
+      {
+        operations: [{ id: "create", label: "create", run: run("create") }],
+      },
+    ]);
+
+    await Promise.resolve();
+    expect(events).toEqual(["a:start", "b:start"]);
+    releaseFirstBatch();
+    await plan;
+    expect(events.slice(-2)).toEqual(["create:start", "create:end"]);
+  });
+
+  it("aborts later stages after the first failed prerequisite", async () => {
+    const later = vi.fn();
+    await expect(runDeploymentPlan([
+      {
+        operations: [{
+          id: "failed",
+          label: "failed",
+          run: async () => {
+            throw new Error("failed prerequisite");
+          },
+        }],
+      },
+      { operations: [{ id: "later", label: "later", run: later }] },
+    ])).rejects.toThrow("failed prerequisite");
+    expect(later).not.toHaveBeenCalled();
+  });
+
+  it("skips operations already persisted as complete", async () => {
+    const skipped = vi.fn();
+    const pending = vi.fn().mockResolvedValue(undefined);
+    const completed = await runDeploymentPlan([{
+      operations: [
+        { id: "skipped", label: "skipped", run: skipped },
+        { id: "pending", label: "pending", run: pending },
+      ],
+    }], new Set(["skipped"]));
+
+    expect(skipped).not.toHaveBeenCalled();
+    expect(pending).toHaveBeenCalledOnce();
+    expect([...completed]).toEqual(["skipped", "pending"]);
+  });
+});

--- a/ambari-web/latest/src/screens/ClusterWizard/deploymentQueue.ts
+++ b/ambari-web/latest/src/screens/ClusterWizard/deploymentQueue.ts
@@ -1,0 +1,67 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export type DeploymentOperation = {
+  id: string;
+  label: string;
+  run: () => Promise<unknown>;
+};
+
+export type DeploymentStage = {
+  operations: DeploymentOperation[];
+  parallel?: boolean;
+};
+
+type DeploymentProgress = {
+  completed: number;
+  operation: DeploymentOperation;
+  total: number;
+};
+
+export async function runDeploymentPlan(
+  stages: DeploymentStage[],
+  completedOperationIds: Set<string> = new Set(),
+  onProgress: (progress: DeploymentProgress) => void | Promise<void> = () => undefined,
+): Promise<Set<string>> {
+  const operations = stages.flatMap((stage) => stage.operations);
+  let completed = operations.filter((operation) =>
+    completedOperationIds.has(operation.id),
+  ).length;
+
+  const runOperation = async (operation: DeploymentOperation) => {
+    if (completedOperationIds.has(operation.id)) {
+      return;
+    }
+    await operation.run();
+    completedOperationIds.add(operation.id);
+    completed += 1;
+    await onProgress({ completed, operation, total: operations.length });
+  };
+
+  for (const stage of stages) {
+    if (stage.parallel) {
+      await Promise.all(stage.operations.map(runOperation));
+    } else {
+      for (const operation of stage.operations) {
+        await runOperation(operation);
+      }
+    }
+  }
+
+  return completedOperationIds;
+}

--- a/ambari-web/latest/src/screens/ClusterWizard/installationProgress.test.ts
+++ b/ambari-web/latest/src/screens/ClusterWizard/installationProgress.test.ts
@@ -1,0 +1,69 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  canEnterSummary,
+  canRetryInstallation,
+  mergeInstallTasks,
+  requestFailed,
+  requestFinished,
+  requestIdFrom,
+  wizardCheckpoint,
+} from "./installationProgress";
+
+describe("installation progress", () => {
+  it("extracts request IDs from supported Ambari response shapes", () => {
+    expect(requestIdFrom({ Requests: { id: 1 } })).toBe(1);
+    expect(requestIdFrom({ data: { Requests: { id: 2 } } })).toBe(2);
+    expect(requestIdFrom({ id: "3" })).toBe("3");
+  });
+
+  it("recognizes terminal and failed request or task states", () => {
+    expect(requestFinished({ Requests: { request_status: "COMPLETED" } })).toBe(true);
+    expect(requestFinished({ tasks: [{ Tasks: { status: "TIMEDOUT" } }] })).toBe(true);
+    expect(requestFailed({ tasks: [{ Tasks: { status: "FAILED" } }] })).toBe(true);
+    expect(requestFinished({ tasks: [{ Tasks: { status: "IN_PROGRESS" } }] })).toBe(false);
+  });
+
+  it("keeps logs from prior requests while replacing matching task snapshots", () => {
+    const merged = mergeInstallTasks(
+      [{ Tasks: { request_id: 1, id: 1, status: "IN_PROGRESS" } }],
+      [
+        { Tasks: { request_id: 1, id: 1, status: "COMPLETED" } },
+        { Tasks: { request_id: 2, id: 1, status: "PENDING" } },
+      ],
+    );
+    expect(merged.map((task) => task.Tasks?.status)).toEqual(["COMPLETED", "PENDING"]);
+  });
+
+  it("matches the Classic retry and Summary gates", () => {
+    expect(canRetryInstallation("INSTALL FAILED")).toBe(true);
+    expect(canRetryInstallation("START FAILED")).toBe(false);
+    expect(canEnterSummary("clusterCreation", "INSTALL FAILED")).toBe(false);
+    expect(canEnterSummary("addService", "INSTALL FAILED")).toBe(true);
+    expect(canEnterSummary("clusterCreation", "START FAILED")).toBe(true);
+  });
+
+  it("builds recovery checkpoints for every wizard", () => {
+    expect(wizardCheckpoint("clusterCreation", "PREP")).toBe("CLUSTER_DEPLOY_PREP_2");
+    expect(wizardCheckpoint("addHost", "INSTALLING")).toBe("ADD_HOSTS_INSTALLING_3");
+    expect(wizardCheckpoint("addService", "INSTALLED")).toBe("ADD_SERVICES_INSTALLED_4");
+    expect(wizardCheckpoint("addService", "STARTING")).toBe("SERVICE_STARTING_3");
+  });
+});

--- a/ambari-web/latest/src/screens/ClusterWizard/installationProgress.ts
+++ b/ambari-web/latest/src/screens/ClusterWizard/installationProgress.ts
@@ -1,0 +1,117 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export type InstallWizardName = "clusterCreation" | "addHost" | "addService";
+export type InstallationPhase = "INSTALL" | "KEYTABS" | "START" | "COMPLETE";
+
+export const terminalRequestStatuses = new Set([
+  "ABORTED",
+  "COMPLETED",
+  "FAILED",
+  "TIMEDOUT",
+]);
+export const failedRequestStatuses = new Set(["ABORTED", "FAILED", "TIMEDOUT"]);
+export const terminalTaskStatuses = new Set([
+  "ABORTED",
+  "COMPLETED",
+  "FAILED",
+  "TIMEDOUT",
+]);
+export const failedTaskStatuses = new Set(["ABORTED", "FAILED", "TIMEDOUT"]);
+
+type RequestId = string | number;
+
+type AmbariTask = {
+  Tasks?: {
+    id?: RequestId;
+    request_id?: RequestId;
+    status?: string;
+  };
+  [key: string]: unknown;
+};
+
+type AmbariRequestResponse = {
+  Requests?: { id?: RequestId; request_status?: string };
+  data?: { Requests?: { id?: RequestId } };
+  id?: RequestId;
+  tasks?: AmbariTask[];
+};
+
+export function requestIdFrom(response: AmbariRequestResponse): RequestId | undefined {
+  return response?.Requests?.id ?? response?.data?.Requests?.id ?? response?.id;
+}
+
+export function mergeInstallTasks(
+  existing: AmbariTask[],
+  incoming: AmbariTask[],
+): AmbariTask[] {
+  const tasks = new Map(existing.map((task) => [
+    `${task.Tasks?.request_id || ""}:${task.Tasks?.id}`,
+    task,
+  ]));
+  incoming.forEach((task) => {
+    tasks.set(`${task.Tasks?.request_id || ""}:${task.Tasks?.id}`, task);
+  });
+  return [...tasks.values()];
+}
+
+export function requestFinished(response: AmbariRequestResponse): boolean {
+  const tasks = response?.tasks || [];
+  return terminalRequestStatuses.has(response?.Requests?.request_status || "")
+    || (tasks.length > 0 && tasks.every((task) =>
+      terminalTaskStatuses.has(task.Tasks?.status || ""),
+    ));
+}
+
+export function requestFailed(response: AmbariRequestResponse): boolean {
+  return failedRequestStatuses.has(response?.Requests?.request_status || "")
+    || (response?.tasks || []).some((task) =>
+      failedTaskStatuses.has(task.Tasks?.status || ""),
+    );
+}
+
+export function canRetryInstallation(status: string): boolean {
+  return status === "INSTALL FAILED";
+}
+
+export function canEnterSummary(wizard: InstallWizardName, status: string): boolean {
+  if (["STARTED", "START FAILED", "START_SKIPPED"].includes(status)) {
+    return true;
+  }
+  return wizard !== "clusterCreation" && status === "INSTALL FAILED";
+}
+
+export function wizardCheckpoint(
+  wizard: InstallWizardName,
+  stage: "PREP" | "INSTALLING" | "INSTALLED" | "STARTING",
+): string {
+  if (stage === "STARTING") {
+    return "SERVICE_STARTING_3";
+  }
+  const prefix = wizard === "clusterCreation"
+    ? "CLUSTER"
+    : wizard === "addHost"
+      ? "ADD_HOSTS"
+      : "ADD_SERVICES";
+  const suffix = stage === "PREP"
+    ? "DEPLOY_PREP_2"
+    : stage === "INSTALLING"
+      ? "INSTALLING_3"
+      : "INSTALLED_4";
+  return `${prefix}_${suffix}`;
+}

--- a/ambari-web/latest/src/screens/ClusterWizard/masterValidation.test.ts
+++ b/ambari-web/latest/src/screens/ClusterWizard/masterValidation.test.ts
@@ -1,0 +1,100 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  getMasterValidationMessages,
+  masterValidationKey,
+} from "./masterValidation";
+import { Masters } from "./types/AssignMastersTypes";
+
+const masters: Masters[] = [
+  {
+    component: "NAMENODE",
+    display_name: "NameNode",
+    hostName: "host1.example.com",
+    host_id: 1,
+    serviceId: "HDFS",
+  },
+  {
+    component: "ZOOKEEPER_SERVER",
+    display_name: "ZooKeeper Server",
+    hostName: "host2.example.com",
+    host_id: 2,
+    serviceId: "ZOOKEEPER",
+    isInstalled: true,
+  },
+];
+
+describe("master validation issue mapping", () => {
+  it("keeps only ERROR and WARN issues matching non-installed assignments", () => {
+    const response = {
+      resources: [
+        {
+          items: [
+            {
+              type: "host-component",
+              level: "ERROR",
+              host: "host1.example.com",
+              "component-name": "NAMENODE",
+              message: "Move NameNode",
+            },
+            {
+              type: "host-component",
+              level: "WARN",
+              host: "host1.example.com",
+              "component-name": "NAMENODE",
+              message: "Review NameNode placement",
+            },
+            {
+              type: "host-component",
+              level: "ERROR",
+              host: "host2.example.com",
+              "component-name": "ZOOKEEPER_SERVER",
+              message: "Already installed",
+            },
+            {
+              type: "service",
+              level: "ERROR",
+              message: "General issue",
+            },
+            {
+              type: "host-component",
+              level: "WARN",
+              host: "host3.example.com",
+              "component-name": "JOURNALNODE",
+              message: "Unmatched issue",
+            },
+          ],
+        },
+      ],
+    };
+
+    expect(getMasterValidationMessages(response, masters)).toEqual({
+      [masterValidationKey("host1.example.com", "NAMENODE")]: {
+        errorMessage: "Move NameNode",
+        warnMessage: "Review NameNode placement",
+      },
+    });
+  });
+
+  it("returns no issues for an incomplete validation response", () => {
+    expect(getMasterValidationMessages({}, masters)).toEqual({});
+  });
+});
+

--- a/ambari-web/latest/src/screens/ClusterWizard/masterValidation.ts
+++ b/ambari-web/latest/src/screens/ClusterWizard/masterValidation.ts
@@ -1,0 +1,84 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Masters } from "./types/AssignMastersTypes";
+
+export type MasterValidationMessage = {
+  errorMessage?: string;
+  warnMessage?: string;
+};
+
+export type MasterValidationMessages = Record<string, MasterValidationMessage>;
+
+type MasterValidationItem = {
+  type?: string;
+  level?: string;
+  host?: string;
+  "component-name"?: string;
+  message?: string;
+};
+
+type MasterValidationResponse = {
+  resources?: Array<{
+    items?: MasterValidationItem[];
+  }>;
+};
+
+export const masterValidationKey = (hostName: string, component: string) =>
+  `${hostName}\u0000${component}`;
+
+export function getMasterValidationMessages(
+  response: MasterValidationResponse,
+  masters: Masters[],
+): MasterValidationMessages {
+  const messages: MasterValidationMessages = {};
+  const items = response?.resources?.[0]?.items;
+
+  if (!Array.isArray(items)) {
+    return messages;
+  }
+
+  items
+    .filter(
+      (item) =>
+        item.type === "host-component" &&
+        (item.level === "ERROR" || item.level === "WARN"),
+    )
+    .forEach((item) => {
+      const master = masters.find(
+        (candidate) =>
+          !candidate.isInstalled &&
+          candidate.component === item["component-name"] &&
+          candidate.hostName === item.host,
+      );
+
+      if (!master) {
+        return;
+      }
+
+      const key = masterValidationKey(master.hostName, master.component);
+      messages[key] = {
+        ...messages[key],
+        ...(item.level === "ERROR"
+          ? { errorMessage: item.message }
+          : { warnMessage: item.message }),
+      };
+    });
+
+  return messages;
+}

--- a/ambari-web/latest/src/screens/ClusterWizard/preInstallChecks.test.ts
+++ b/ambari-web/latest/src/screens/ClusterWizard/preInstallChecks.test.ts
@@ -1,0 +1,29 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from "vitest";
+import { shouldWarnBeforeSkippingPreInstallChecks } from "./preInstallChecks";
+
+describe("Pre Install Checks gate", () => {
+  it("warns only in a supported new-cluster flow before the placeholder ran", () => {
+    expect(shouldWarnBeforeSkippingPreInstallChecks("clusterCreation", true, false)).toBe(true);
+    expect(shouldWarnBeforeSkippingPreInstallChecks("clusterCreation", true, true)).toBe(false);
+    expect(shouldWarnBeforeSkippingPreInstallChecks("addService", true, false)).toBe(false);
+    expect(shouldWarnBeforeSkippingPreInstallChecks("clusterCreation", false, false)).toBe(false);
+  });
+});

--- a/ambari-web/latest/src/screens/ClusterWizard/preInstallChecks.ts
+++ b/ambari-web/latest/src/screens/ClusterWizard/preInstallChecks.ts
@@ -1,0 +1,25 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export function shouldWarnBeforeSkippingPreInstallChecks(
+  wizardName: string,
+  supported: boolean,
+  checksWereRun: boolean,
+) {
+  return wizardName === "clusterCreation" && supported && !checksWereRun;
+}

--- a/ambari-web/latest/src/screens/ClusterWizard/types/AssignMastersTypes.ts
+++ b/ambari-web/latest/src/screens/ClusterWizard/types/AssignMastersTypes.ts
@@ -22,6 +22,7 @@ export interface AssignMastersProps {
   hostsList: any;
   services: string[];
   setCanProceed: (canProcced: boolean) => void;
+  setHasValidationIssues?: (hasIssues: boolean) => void;
   dispatch: any;
   installedServices?: string[];
   parentState?:any;

--- a/ambari-web/latest/src/screens/ClusterWizard/types/VersionsDefinition.ts
+++ b/ambari-web/latest/src/screens/ClusterWizard/types/VersionsDefinition.ts
@@ -30,6 +30,8 @@ export interface Item {
 export interface VersionDefinition {
     id: string
     repository_version: string
+    min_jdk?: string
+    max_jdk?: string
     show_available: boolean
     stack_default: boolean
     stack_name: string

--- a/ambari-web/latest/src/screens/ClusterWizard/versionSelection.test.ts
+++ b/ambari-web/latest/src/screens/ClusterWizard/versionSelection.test.ts
@@ -1,0 +1,35 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from "vitest";
+import { compareVersions, isJdkCompatible } from "./versionSelection";
+
+describe("cluster version selection", () => {
+  it("compares numeric version segments", () => {
+    expect(compareVersions("1.8.0_352", "1.8")).toBe(1);
+    expect(compareVersions("17.0.2", "17.0.10")).toBe(-1);
+    expect(compareVersions("17", "17.0")).toBe(0);
+  });
+
+  it("applies inclusive JDK ranges and skips custom JDKs", () => {
+    expect(isJdkCompatible("17.0.8", "11", "17")).toBe(false);
+    expect(isJdkCompatible("17", "11", "17")).toBe(true);
+    expect(isJdkCompatible(undefined, "11", "17")).toBe(true);
+    expect(isJdkCompatible("17", undefined, undefined)).toBe(true);
+  });
+});

--- a/ambari-web/latest/src/screens/ClusterWizard/versionSelection.ts
+++ b/ambari-web/latest/src/screens/ClusterWizard/versionSelection.ts
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+function versionParts(value: string): number[] {
+  return value.split(/[^0-9]+/).filter(Boolean).map(Number);
+}
+
+export function compareVersions(left: string, right: string): number {
+  const leftParts = versionParts(left);
+  const rightParts = versionParts(right);
+  const length = Math.max(leftParts.length, rightParts.length);
+  for (let index = 0; index < length; index += 1) {
+    const difference = (leftParts[index] || 0) - (rightParts[index] || 0);
+    if (difference !== 0) {
+      return difference < 0 ? -1 : 1;
+    }
+  }
+  return 0;
+}
+
+export function isJdkCompatible(
+  currentVersion: string | undefined,
+  minimumVersion: string | undefined,
+  maximumVersion: string | undefined,
+): boolean {
+  if (!currentVersion || (!minimumVersion && !maximumVersion)) {
+    return true;
+  }
+  const minimum = minimumVersion || maximumVersion || "";
+  const maximum = maximumVersion || minimumVersion || "";
+  return compareVersions(currentVersion, minimum) >= 0
+    && compareVersions(currentVersion, maximum) <= 0;
+}

--- a/ambari-web/latest/src/screens/ClusterWizard/wizardRecovery.test.ts
+++ b/ambari-web/latest/src/screens/ClusterWizard/wizardRecovery.test.ts
@@ -1,0 +1,36 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from "vitest";
+import { resolveRecoveryStep } from "./wizardRecovery";
+
+describe("resolveRecoveryStep", () => {
+  it("restores active requests to Deploy and completed requests to Summary", () => {
+    expect(resolveRecoveryStep("clusterCreation", "CLUSTER_INSTALLING_3")).toBe(9);
+    expect(resolveRecoveryStep("clusterCreation", "CLUSTER_INSTALLED_4")).toBe(10);
+    expect(resolveRecoveryStep("addHost", "ADD_HOSTS_INSTALLING_3")).toBe(6);
+    expect(resolveRecoveryStep("addHost", "ADD_HOSTS_INSTALLED_4")).toBe(7);
+    expect(resolveRecoveryStep("addService", "SERVICE_STARTING_3")).toBe(6);
+    expect(resolveRecoveryStep("addService", "ADD_SERVICES_INSTALLED_4")).toBe(7);
+  });
+
+  it("returns undefined for unknown or malformed state", () => {
+    expect(resolveRecoveryStep("clusterCreation", "UNKNOWN")).toBeUndefined();
+    expect(resolveRecoveryStep("clusterCreation", null)).toBeUndefined();
+  });
+});

--- a/ambari-web/latest/src/screens/ClusterWizard/wizardRecovery.ts
+++ b/ambari-web/latest/src/screens/ClusterWizard/wizardRecovery.ts
@@ -1,0 +1,49 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export type InstallationWizard = "clusterCreation" | "addHost" | "addService";
+
+const RECOVERY_STEPS: Record<InstallationWizard, Record<string, number>> = {
+  clusterCreation: {
+    CLUSTER_DEPLOY_PREP_2: 8,
+    CLUSTER_INSTALLING_3: 9,
+    SERVICE_STARTING_3: 9,
+    CLUSTER_INSTALLED_4: 10,
+  },
+  addHost: {
+    ADD_HOSTS_DEPLOY_PREP_2: 5,
+    ADD_HOSTS_INSTALLING_3: 6,
+    SERVICE_STARTING_3: 6,
+    ADD_HOSTS_INSTALLED_4: 7,
+  },
+  addService: {
+    ADD_SERVICES_DEPLOY_PREP_2: 5,
+    ADD_SERVICES_INSTALLING_3: 6,
+    SERVICE_STARTING_3: 6,
+    ADD_SERVICES_INSTALLED_4: 7,
+  },
+};
+
+export function resolveRecoveryStep(
+  wizard: InstallationWizard,
+  clusterState: unknown,
+): number | undefined {
+  return typeof clusterState === "string"
+    ? RECOVERY_STEPS[wizard][clusterState]
+    : undefined;
+}

--- a/ambari-web/latest/src/screens/Hosts/AddHostWizard/AddHostInstall.tsx
+++ b/ambari-web/latest/src/screens/Hosts/AddHostWizard/AddHostInstall.tsx
@@ -30,6 +30,10 @@ import {
   AddHostComponentMetadata,
 } from "../../../Utils/hostWizard";
 import { ActionTypes } from "./wizardDataStore/types";
+import {
+  canRetryInstallation,
+  wizardCheckpoint,
+} from "../../ClusterWizard/installationProgress";
 
 type DeploymentPhase = "INSTALL" | "KEYTABS" | "START" | "COMPLETE";
 
@@ -211,6 +215,14 @@ export default function AddHostInstall() {
     setTerminal(false);
     setWorking(true);
     updateDeploymentState(nextStatus, nextPhase);
+    void Promise.resolve(flushStateToDb(
+      "checkpoint",
+      -1,
+      wizardCheckpoint(
+        "addHost",
+        nextPhase === "INSTALL" ? "INSTALLING" : "STARTING",
+      ),
+    ));
     schedulePoll();
   };
 
@@ -528,7 +540,7 @@ export default function AddHostInstall() {
         isBackEnabled={false}
         lifted
         step={currentStep}
-        sideItems={clusterStatus.status?.includes("FAILED") ? (
+        sideItems={canRetryInstallation(clusterStatus.status) ? (
           <Button
             variant="outline-primary"
             className="me-3"
@@ -540,7 +552,11 @@ export default function AddHostInstall() {
         ) : null}
         onNext={async () => {
           persist(hostsRef.current, clusterStatusRef.current, phaseRef.current);
-          await Promise.resolve(flushStateToDb("next"));
+          await Promise.resolve(flushStateToDb(
+            "next",
+            -1,
+            wizardCheckpoint("addHost", "INSTALLED"),
+          ));
           handleNextImperitive();
         }}
         onCancel={() => void flushStateToDb("cancel")}

--- a/ambari-web/latest/src/screens/Hosts/AddHostWizard/AddHostReview.tsx
+++ b/ambari-web/latest/src/screens/Hosts/AddHostWizard/AddHostReview.tsx
@@ -30,6 +30,7 @@ import {
   buildAddHostConfigGroupUpdates,
 } from "../../../Utils/hostWizard";
 import { ActionTypes } from "./wizardDataStore/types";
+import { wizardCheckpoint } from "../../ClusterWizard/installationProgress";
 
 function requestIdFrom(response: any): string | number | undefined {
   return response?.Requests?.id ?? response?.data?.Requests?.id ?? response?.id;
@@ -143,6 +144,11 @@ export default function AddHostReview() {
     setDeployError("");
 
     try {
+      await Promise.resolve(flushStateToDb(
+        "checkpoint",
+        -1,
+        wizardCheckpoint("addHost", "PREP"),
+      ));
       await waitForKDCSession();
 
       if (!hostsRegistered.current) {
@@ -236,7 +242,11 @@ export default function AddHostReview() {
         clusterStatus,
         deploymentStage: "Installation request launched",
       });
-      await Promise.resolve(flushStateToDb("next"));
+      await Promise.resolve(flushStateToDb(
+        "next",
+        -1,
+        wizardCheckpoint("addHost", "INSTALLING"),
+      ));
       handleNextImperitive();
     } catch (error: any) {
       setDeployError(String(errorMessage(error)));

--- a/ambari-web/latest/src/screens/Hosts/AddHostWizard/wizardDataStore/context.test.tsx
+++ b/ambari-web/latest/src/screens/Hosts/AddHostWizard/wizardDataStore/context.test.tsx
@@ -96,7 +96,7 @@ describe("Add Host persistence", () => {
     fireEvent.click(screen.getByRole("button", { name: "Retry" }));
 
     expect(await screen.findByRole("button", { name: "Persist" })).toBeTruthy();
-    expect(mocks.getPersistData).toHaveBeenCalledTimes(2);
+    expect(mocks.getPersistData).toHaveBeenCalledTimes(3);
   });
 
   it("serializes persistence requests", async () => {

--- a/ambari-web/latest/src/screens/Hosts/AddHostWizard/wizardDataStore/context.tsx
+++ b/ambari-web/latest/src/screens/Hosts/AddHostWizard/wizardDataStore/context.tsx
@@ -36,6 +36,8 @@ import { HostsApi } from "../../../../api/hostsApi";
 import { getAllComponents } from "../../utils";
 import { ClusterProgressStatus } from "../../../../constants";
 import { Alert, Button } from "react-bootstrap";
+import { claimWizard, releaseWizard } from "../../../../Utils/wizardOwnership";
+import { resolveRecoveryStep } from "../../../ClusterWizard/wizardRecovery";
 
 interface AddHostContextProps {
   state: State;
@@ -62,7 +64,7 @@ export const AddHostProvider: React.FC<{
   const [isHydrated, setIsHydrated] = useState(false);
   const [initializationError, setInitializationError] = useState<string | null>(null);
   const [retryCount, setRetryCount] = useState(0);
-  const { clusterName, services, serviceComponentInfo } =
+  const { clusterName, services, serviceComponentInfo, loginName } =
     useContext(AppContext);
 
   const isDataPersisted = useRef(false);
@@ -316,16 +318,23 @@ export const AddHostProvider: React.FC<{
           payload: persistedData,
         });
       }
-      if (get(persistedData, "activeStep", "")) {
+      const clusterState = await ClusterApi.getPersistData("CLUSTER_STATE");
+      const classicStep = resolveRecoveryStep(
+        "addHost",
+        get(clusterState, "clusterState"),
+      );
+      if (get(persistedData, "activeStep", "") || classicStep !== undefined) {
         try {
           const activeStepName = get(persistedData, "activeStep");
-          const restoredStepData = {
-            progressStatus: ClusterProgressStatus.ADDING_HOST,
-            stepName: activeStepName,
-          };
+          const restoredStepData = clusterState && !isEmpty(clusterState)
+            ? clusterState
+            : {
+                progressStatus: ClusterProgressStatus.ADDING_HOST,
+                stepName: activeStepName,
+              };
           currStepDataRef.current = restoredStepData;
           setCurrStepData(restoredStepData);
-          let activeStepNumber = Object.keys(
+          const storedStep = Object.keys(
             stepWizardUtilities.wizardSteps
           ).find((stepName) => {
             return (
@@ -333,12 +342,18 @@ export const AddHostProvider: React.FC<{
               activeStepName
             );
           });
-          stepWizardUtilities.jumpToStep(Number(activeStepNumber), true);
+          stepWizardUtilities.jumpToStep(
+            classicStep ?? Number(storedStep),
+            true,
+          );
         } catch (err) {
           console.error("Error while jumping to step", err);
         }
       } else {
         stepWizardUtilities.jumpToStep(1, true);
+      }
+      if (loginName) {
+        await claimWizard(loginName, "addHostController");
       }
       isDataPersisted.current = true;
       setIsHydrated(true);
@@ -373,10 +388,11 @@ export const AddHostProvider: React.FC<{
         CLUSTER_STATE: JSON.stringify({}),
       }),
     ));
+    await releaseWizard();
     window.location.assign("/main/hosts");
   }
 
-  async function flushOnStepChange(nextStep: number) {
+  async function flushOnStepChange(nextStep: number, clusterState?: string) {
     if (nextStep >= 1) {
       const nextStepDetails = stepWizardUtilities.wizardSteps?.[nextStep];
       const nextAddHostSteps = { ...stateRef.current.addHostSteps };
@@ -393,6 +409,7 @@ export const AddHostProvider: React.FC<{
       const nextStepData = {
         progressStatus: ClusterProgressStatus.ADDING_HOST,
         stepName: stepWizardUtilities?.wizardSteps?.[nextStep]?.name,
+        ...(clusterState ? { clusterState } : {}),
       };
       currStepDataRef.current = nextStepData;
       setCurrStepData(nextStepData);
@@ -402,7 +419,8 @@ export const AddHostProvider: React.FC<{
 
   async function flushStateToDb(
     operation: string = "default",
-    jumpStep: number = -1
+    jumpStep: number = -1,
+    clusterState?: string,
   ) {
     let activeStep = Object.keys(stepWizardUtilities.wizardSteps).find(
       (stepName) => {
@@ -417,14 +435,26 @@ export const AddHostProvider: React.FC<{
         await flushOnCancel();
         break;
       case "back":
-        await flushOnStepChange(Number(activeStep) - 1);
+        await flushOnStepChange(Number(activeStep) - 1, clusterState);
         break;
       case "next":
-        await flushOnStepChange(Number(activeStep) + 1);
+        await flushOnStepChange(Number(activeStep) + 1, clusterState);
         break;
       case "jump":
-        await flushOnStepChange(jumpStep);
+        await flushOnStepChange(jumpStep, clusterState);
         break;
+      case "checkpoint": {
+        const nextStepData = {
+          ...currStepDataRef.current,
+          progressStatus: ClusterProgressStatus.ADDING_HOST,
+          stepName: stepWizardUtilities.currentStep.name,
+          clusterState,
+        };
+        currStepDataRef.current = nextStepData;
+        setCurrStepData(nextStepData);
+        await queuePersistence(() => flushCurrentData(stateRef.current, nextStepData));
+        break;
+      }
       default:
         await queuePersistence(() => flushCurrentData(
           stateRef.current,

--- a/ambari-web/latest/src/screens/Services/AddServiceWizard/addServiceNavigation.test.ts
+++ b/ambari-web/latest/src/screens/Services/AddServiceWizard/addServiceNavigation.test.ts
@@ -1,0 +1,54 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  deriveAddServiceFlow,
+  nextAddServiceStep,
+  previousAddServiceStep,
+} from "./addServiceNavigation";
+
+describe("Add Service conditional navigation", () => {
+  it("skips master-only gaps and returns to the last applicable step", () => {
+    const flow = deriveAddServiceFlow({
+      CLIENT_ONLY: {
+        hasClient: true,
+        hasConfigs: false,
+        selected: true,
+      },
+    });
+
+    expect(flow).toEqual({
+      skipConfigStep: true,
+      skipMasterStep: true,
+      skipSlavesStep: false,
+    });
+    expect(nextAddServiceStep(1, flow)).toBe(3);
+    expect(nextAddServiceStep(3, flow)).toBe(5);
+    expect(previousAddServiceStep(5, flow)).toBe(3);
+  });
+
+  it("goes directly from Services to Review when no assignment or config step applies", () => {
+    const flow = deriveAddServiceFlow({
+      HEADLESS: { hasConfigs: false, selected: true },
+    });
+
+    expect(nextAddServiceStep(1, flow)).toBe(5);
+    expect(previousAddServiceStep(5, flow)).toBe(1);
+  });
+});

--- a/ambari-web/latest/src/screens/Services/AddServiceWizard/addServiceNavigation.ts
+++ b/ambari-web/latest/src/screens/Services/AddServiceWizard/addServiceNavigation.ts
@@ -1,0 +1,74 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export type AddServiceFlow = {
+  skipConfigStep: boolean;
+  skipMasterStep: boolean;
+  skipSlavesStep: boolean;
+};
+
+type ServiceFlowMetadata = {
+  hasClient?: boolean;
+  hasConfigs?: boolean;
+  hasMaster?: boolean;
+  hasNonMastersWithCustomAssignment?: boolean;
+  hasSlave?: boolean;
+  installed?: boolean;
+  selected?: boolean;
+};
+
+export function deriveAddServiceFlow(
+  services: Record<string, ServiceFlowMetadata>,
+): AddServiceFlow {
+  const selected = Object.values(services).filter(
+    (service) => service.selected && !service.installed,
+  );
+  return {
+    skipMasterStep: selected.every((service) => !service.hasMaster),
+    skipSlavesStep: selected.every((service) =>
+      !service.hasSlave
+      && !service.hasClient
+      && !service.hasNonMastersWithCustomAssignment,
+    ),
+    skipConfigStep: selected.every((service) => service.hasConfigs === false),
+  };
+}
+
+export function nextAddServiceStep(
+  currentStep: number,
+  flow: AddServiceFlow,
+): number {
+  const candidates = [2, 3, 4, 5];
+  return candidates.find((step) => step > currentStep && !(
+    (step === 2 && flow.skipMasterStep)
+    || (step === 3 && flow.skipSlavesStep)
+    || (step === 4 && flow.skipConfigStep)
+  )) ?? 5;
+}
+
+export function previousAddServiceStep(
+  currentStep: number,
+  flow: AddServiceFlow,
+): number {
+  const candidates = [4, 3, 2, 1];
+  return candidates.find((step) => step < currentStep && !(
+    (step === 2 && flow.skipMasterStep)
+    || (step === 3 && flow.skipSlavesStep)
+    || (step === 4 && flow.skipConfigStep)
+  )) ?? 1;
+}

--- a/ambari-web/latest/src/screens/Services/AddServiceWizard/wizardDataStore/context.tsx
+++ b/ambari-web/latest/src/screens/Services/AddServiceWizard/wizardDataStore/context.tsx
@@ -19,6 +19,7 @@
 import React, {
   createContext,
   Dispatch,
+  useCallback,
   useContext,
   useEffect,
   useReducer,
@@ -41,6 +42,9 @@ import {
   CANCEL_ADD_SERVICE_WIZARD_EVENT,
   clearAddServiceWizardState,
 } from "../../../../Utils/addServicePersistence";
+import { Alert, Button } from "react-bootstrap";
+import { claimWizard, releaseWizard } from "../../../../Utils/wizardOwnership";
+import { resolveRecoveryStep } from "../../../ClusterWizard/wizardRecovery";
 
 interface AddServiceContextProps {
   state: State;
@@ -65,40 +69,37 @@ export const AddServiceProvider: React.FC<{
   stepWizardUtilities: any;
   children: React.ReactNode;
 }> = ({ stepWizardUtilities, children }) => {
-  const [state, dispatch] = useReducer(reducer, initialState);
+  const [state, reducerDispatch] = useReducer(reducer, initialState);
   const [installedHosts, setInstalledHosts] = useState([]);
   const [installedServices, setInstalledServices] = useState([]);
   const [serviceContextLoading, setServiceContextLoading] = useState(true);
   const [currStepData, setCurrStepData] = useState({});
-  const { clusterName, services, serviceComponentInfo } =
+  const [isHydrated, setIsHydrated] = useState(false);
+  const [initializationError, setInitializationError] = useState<string | null>(null);
+  const [retryCount, setRetryCount] = useState(0);
+  const { clusterName, services, serviceComponentInfo, loginName } =
     useContext(AppContext);
 
   const isDataPersisted = useRef(false);
   const isCancelled = useRef(false);
-  const requestSequence = useRef(0);
-  const debounceTimer = useRef<NodeJS.Timeout | null>(null);
   const cancelWizardRef = useRef<(() => Promise<void>) | null>(null);
+  const persistenceQueue = useRef<Promise<void>>(Promise.resolve());
+  const stateRef = useRef<State>(initialState);
+  const currStepDataRef = useRef<Record<string, any>>({});
 
-  // Custom debounced persist function with cancellation capability
-  const debouncedPersist = () => {
-    // Clear any existing timer
-    if (debounceTimer.current) {
-      clearTimeout(debounceTimer.current);
-    }
-    
-    // Set new timer
-    debounceTimer.current = setTimeout(() => {
-      flushCurrentData();
-    }, 500);
+  const dispatch: Dispatch<Action> = (action) => {
+    stateRef.current = reducer(stateRef.current, action);
+    reducerDispatch(action);
   };
 
-  // Function to cancel the debounced persist
-  const cancelDebouncedPersist = () => {
-    if (debounceTimer.current) {
-      clearTimeout(debounceTimer.current);
-      debounceTimer.current = null;
-    }
-  };
+  const queuePersistence = useCallback((operation: () => Promise<any>) => {
+    const nextOperation = persistenceQueue.current
+      .catch(() => undefined)
+      .then(operation)
+      .then(() => undefined);
+    persistenceQueue.current = nextOperation.catch(() => undefined);
+    return nextOperation;
+  }, []);
 
   const getInstalledServices = () => {
     const serviceNames = services.map((service: any) =>
@@ -151,6 +152,9 @@ export const AddServiceProvider: React.FC<{
     
     // Use the current stack if found, otherwise fallback to the first one
     const stackToUse = currentStack || response.items[0];
+    if (!stackToUse) {
+      throw new Error("No stack version is available for this cluster.");
+    }
     
     const repoVersionId = get(
       stackToUse,
@@ -215,27 +219,72 @@ export const AddServiceProvider: React.FC<{
   };
 
   useEffect(() => {
-    getAlreadyInstalledServices();
-  }, []);
+    if (isHydrated && clusterName) {
+      void getAlreadyInstalledServices().catch(handleInitializationError);
+    }
+  }, [clusterName, isHydrated, retryCount]);
 
   useEffect(() => {
-    if (!isEmpty(services) && !isEmpty(serviceComponentInfo)) {
+    if (
+      isHydrated
+      && !isEmpty(services)
+      && !isEmpty(serviceComponentInfo)
+      && !state.addServiceSteps?.SERVICES
+    ) {
       getInstalledServices();
     }
-  }, [services, serviceComponentInfo]);
+  }, [isHydrated, services, serviceComponentInfo, state.addServiceSteps?.SERVICES]);
 
   useEffect(() => {
-    syncUserPersistedData();
-    getHostComponents();
-  }, []);
+    void syncUserPersistedData();
+  }, [retryCount]);
+
+  useEffect(() => {
+    if (isHydrated && clusterName && !state.addServiceSteps?.NAME) {
+      setClusterName();
+    }
+  }, [clusterName, isHydrated, state.addServiceSteps?.NAME]);
+
+  useEffect(() => {
+    if (
+      isHydrated
+      && clusterName
+      && !isEmpty(serviceComponentInfo)
+      && (!state.addServiceSteps?.HOST_STATUS || !state.addServiceSteps?.MASTERS)
+    ) {
+      void getHostComponents().catch(handleInitializationError);
+    }
+  }, [clusterName, isHydrated, serviceComponentInfo, retryCount]);
+
+  useEffect(() => {
+    if (isHydrated && clusterName && !state.addServiceSteps?.VERSION) {
+      setServiceContextLoading(true);
+      void setStackAndVersion().catch(handleInitializationError);
+    } else if (isHydrated) {
+      setServiceContextLoading(false);
+    }
+  }, [clusterName, isHydrated, state.addServiceSteps?.VERSION, retryCount]);
 
   useEffect(() => {
     if (isDataPersisted.current) {
-      debouncedPersist();
+      void queuePersistence(() => flushCurrentData(state, currStepData));
     }
   }, [state.addServiceSteps, currStepData]);
 
+  const handleInitializationError = (error: any) => {
+    isDataPersisted.current = false;
+    setInitializationError(
+      error?.response?.data?.message
+        || error?.message
+        || "Ambari could not initialize the Add Service wizard.",
+    );
+  };
+
   async function syncUserPersistedData() {
+    setInitializationError(null);
+    setIsHydrated(false);
+    isDataPersisted.current = false;
+    isCancelled.current = false;
     try {
       const persistedData = await ClusterApi.getPersistData("ADD_SERVICE");
       if (!isEmpty(get(persistedData, "addServiceSteps", {}))) {
@@ -244,33 +293,33 @@ export const AddServiceProvider: React.FC<{
           payload: persistedData,
         });
       }
-      if (get(persistedData, "activeStep", "")) {
-        try {
-          const activeStepName = get(persistedData, "activeStep");
-          setCurrStepData({
+      const clusterState = await ClusterApi.getPersistData("CLUSTER_STATE");
+      const classicStep = resolveRecoveryStep(
+        "addService",
+        get(clusterState, "clusterState"),
+      );
+      const activeStepName = get(persistedData, "activeStep", "");
+      const storedStep = Object.keys(stepWizardUtilities.wizardSteps).find(
+        (stepNumber) =>
+          stepWizardUtilities.wizardSteps?.[stepNumber]?.name === activeStepName,
+      );
+      const activeStep = classicStep ?? (storedStep === undefined ? 1 : Number(storedStep));
+      const restoredStepData = clusterState && !isEmpty(clusterState)
+        ? clusterState
+        : {
             progressStatus: ClusterProgressStatus.ADDING_SERVICE,
-            stepName: activeStepName,
-          });
-          let activeStepNumber = Object.keys(
-            stepWizardUtilities.wizardSteps
-          ).find((stepName) => {
-            return (
-              stepWizardUtilities.wizardSteps?.[stepName]?.name ===
-              activeStepName
-            );
-          });
-          stepWizardUtilities.jumpToStep(Number(activeStepNumber), true);
-        } catch (err) {
-          console.error("Error while jumping to step", err);
-        }
-      } else {
-        getInstalledServices();
-        setClusterName();
-        setStackAndVersion();
-        stepWizardUtilities.jumpToStep(1, true);
+            stepName: stepWizardUtilities.wizardSteps?.[activeStep]?.name,
+          };
+      currStepDataRef.current = restoredStepData;
+      setCurrStepData(restoredStepData);
+      stepWizardUtilities.jumpToStep(activeStep, true);
+      if (loginName) {
+        await claimWizard(loginName, "addServiceController");
       }
-    } finally {
       isDataPersisted.current = true;
+      setIsHydrated(true);
+    } catch (error: any) {
+      handleInitializationError(error);
     }
   }
 
@@ -343,61 +392,34 @@ export const AddServiceProvider: React.FC<{
     });
   };
 
-  async function flushCurrentData() {
-    // Assign a sequence number to this request
-    const currentSequence = ++requestSequence.current;
-    
-    // Don't persist if wizard has been cancelled
+  async function flushCurrentData(
+    stateSnapshot: State = stateRef.current,
+    stepSnapshot: Record<string, any> = currStepDataRef.current,
+  ) {
     if (isCancelled.current) {
       return;
     }
-
-    try {
-      const result = await ClusterApi.postPersistData(
-        JSON.stringify({
-          ADD_SERVICE: JSON.stringify({
-            ...state,
-            activeStep: get(currStepData, "stepName", ""),
-            requestSequence: currentSequence, // Include sequence number in the data
-          }),
-          CLUSTER_STATE: JSON.stringify(currStepData),
-        })
-      );
-      
-      // Check if this request is still the latest after completion
-      if (currentSequence !== requestSequence.current || isCancelled.current) {
-        return;
-      }
-      
-      return result;
-    } catch (error: any) {
-      // Only log errors if the wizard hasn't been cancelled and this is still the latest request
-      if (!isCancelled.current && currentSequence === requestSequence.current) {
-        console.error('Error persisting data:', error);
-      }
-    }
+    await ClusterApi.postPersistData(JSON.stringify({
+      ADD_SERVICE: JSON.stringify({
+        ...stateSnapshot,
+        activeStep: get(stepSnapshot, "stepName", ""),
+      }),
+      CLUSTER_STATE: JSON.stringify(stepSnapshot),
+    }));
   }
 
   async function flushOnCancel() {
-    // Set cancellation flag to prevent any pending flushCurrentData calls
     isCancelled.current = true;
-    
-    // Increment sequence to invalidate any pending requests
-    const cancelSequence = ++requestSequence.current;
-
-    // Cancel the debounced function to prevent it from executing
-    cancelDebouncedPersist();
-
     try {
-      // Clear the persisted state with the latest sequence number
-      await clearAddServiceWizardState(initialState, cancelSequence);
+      await queuePersistence(() => clearAddServiceWizardState(initialState));
+      await releaseWizard();
     } catch (error: any) {
-      console.error('Error clearing persisted data:', error);
-    } finally {
-      modalManager.hide();
-      window.location.href = "/#/main/dashboard/metrics";
-      window.location.reload();
+      isCancelled.current = false;
+      throw error;
     }
+    modalManager.hide();
+    window.location.href = "/#/main/dashboard/metrics";
+    window.location.reload();
   }
 
   cancelWizardRef.current = flushOnCancel;
@@ -409,37 +431,39 @@ export const AddServiceProvider: React.FC<{
     window.addEventListener(CANCEL_ADD_SERVICE_WIZARD_EVENT, cancelWizard);
     return () => {
       window.removeEventListener(CANCEL_ADD_SERVICE_WIZARD_EVENT, cancelWizard);
-      if (debounceTimer.current) {
-        clearTimeout(debounceTimer.current);
-        debounceTimer.current = null;
-      }
       isCancelled.current = true;
     };
   }, []);
 
-  async function flushOnStepChange(nextStep: number) {
+  async function flushOnStepChange(nextStep: number, clusterState?: string) {
     if (nextStep >= 1) {
-      let nextStepDetails = stepWizardUtilities.wizardSteps?.[nextStep];
+      const nextStepDetails = stepWizardUtilities.wizardSteps?.[nextStep];
+      const nextAddServiceSteps = { ...stateRef.current.addServiceSteps };
       if (nextStepDetails?.keysToRemove) {
         nextStepDetails.keysToRemove.forEach((key: string) => {
-          if (state?.addServiceSteps?.[key]) {
-            dispatch({
-              type: ActionTypes.REMOVE_KEY,
-              payload: { key },
-            });
-          }
+          delete nextAddServiceSteps[key];
         });
       }
-      setCurrStepData({
+      const nextState = {
+        ...stateRef.current,
+        addServiceSteps: nextAddServiceSteps,
+      };
+      dispatch({ type: ActionTypes.SYNC_STATE, payload: nextState });
+      const nextStepData = {
         progressStatus: ClusterProgressStatus.ADDING_SERVICE,
         stepName: stepWizardUtilities?.wizardSteps?.[nextStep]?.name,
-      });
+        ...(clusterState ? { clusterState } : {}),
+      };
+      currStepDataRef.current = nextStepData;
+      setCurrStepData(nextStepData);
+      await queuePersistence(() => flushCurrentData(nextState, nextStepData));
     }
   }
 
-  function flushStateToDb(
+  async function flushStateToDb(
     operation: string = "default",
-    jumpStep: number = -1
+    jumpStep: number = -1,
+    clusterState?: string,
   ) {
     let activeStep = Object.keys(stepWizardUtilities.wizardSteps).find(
       (stepName) => {
@@ -451,15 +475,28 @@ export const AddServiceProvider: React.FC<{
     );
     switch (operation) {
       case "cancel":
-        return flushOnCancel();
+        return await flushOnCancel();
+      case "complete":
+        return await flushOnCancel();
       case "back":
-        return flushOnStepChange(Number(activeStep) - 1);
+        return await flushOnStepChange(Number(activeStep) - 1, clusterState);
       case "next":
-        return flushOnStepChange(Number(activeStep) + 1);
+        return await flushOnStepChange(Number(activeStep) + 1, clusterState);
       case "jump":
-        return flushOnStepChange(jumpStep);
+        return await flushOnStepChange(jumpStep, clusterState);
+      case "checkpoint": {
+        const nextStepData = {
+          ...currStepDataRef.current,
+          progressStatus: ClusterProgressStatus.ADDING_SERVICE,
+          stepName: stepWizardUtilities.currentStep.name,
+          clusterState,
+        };
+        currStepDataRef.current = nextStepData;
+        setCurrStepData(nextStepData);
+        return await queuePersistence(() => flushCurrentData(stateRef.current, nextStepData));
+      }
       default:
-        return flushCurrentData();
+        return await queuePersistence(() => flushCurrentData());
     }
   }
 
@@ -475,7 +512,18 @@ export const AddServiceProvider: React.FC<{
         installedServices,
       }}
     >
-      {children}
+      {initializationError ? (
+        <Alert variant="danger" className="m-4">
+          {initializationError}{" "}
+          <Button
+            size="sm"
+            variant="outline-danger"
+            onClick={() => setRetryCount((value) => value + 1)}
+          >
+            Retry
+          </Button>
+        </Alert>
+      ) : children}
     </AddServiceContext.Provider>
   );
 };

--- a/ambari-web/latest/src/store/context.tsx
+++ b/ambari-web/latest/src/store/context.tsx
@@ -114,6 +114,7 @@ interface AppContextProps {
   wizardIsNotFinished: boolean;
   isNonWizardUser: boolean;
   isClusterInstalled?: boolean;
+  loginName: string;
 }
 
 type BackgroundRequestPage = {
@@ -183,6 +184,7 @@ export const AppContext = createContext<AppContextProps>({
   wizardIsNotFinished: false,
   isNonWizardUser: false,
   isClusterInstalled: false,
+  loginName: "",
 });
 
 export const AppProvider: React.FC<{ children: React.ReactNode }> = ({
@@ -761,6 +763,7 @@ export const AppProvider: React.FC<{ children: React.ReactNode }> = ({
         wizardIsNotFinished,
         isNonWizardUser,
         isClusterInstalled,
+        loginName: loginName || "",
       }}
     >
       {children}

--- a/docs/frontend-refactor/react-current/07-cluster-installation-gap.md
+++ b/docs/frontend-refactor/react-current/07-cluster-installation-gap.md
@@ -1,0 +1,402 @@
+<!---
+   Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+
+# React Cluster Installation Comparison
+
+## Comparison Scope
+
+| Item | Value |
+| --- | --- |
+| Ember baseline | `ember-baseline/07-cluster-installation.md` |
+| React implementation | `ambari-web/latest`, Module 07 based on `4fb6dadf190007b831fdd2d08a9a9c6431b252b9` |
+| Feature IDs | 79 IDs from `INST-MODE-001` through `INST-10-002` |
+| Review date | 2026-08-17 |
+| Deployment modes | New cluster, Add Host, and Add Service |
+| Metrics boundary | Ambari Metrics, Ganglia, metric widgets, charts, and metric display data are excluded; service dependency metadata and operational host/request state remain included |
+
+The comparison used the written baseline, executable Classic routes, controllers,
+mixins, templates, AJAX registry, and tests, and the current React routes,
+stores, screens, APIs, and tests. The generated API-by-module page was used only
+to locate candidates. The authoritative network review combined AJAX
+definitions, AJAX call sites, direct HTTP, browser entry points, and realtime
+channels.
+
+## Initial Static Conclusion
+
+| Status | Meaning | Count |
+| --- | --- | ---: |
+| `STATICALLY_ALIGNED` | The reviewed React path matches the static Classic contract but still requires live acceptance | 13 |
+| `PARTIAL` | A user-reachable path exists, but a condition, payload, branch, recovery path, or test is incomplete | 40 |
+| `INCORRECT` | React can issue a wrong request, transition at the wrong time, or expose a materially different result | 14 |
+| `MISSING` | No user-reachable implementation exists for the Feature ID | 12 |
+| Total |  | 79 |
+
+The highest-risk gap is Review deployment. Classic uses an abort-on-error serial
+resource queue after destructive cleanup. React starts a mixture of already
+running promises and delayed requests, converts several rejected mutations into
+successful promise settlement, has an empty config-group creation function, and
+can invoke the install phase after an incomplete resource graph. New-cluster
+version APIs are also hard-coded to `VDP`, and Deploy permits Summary while work
+is still active.
+
+## Complete Wizard State Machines
+
+### New Cluster
+
+| State | Forward condition and side effects | Back/cancel condition | Recovery contract | Initial React result |
+| --- | --- | --- | --- | --- |
+| 0 Name | Valid name and at least one installable stack; store name, then enter Version | Cancel confirms and navigates to Admin View | `CLUSTER_CURRENT` plus `CLUSTER_STATE.stepName=NAME` | Name validation exists; stack availability is not a Step 0 gate |
+| 1 Version | Visible version definition selected; repository rows syntactically valid; URL checks pass or are explicitly skipped; JDK warning accepted; persist VDF source and repository edits | Back clears Version and all downstream state | Restore stack, definition, repository source, OS rows, validation result, and flags | State restores, but APIs are `VDP`-specific, JDK validation is absent, and VDF source is lost |
+| 2 Install Options | At least one new normalized host; automatic mode has required credentials; suspicious or installed hosts are explicitly accepted | Back clears hosts and downstream state | Restore normalized hosts and registration mode without replaying a mutation | Linux SSH/manual paths exist; new-cluster HDPWIN and support-derived Agent user are absent |
+| 3 Confirm Hosts | At least one `REGISTERED` host; bootstrap/registration has settled; generic warnings accepted | Back stops timers; remove/retry affects only selected local wizard hosts | Restore request ID, host states/logs, registration deadline, check request, and results | Timers stop on unmount, but active bootstrap/check identity is not persisted and refresh can replay work |
+| 4 Services | At least one installable non-Metrics service; CRITICAL dependency/filesystem conflicts fixed; WARNING accepted | Back returns to hosts; change clears assignments/configs | Restore selection and accepted warnings | Service selection exists; complete stack-specific validation evidence is absent |
+| 5 Masters | Advisor result loaded; assignment is cardinality-valid; current matching WARN/ERROR explicitly accepted | Back clears master and later data | Restore recommendation and manual moves; recalculate after service changes | Advisor and validation exist; React hard-blocks some server errors and adds non-metadata placement rules |
+| 6 Slaves/Clients | Required matrix selection valid; server mapping WARN/ERROR explicitly accepted | Back preserves master assignments and clears later data | Restore matrix, hidden components, and accepted validation | Core matrix and validation exist; restoration and dependency permutations are incomplete |
+| 7 Configs | Required values valid; required recommendations applied; dependent changes accepted; external tests pass or are consciously retried | Dirty Back confirms discard | Restore tabs, values, overrides, recommendations, validation, and dynamic assignments | Main config surface exists; pre-install shell, complete overrides, and dirty-state behavior are incomplete |
+| 8 Review | Checkpoint `CLUSTER_DEPLOY_PREP_2`; complete destructive cleanup; non-dry-run VDF; abort-on-error serial resource queue; install request accepted | Back enabled only before successful submission; failures reopen Back/Deploy without rollback | Persist checkpoint and completed resource/request identity | Cleanup exists, but the creation order and failure accounting are incorrect |
+| 9 Deploy | Install terminal; optionally start/check terminal; only defined terminal states enable Next; write `CLUSTER_INSTALLED_4` | No ordinary Back; only Classic Admin View/Views route exceptions; Retry only `INSTALL FAILED` | Resume current request and phase from server state and persisted request IDs | Polling/request identity, Next gating, route blocking, and completion checkpoint are incorrect or missing |
+| 10 Summary | Complete attempts provisioning `INSTALLED`, clears wizard and cluster state, then enters Dashboard | No reachable Back; Cancel is not a second completion path | Restore static summary at `CLUSTER_INSTALLED_4` | Summary exists; provisioning failure and cluster-state reset semantics differ |
+
+### Add Host
+
+| Step | Forward condition and branch | Back/cancel and recovery | Initial React result |
+| --- | --- | --- | --- |
+| 1 Install Options | Same Linux SSH, HDPWIN PowerShell, and manual paths as new cluster; optional Classic `Skip host checks` | No Back; cancel clears Add Host state; resume from `ADD_HOST` | Modes and serialized persistence exist; Skip Host Checks is missing |
+| 2 Confirm Hosts | Registration/check rules from core Step 3 | Back stops polling; resume host/check request state | Registration is shared, but in-flight bootstrap/check recovery is incomplete |
+| 3 Slaves/Clients | Assign only slave/client components to new hosts; client-only/no-component is valid | Back preserves registered hosts | Core matrix is reused and covered by focused Add Host utility tests |
+| 4 Config Groups | Skip automatically when no selected component; otherwise choose existing/default groups by affected service | Back to assignments; persist exact group choice | Dedicated React page and persisted selection exist |
+| 5 Review | Write `ADD_HOSTS_DEPLOY_PREP_2`; register hosts/components; apply full config-group memberships; obtain KDC session before install | Resource/config-group failure remains retryable on Review | Dedicated React deployment is serial and tested; KDC/real-cluster behavior remains conditional |
+| 6 Deploy | Poll install, optional keytab regeneration, start selected non-client components; Retry failed phase | No Back; persist phase/request; Add Host may proceed after terminal install failure | Dedicated React flow persists phase/request and is focused-tested |
+| 7 Summary | Show host/task outcome; clear Add Host state; refresh Hosts; never write cluster provisioning state | No Back | Dedicated React summary follows this boundary |
+
+Classic server-state mappings are intentionally recorded for runtime tests:
+`ADD_HOSTS_DEPLOY_PREP_2 -> Step 4`, `ADD_HOSTS_INSTALLING_3` and
+`SERVICE_STARTING_3 -> Step 5`, and `ADD_HOSTS_INSTALLED_4 -> Step 6`. React
+currently restores its own `ADD_HOST.activeStep`; it does not independently map
+these Classic server states.
+
+### Add Service
+
+| Step | Forward condition and conditional skip | Back/cancel and recovery | Initial React result |
+| --- | --- | --- | --- |
+| 1 Services | Show only uninstalled/installable services and enforce dependencies | No Back; cancel owns `ADD_SERVICE` cleanup | Selection filtering exists |
+| 2 Masters | Skip when selected services have no assignable masters | Back to Services | React always enters this step |
+| 3 Slaves/Clients | Skip when selected services have no slave/client components | Back to last applicable step | React always enters this step |
+| 4 Configs | Skip when no selected service config is required; on Kerberos, validate/update descriptor | Back to last applicable assignment step | React always enters; descriptor handling is incomplete |
+| 5 Review | Write `ADD_SERVICES_DEPLOY_PREP_2`; show Manual KDC responsibility; offer CSV for every non-empty `kdc_type`; create service resources serially | Failure reopens Review; persist completed boundary | CSV/manual confirmation are missing and the shared queue is incorrect |
+| 6 Deploy | Install/start/check only added services; Retry `INSTALL FAILED`; persist request IDs | No Back; terminal states only | Shared Step 9 has request, polling, and Next defects |
+| 7 Summary | Show results; clear Add Service state; refresh cluster; never write provisioning state | No Back | Provisioning boundary is correct; summary/recovery remains partial |
+
+Classic maps `ADD_SERVICES_DEPLOY_PREP_2 -> Step 5`, and all of
+`ADD_SERVICES_INSTALLING_3`, `SERVICE_STARTING_3`, and
+`ADD_SERVICES_INSTALLED_4 -> Step 7`. The latter mapping can prematurely show a
+static Classic Summary; React must not create a second request on refresh and
+must reconcile the active server request before presenting completion.
+
+## Feature Status
+
+### Modes, Entries, and Recovery
+
+| ID | Initial status | Classic behavior versus current React |
+| --- | --- | --- |
+| `INST-MODE-001` | `PARTIAL` | Eleven-step new-cluster UI exists, but version selection, Review ordering, Deploy recovery, and final state are not equivalent |
+| `INST-MODE-002` | `PARTIAL` | Seven-step Add Host is substantially implemented; Skip Host Checks and server-state mapping remain |
+| `INST-MODE-003` | `PARTIAL` | Seven-step Add Service exists; conditional step skipping, complete Kerberos branch, deploy queue, and recovery remain |
+| `INST-MODE-004` | `INCORRECT` | Public Repository exists, but React initially selects Local, loads blank OS URLs through hard-coded `VDP`, and lacks the JDK branch |
+| `INST-MODE-005` | `INCORRECT` | XML dry-run exists, but raw XML/source metadata is not retained for the required non-dry-run Review POST |
+| `INST-MODE-006` | `INCORRECT` | URL dry-run exists, but Review posts a synthetic `VersionDefinition.available` payload instead of the retained URL source |
+| `INST-MODE-007` | `PARTIAL` | Linux bootstrap fields and payload helper exist; new-cluster support flag wiring and refresh recovery are incomplete |
+| `INST-MODE-008` | `PARTIAL` | Manual mode skips bootstrap and uses the 15-second timeout; in-flight recovery remains incomplete |
+| `INST-MODE-009` | `PARTIAL` | Dedicated Add Host install can regenerate keytabs, but KDC session/runtime prerequisites need live acceptance |
+| `INST-MODE-010` | `PARTIAL` | Add Service reads security and descriptor data, but KDC type, CSV, Manual responsibility, and blocking error behavior are incomplete |
+| `INST-MODE-011` | `PARTIAL` | Add Host derives HDPWIN and sends automatic bootstrap; new-cluster Step 2 never derives HDPWIN from the selected stack |
+| `INST-ENTRY-001` | `MISSING` | `/installer/:stepNumber` has no `AMBARI.ADD_DELETE_CLUSTERS` route guard |
+| `INST-ENTRY-002` | `STATICALLY_ALIGNED` | Add Service route has feature, permission, and operation guards |
+| `INST-ENTRY-003` | `PARTIAL` | Host list hides Add Host without permission, but the direct React route has no authorization or operation guard |
+| `INST-FLOW-001` | `PARTIAL` | Landing can select Installer and local persisted step can restore; complete provisioning-state routing is not reconciled here |
+| `INST-FLOW-002` | `INCORRECT` | New-cluster and Add Service step changes do not await persistence and can write a stale pre-dispatch snapshot |
+| `INST-FLOW-003` | `MISSING` | React does not map `wizardControllerName` plus Classic cluster states to all three actual recovery steps |
+| `INST-FLOW-004` | `INCORRECT` | React Cancel clears persisted wizard state before Admin View, while Classic Cancel only navigates and retains recovery state |
+| `INST-FLOW-005` | `MISSING` | Common Back/Next controls have no in-flight click lock and handlers commonly advance before persistence settles |
+| `INST-FLOW-006` | `MISSING` | AppContext reads `wizard-data`, but installation providers never claim/release it; multi-window ownership is therefore not complete |
+
+### Steps 0 Through 3
+
+| ID | Initial status | Classic behavior versus current React |
+| --- | --- | --- |
+| `INST-0-001` | `STATICALLY_ALIGNED` | Name required, length, whitespace, and special-character validation exist |
+| `INST-0-002` | `PARTIAL` | Version definitions load in Step 1 rather than stacks in Step 0; load failure has no focused recovery UI |
+| `INST-1-001` | `INCORRECT` | React filters through the API but hard-codes `stack_name=VDP` and does not safely handle an empty definition set |
+| `INST-1-002` | `PARTIAL` | Public/Local controls and network warning exist; initial selection/default repository population differs |
+| `INST-1-003` | `INCORRECT` | File/URL dry-run UI exists, but source type/content is not retained for Review submission |
+| `INST-1-004` | `PARTIAL` | Edit/add/remove/restore and syntax validation exist; uniqueness, autocomplete, and server contract are incomplete |
+| `INST-1-005` | `PARTIAL` | Next can rerun validation, but there is no explicit failed-repository Retry lifecycle |
+| `INST-1-006` | `MISSING` | No Ambari Server JDK versus `min_jdk`/`max_jdk` warning and Proceed Anyway branch |
+| `INST-1-007` | `INCORRECT` | Satellite toggle exists, but repository submission still sends `verify_base_url=true` and control locking differs |
+| `INST-2-001` | `STATICALLY_ALIGNED` | Input is lowercased, whitespace-split, pattern-expanded, deduplicated, and installed hosts are filtered |
+| `INST-2-002` | `PARTIAL` | SSH fields validate, but new-cluster Agent user does not consume `customizeAgentUserAccount` |
+| `INST-2-003` | `STATICALLY_ALIGNED` | Manual instructions, no bootstrap, and registration-only wait exist |
+| `INST-2-004` | `STATICALLY_ALIGNED` | Suspicious FQDN and mixed installed-host confirmations exist |
+| `INST-2-005` | `MISSING` | Add Host has no Skip Host Checks checkbox or independent-JDK boundary |
+| `INST-3-001` | `PARTIAL` | Bootstrap POST and serialized 3-second polling exist with timer cleanup; request identity is not persisted for refresh |
+| `INST-3-002` | `STATICALLY_ALIGNED` | Registration poll is serialized and uses 120-second automatic/15-second manual timeouts |
+| `INST-3-003` | `STATICALLY_ALIGNED` | Status filters and read-only bootstrap logs exist |
+| `INST-3-004` | `PARTIAL` | Retry resets all failed hosts; selected-subset retry and refresh continuity are absent |
+| `INST-3-005` | `STATICALLY_ALIGNED` | Removal is local only and at least one registered host gates Next |
+| `INST-3-006` | `PARTIAL` | Preinstalled request/task polling and warning parsing exist; complete category and warning-acceptance parity needs tests |
+| `INST-3-007` | `MISSING` | No separate `/requests` JDK check and result phase parses `java_home_check.exit_code` |
+| `INST-3-008` | `STATICALLY_ALIGNED` | Other registered Agents are discovered and can be included |
+
+### Steps 4 Through 7
+
+| ID | Initial status | Classic behavior versus current React |
+| --- | --- | --- |
+| `INST-4-001` | `PARTIAL` | Installable service list and selection exist; complete filesystem grouping and cancel behavior remain |
+| `INST-4-002` | `PARTIAL` | Required-service prompts exist; transitive and already-installed dependency cases lack focused evidence |
+| `INST-4-003` | `PARTIAL` | Several filesystem/service conflicts are checked; the complete stack-conditional matrix remains |
+| `INST-4-004` | `STATICALLY_ALIGNED` | Choose Services validation remains client-side and does not invent Advisor validation |
+| `INST-5-001` | `PARTIAL` | Advisor recommendations load, but React adds a hard-coded ZooKeeper placement and assumes response topology |
+| `INST-5-002` | `INCORRECT` | React can hard-block validation errors and retains general issues; Classic attaches only matching host-component ERROR/WARN and permits Continue Anyway |
+| `INST-5-003` | `PARTIAL` | Re-entry can recalculate, but stale-request ordering and dynamic service changes are not tested |
+| `INST-6-001` | `STATICALLY_ALIGNED` | Host/component matrix, All/None, required, and disabled selections exist |
+| `INST-6-002` | `STATICALLY_ALIGNED` | Master plus slave/client Blueprint and hidden required components are produced |
+| `INST-6-003` | `PARTIAL` | Server validation and Continue Anyway modal exist; exact general/host/component issue mapping needs coverage |
+| `INST-6-004` | `PARTIAL` | Persisted selections are consumed, but refresh/back recommendation preservation is not focused-tested |
+| `INST-7-001` | `PARTIAL` | Service/theme/category configuration exists; all stack control types and fallback themes remain |
+| `INST-7-002` | `PARTIAL` | Accounts and Credentials are dedicated; complete Database/Directory tab and validation semantics remain |
+| `INST-7-003` | `PARTIAL` | Recommendations, dependencies, and required values exist; rejection/required matrices remain |
+| `INST-7-004` | `PARTIAL` | Shared connection test paths exist; all conditional services and recovery remain |
+| `INST-7-005` | `PARTIAL` | Existing values/overrides are loaded for Add Service; host override/config-group parity is incomplete |
+| `INST-7-006` | `MISSING` | React has no `preInstallChecks`-gated placeholder modal matching Classic's shell |
+| `INST-7-007` | `PARTIAL` | Config-derived assignments are calculated, but Review Blueprint propagation lacks focused evidence |
+| `INST-7-008` | `PARTIAL` | Generic sidebar warning always claims data loss; it does not detect actual dirty configuration state |
+
+### Review, Deploy, and Summary
+
+| ID | Initial status | Classic behavior versus current React |
+| --- | --- | --- |
+| `INST-8-001` | `PARTIAL` | Review shows cluster, hosts, repositories, services, and assignments; complete config and expandable host detail are absent |
+| `INST-8-002` | `MISSING` | No Print Review action |
+| `INST-8-003` | `MISSING` | No Kerberos CSV prefetch/download for non-empty `kdc_type` |
+| `INST-8-004` | `MISSING` | No local Blueprint and cluster-template ZIP export |
+| `INST-8-005` | `PARTIAL` | New cluster queries and deletes all clusters; GET failure has no recoverable UI and locks Deploy |
+| `INST-8-008` | `PARTIAL` | Deletes are parallel and non-transactional; partial failures are not aggregated for explicit retry |
+| `INST-8-009` | `PARTIAL` | Definitions and repository versions are deleted; failure is only a rejected chain with no recovery presentation |
+| `INST-8-006` | `INCORRECT` | React does not implement the dependency-ordered abort-on-error serial queue and `createConfigurationGroups()` is empty |
+| `INST-8-007` | `INCORRECT` | Review loses the selected XML/URL source, posts a synthetic payload, and treats repository update failure differently |
+| `INST-9-001` | `INCORRECT` | The new-cluster start query is malformed, one poll starts with an empty request ID, and phase/check flags are inverted or incomplete |
+| `INST-9-002` | `PARTIAL` | Task modal exists, but lazy log loading returns when a task ID exists and there is no Classic copy/new-window parity |
+| `INST-9-003` | `PARTIAL` | Host status filters and failures exist; heartbeat and failed-master branches contain unsafe model-style calls on plain objects |
+| `INST-9-004` | `INCORRECT` | Retry can appear for failed hosts independent of exact `INSTALL FAILED`; Step 9 Next is always enabled, including active and failed new-cluster states |
+| `INST-9-005` | `MISSING` | React has no route blocker during Deploy |
+| `INST-9-006` | `INCORRECT` | Next does not persist `*_INSTALLED_4`, does not wait for persistence, and has no terminal-state gate |
+| `INST-10-001` | `PARTIAL` | Summary derives host/master/start results, but service-check and recovered-request fidelity remain incomplete |
+| `INST-10-003` | `STATICALLY_ALIGNED` | No Back entry is rendered on Summary |
+| `INST-10-002` | `PARTIAL` | New cluster writes provisioning `INSTALLED` and Add modes do not; React does not reset the Classic cluster state and blocks navigation on PUT failure instead of Classic `.complete()` |
+
+## Authoritative API Contract and Order
+
+All URLs are relative to `/api/v1`. Path values must be encoded at the segment
+boundary. Query expressions and payloads shown below are contract data, not
+display labels.
+
+### Selection, Bootstrap, and Validation
+
+| Order | Method and URL | Query/payload | React gap |
+| ---: | --- | --- | --- |
+| 1 | `GET /stacks` | None | React skips the explicit stack inventory |
+| 2 | `GET /version_definitions` | `fields=VersionDefinition/stack_default,...` and `VersionDefinition/show_available=true&VersionDefinition/stack_name={stackName}` | React hard-codes `VDP` and a cache-buster |
+| 3 | `GET /stacks/{stack}/versions/{version}` | `fields=operating_systems/repositories/Repositories` | React hard-codes `/stacks/VDP` |
+| 4a | `POST /version_definitions?dry_run=true` | XML body with `Content-Type: text/xml` | React adds `skip_url_check=true` and does not retain XML |
+| 4b | `POST /version_definitions?dry_run=true` | `{VersionDefinition:{version_url}}` JSON | React does not retain URL/source mode |
+| 5 | `PUT /stacks/{stack}/versions/{version}/operating_systems/{os}/repositories/{repo}` | `{Repositories:{base_url,repo_name,verify_base_url}}` | React validation uses POST `?validate_only=true`, then always submits `verify_base_url:true`; managed-repository semantics differ |
+| 6 | `GET /services/AMBARI/components/AMBARI_SERVER{fields}` | Ambari Java home, JDK location/version, and skip-check properties | Loaded in parts; Step 1 JDK compatibility is absent |
+| 7 | `POST /bootstrap` | `{verbose,sshKey,hosts,user,userRunAs,sshPort}`; HDPWIN retains automatic mode with empty SSH fields | Payload helper aligns for Add Host; new-cluster flag/Windows derivation is absent |
+| 8 | `GET /bootstrap/{requestId}` | Poll only after prior call settles; stop on unmount/step exit | Request ID/deadline is not persisted |
+| 9 | `GET /hosts?fields=Hosts/host_status` | Registration poll; 120 seconds automatic, 15 seconds manual | Static behavior aligns |
+| 10 | `POST /requests` | `RequestInfo.action=check_host`, check list and host resource filters | Implemented by `useHostChecks` |
+| 11 | `GET /requests/{requestId}` | Request status and host-check structured output fields | Implemented; complete parsing needs runtime acceptance |
+| 12 | `POST /requests` then `GET /requests/{id}` | Separate JDK check with `java_home`, `jdk_location`, and `java_home_check.exit_code` | Missing |
+| 13 | `POST {stackVersionUrl}/recommendations` | Hosts, services, Blueprint, bindings, and configuration properties according to step | Present across assignment/config screens; payload permutations need tests |
+| 14 | `POST {stackVersionUrl}/validations` | Current hosts/services/Blueprint/bindings | Present; Step 5 issue filtering differs |
+
+### Review Submission
+
+Classic writes the `*_DEPLOY_PREP_2` recovery checkpoint before this chain. A
+new-cluster submission then executes stages A through D; Add Host and Add
+Service skip destructive stage A and reuse only their applicable serial
+resources. React must expose a recoverable Review error and must never start the
+install mutation after a resource-stage rejection.
+
+| Stage | Method and URL | Payload/order | Concurrency and failure contract |
+| --- | --- | --- | --- |
+| A1 | `GET /clusters` | None | New cluster only; failure stops and unlocks React Review with Retry |
+| A2 | `DELETE /clusters/{clusterName}` for every item | None | Parallel batch; wait for all; aggregate failures; no rollback |
+| A3 | `GET /version_definitions` | None | Continue only after every cluster DELETE succeeds |
+| A4 | `DELETE /stacks/{stack}/versions/{version}/repository_versions/{id}` | One per definition | Parallel cleanup; wait for all; no rollback; React intentionally replaces Classic's silent lock with a visible retryable failure |
+| B1 | `POST /version_definitions` | Original XML body or `{VersionDefinition:{version_url}}`; no dry-run | Local repository only; source must be identical to the validated source |
+| B2 | `PUT /stacks/{stack}/versions/{version}/repository_versions/{id}` | `{operating_systems:[...]}` and `ambari_managed_repositories` | After B1; record but do not silently lose a failure |
+| C1 | `POST /clusters/{cluster}` | `{Clusters:{version:{stack-version-id}}}` | First abort-on-error serial resource |
+| C2 | `POST /clusters/{cluster}/services` | `[{ServiceInfo:{service_name,desired_repository_version_id}}]` | After cluster creation |
+| C3 | `POST /clusters/{cluster}/services?ServiceInfo/service_name={service}` | `{components:[{ServiceComponentInfo:{component_name}}]}` | One service at a time after C2 |
+| C4 | `POST /clusters/{cluster}/hosts` | Host array | After service/component resources |
+| C5 | `POST /clusters/{cluster}/hosts` | `{RequestInfo:{query},Body:{host_components:[...]}}` | One component association at a time |
+| C6 | `PUT /clusters/{cluster}` | Array of `{Clusters:{desired_config:[...]}}` | Configs before installation |
+| C7 | `POST /clusters/{cluster}/config_groups` or `PUT /clusters/{cluster}/config_groups/{id}` | Full group plus host membership payload | Required for created groups and Add Host selected existing groups |
+| C8 | `POST` or `PUT /clusters/{cluster}/artifacts/kerberos_descriptor` | `{Artifacts:{artifact_data}}` | Conditional Add Service Kerberos resource |
+| D | `PUT /clusters/{cluster}/services?...` or `/host_components?...` | Install desired state plus `RequestInfo.context/query` | Only after every applicable C resource succeeds; persist returned request ID before entering Deploy |
+
+### Deploy Polling and Completion
+
+| Phase | Method and URL | Termination and transition |
+| --- | --- | --- |
+| Install | `GET /clusters/{cluster}/requests/{requestId}?fields=tasks/...&minimal_response=true` | Serialized 3-second polling; `PENDING/QUEUED/IN_PROGRESS` continue; terminal failure becomes `INSTALL FAILED`; success launches the applicable start phase |
+| Host reconciliation | `GET /clusters/{cluster}/hosts?fields=Hosts/host_state,host_components/HostRoles/state` | Detect heartbeat loss and component completion before start |
+| Kerberos | Conditional keytab/principal mutation and returned request poll | Required between component creation/install and start for Kerberized Add Host/Add Service |
+| Start/check | `PUT /clusters/{cluster}/services?...params/run_smoke_test={boolean}` or host-component PUT | Persist the new request ID; terminal failure is `START FAILED`, not install retry |
+| Task detail | `GET /clusters/{cluster}/requests/{requestId}/tasks/{taskId}` | Lazy load stdout, stderr, structured output, and error log; failure leaves the popup retryable |
+| Completion checkpoint | Persist `CLUSTER_INSTALLED_4`, `ADD_HOSTS_INSTALLED_4`, or `ADD_SERVICES_INSTALLED_4` | Only terminal states enable Summary according to each wizard's Classic rules |
+| Final provisioning | `PUT /clusters/{cluster}` with `{Clusters:{provisioning_state:"INSTALLED"}}` | New cluster only; Add Host/Add Service must never send it |
+
+There are no Module 07 STOMP destinations in Classic. Installation progress is
+REST-polled. React must not depend on the global realtime connection to make a
+wizard reach a terminal state.
+
+## Permissions, Flags, and Runtime Conditions
+
+| Gate | New cluster | Add Host | Add Service | Required React boundary |
+| --- | --- | --- | --- | --- |
+| `AMBARI.ADD_DELETE_CLUSTERS` | Required | Not applicable | Not applicable | Entry and direct route guard; backend still authorizes mutations |
+| `HOST.ADD_DELETE_HOSTS` | Not applicable | Required | Not applicable | Menu, direct route, and every mutation boundary |
+| `SERVICE.ADD_DELETE_SERVICES` | Not applicable | Not applicable | Required | Menu, direct route, and every mutation boundary |
+| `supports.enableAddDeleteServices` | Not applicable | Not applicable | Required | UI and route, never a security substitute |
+| `supports.customizeAgentUserAccount` | Agent user shown/required only when enabled | Same | Not applicable | Use runtime supports; false forces `userRunAs=root` |
+| `supports.preInstallChecks` | Shows Classic placeholder only | Not reused | Not reused | New-cluster Step 7 only |
+| `supports.skipComponentStartAfterInstall` | Alters progress weights and omits start/check | Same core behavior | Same core behavior | Runtime branch in deploy state machine |
+| `CLUSTER.MANAGE_USER_PERSISTED_DATA` | Controls server persistence | Same | Same | Denied users must not silently write `/persist` |
+| Wizard owner | Claim during mutation workflow | Claim | Claim | Other users are non-wizard/read-only and cannot enter a competing flow |
+| Upgrade state | Blocks ordinary mutation when required | Blocks | Blocks | Route plus mutation guard, with server authorization |
+| Stack `HDPWIN` | PowerShell automatic bootstrap | PowerShell automatic bootstrap | Not applicable | Derived from selected/current stack, not a manual toggle |
+| Component metadata | Assignment and step presence | Slave/client eligibility | Filter and conditional step skips | Cardinality, master/slave/client, HA-only, dependencies, installable/installed flags |
+| Security/KDC | Initial configs may enable Kerberos later | KDC session before deploy | Descriptor, KDC type, CSV, and Manual responsibility | Failures block deploy and remain retryable |
+| HA prerequisites | Selected services/configs can establish HA topology | Existing HA topology limits eligible component changes | Added service may expose HA prerequisites | Advisor/validation and live topology decide eligibility; no extra HA wizard is embedded |
+
+React's authorization helpers correctly implement comma-separated OR behavior
+and global non-owner restrictions at the application level. Module 07 must use
+the semantic single permission at each entry; it must not reproduce Classic's
+unguarded Add Host deep link.
+
+## Asynchronous, Cancellation, and Recovery Matrix
+
+| Operation | Serialization/cancellation | Retry | Refresh and failure recovery |
+| --- | --- | --- | --- |
+| Persist state | One write at a time; a step transition waits for its destination checkpoint | Visible initialization Retry after load failure | Never overwrite a failed hydration with empty state; retain owner and actual active step |
+| Repository validation | All selected repositories may run concurrently; Next remains locked until all settle | Retry failed/all validations after edits | Preserve source, OS rows, per-repository result, skip flag, and managed mode |
+| Bootstrap | One POST; one non-overlapping GET loop; clear timer on Back/unmount | Selected failed hosts only; never retry RUNNING | Persist request ID/deadline/status/log; reconcile before starting a new POST |
+| Registration | One non-overlapping GET loop; clear timer on Back/unmount | Failed manual/automatic registration returns to the correct initial state | Resume remaining deadline and merge other registered Agents |
+| Host checks | Create one request and poll it serially; cancel local polling on exit | Rerun refreshes `last_agent_env`; Add Host skip bypasses generic checks only | Persist request ID/results; JDK remains independent |
+| Advisor/validation | Ignore stale responses after stack/service/assignment change | Retry with current Blueprint | Preserve manual choices; never apply an older response over newer state |
+| Review cleanup | Cluster DELETEs concurrent within batch; version DELETEs concurrent within batch; stages are serial | Explicit stage-level Retry with partial-success disclosure | Do not repeat successful destructive work blindly; reconcile current server resources |
+| Resource creation | Strict serial, abort on first error | Rebuild queue from current server/client state; created resources are not rolled back | Show failed resource and retain Review controls; never auto-install after failure |
+| Add Host config group | Must finish before install, correcting Classic fire-and-forget behavior | Retry update without duplicating component resources | Re-read group membership before continuing |
+| Install/start/check | One request poll at a time; stop all timers on unmount | Install Retry only for `INSTALL FAILED`; no start retry is invented | Resume persisted request; reconcile server terminal state before any mutation |
+| Logs | Lazy task request; cancel display update after unmount | Popup can retry failed task detail | Previously loaded logs remain available; current task identity persists |
+| Cancel before Review | Confirm once and clear only the current wizard according to accepted React ownership policy | Retry persistence cleanup if it fails | Do not navigate until the cleanup result is known |
+| Cancel during Deploy | Navigation is blocked except explicitly allowed Classic destinations | Not a cancellation of server work | Refresh returns to Deploy and current request rather than starting a new request |
+| Complete | Idempotent state cleanup after final provisioning boundary | A visible failure remains actionable | Add modes refresh existing cluster; new cluster enters Dashboard only after the selected provisioning policy |
+
+## Five-Pass Cross-Check
+
+| Pass | Independent inputs | Findings that determine implementation |
+| --- | --- | --- |
+| 1. Routes, pages, controls, navigation | Classic router/three route files/templates; React `RoutesList`, menus, StepWizard and footers | Installer and Add Host direct routes are unguarded; URL step input is overwritten by local active state; common sidebar click ignores `canJumpFromCurrentStep`; Deploy lacks a route blocker |
+| 2. Controller/service/model state | Classic installer/add controllers, persist and watcher; three React providers/reducers | Only Add Host serializes same-event checkpoints; new cluster can overwrite failed hydration; Add Service closes over stale state; no provider claims `wizard-data`; Classic server-state mappings are absent |
+| 3. API definitions, calls, order | All five generated network inventories plus Classic AJAX registry/callers and React APIs | `VDP` is hard-coded; VDF source is lost; no separate JDK check; Review is not serial/abort-on-error; config-group creation is empty; Deploy uses an empty request ID and malformed start query |
+| 4. Modes, permissions, flags | Generated permission/flag inventories, `13-permissions-flags.md`, stack metadata and React AppContext | Add Service gate is present; Installer/Add Host route gates are absent; new cluster misses HDPWIN/support wiring; Add Service step skips and KDC type/CSV/Manual branches are absent |
+| 5. Error, retry, refresh, back, interruption, tests | Classic tests and route/controller error paths; React Vitest inventory and error handlers | Focused tests cover Add Host persistence/deploy and registration serialization only; no Step 1, Review queue, Step 9, route gate, new-cluster persistence, Add Service recovery, or completion-state tests exist |
+
+The Ember baseline validator passed with 1,002 feature IDs, 288 non-Metrics AJAX
+definitions, 394 AJAX call sites, 19 direct HTTP calls, 56 browser entry points,
+38 permissions, 23 flags, 160 route fragments, and no warnings or errors. No
+new conflict between the written Module 07 baseline and executable Classic
+source was found, so this audit does not edit the frozen baseline or generated
+evidence.
+
+## Executable Acceptance Criteria
+
+1. Route tests prove Installer requires `AMBARI.ADD_DELETE_CLUSTERS`, Add Host
+   requires `HOST.ADD_DELETE_HOSTS`, Add Service requires its permission and
+   flag, and all three reject a conflicting non-owner or upgrade workflow.
+2. State-provider tests prove hydration failure cannot write empty state,
+   same-event transitions persist the destination step and dispatched data,
+   writes are serialized, Cancel/Complete clear only owned keys, and refresh
+   maps each server checkpoint to the intended actual step.
+3. Version API tests assert dynamic stack names, exact fields/query parameters,
+   XML versus URL dry-run payloads, retained source for non-dry-run POST,
+   managed-repository flags, URL validation, and JDK acceptance.
+4. Install Options and Confirm Hosts tests cover Linux SSH, HDPWIN PowerShell,
+   manual Agent, customized/default Agent user, pattern/installed/suspicious
+   hosts, automatic/manual timeout, bootstrap POST failure, serialized polling,
+   selected retry/remove, Add Host skip, JDK results, and unmount cleanup.
+5. Service, master, slave/client, and config tests cover dependencies,
+   filesystem conflicts, cardinality, conditional Add Service step skips,
+   matching validation issue filtering, Continue Anyway, manual choices after
+   Back/refresh, required/dependent configs, external tests, and dirty Back.
+6. Review tests assert Print, Blueprint ZIP, applicable Kerberos CSV/Manual
+   confirmation, destructive cleanup batches, retained VDF source, exact serial
+   resource order, abort on first failure, no install handoff on failure,
+   partial-success Retry, config groups, and Kerberos descriptor ordering.
+7. Deploy tests use fake timers and deferred promises to prove one poll at a
+   time, request-ID persistence, no empty request, install/start/check phase
+   transitions, support-flag branches, exact Retry visibility, task log detail,
+   route blocking, unmount cancellation, and terminal-only Summary.
+8. Summary tests prove no Back, correct service/host outcomes, new-cluster-only
+   provisioning PUT, idempotent cleanup, Add Host/Add Service refresh, and
+   recoverable completion failure.
+9. `npm test`, focused Vitest commands, `npm run build`, baseline validation,
+   `git diff --check`, and whitespace checks pass from the worktree.
+
+## Runtime Acceptance Matrix
+
+No Feature ID may be changed to `COVERED` from static evidence alone. Capture
+browser Network requests, persisted values, server cluster status, request/task
+IDs, and screenshots for each scenario.
+
+| Scenario | Variants | Breakpoints and expected recovery | Feature IDs |
+| --- | --- | --- | --- |
+| New cluster repository | Public; Local XML; Local URL; Satellite; skip validation; incompatible JDK | Network loss before/after dry-run, one invalid repository, VDF POST failure, repository PUT failure, refresh on Step 1/8 | `INST-MODE-001`, `INST-MODE-004` through `006`, `INST-1-*`, `INST-8-007` |
+| Host onboarding | Linux SSH; manual Agent; HDPWIN PowerShell; customized/default Agent user | Bootstrap POST failure, mid-poll refresh, one failed host, timeout, other Agent, remove/retry, Back/unmount | `INST-MODE-007`, `008`, `011`, `INST-2-*`, `INST-3-*` |
+| Host checks | New cluster; Add Host regular; Add Host skip | Generic check create/poll failure, JDK failure, repository/disk/THP warning, rerun, refresh | `INST-2-005`, `INST-3-006`, `007` |
+| Service selection | HDFS-compatible filesystem; multiple DFS; Ozone/Spark; Ranger dependencies; service with no masters/slaves/configs | Accept WARNING, reject CRITICAL, Back and change selection, refresh each assignment step | `INST-4-*`, `INST-5-*`, `INST-6-*` |
+| Config customization | Accounts; credentials; database; directories; required/dependent values; override/config group | Advisor failure, DB test failure/retry, dirty Back, dynamic component change, refresh | `INST-7-*` |
+| New-cluster cleanup | Zero/one/multiple existing clusters and version definitions | GET failure, one parallel DELETE failure, partial deletion, refresh and Retry | `INST-8-005`, `008`, `009` |
+| Resource creation | Minimal stack and multi-service stack | Failure at every serial resource stage, partial prior success, refresh, resubmit without duplicate install | `INST-8-006` |
+| Add Host | Component hosts; client-only; no component; default/non-default config groups | Group PUT failure, install failure/retry, start failure, Kerberos keytab failure, refresh in every phase | `INST-MODE-002`, `009`, all reused IDs |
+| Add Service | Master-only; slave/client-only; config-free; all steps | Conditional skips, descriptor create/update failure, each KDC type, CSV, Manual acknowledgment, install/start failure, refresh | `INST-MODE-003`, `010`, all reused IDs |
+| Deploy | Service checks on/off; `skipComponentStartAfterInstall` true/false | Install poll 403/500/network recovery, task failure, heartbeat loss, task log failure, route attempt, browser refresh | `INST-9-*` |
+| Completion | Success; warnings; install failure; start failure; provisioning PUT failure | Refresh before Complete, double click, failed cleanup, dashboard/Hosts refresh | `INST-10-*` |
+| RBAC/ownership | Ambari admin, cluster admin without Ambari permission, host/service operator, read-only, View-only, current owner, different user | Direct deep links and direct mutations; upgrade active/suspended; second browser window | `INST-ENTRY-*`, `INST-FLOW-*` |
+| Scale and concurrency | 1, 50, and environment-maximum hosts; many services/repositories | Slow responses longer than poll interval, large GET override behavior, browser reload, server restart | `INST-FLOW-005`, `INST-3-*`, `INST-8-*`, `INST-9-*` |
+
+## Issue and PR Scope
+
+Module 07 uses one ASF JIRA, one branch named with that JIRA key, and one pull
+request against `apache/ambari:frontend-refactor`. It will not edit Module 05,
+Module 06, or any other module's gap document or implementation. Shared router,
+wizard, API, and application-state files may receive only the minimum changes
+needed to enforce Module 07 contracts, and those changes must be listed in the
+pull request.

--- a/docs/frontend-refactor/react-current/07-cluster-installation-gap.md
+++ b/docs/frontend-refactor/react-current/07-cluster-installation-gap.md
@@ -22,7 +22,7 @@
 | Item | Value |
 | --- | --- |
 | Ember baseline | `ember-baseline/07-cluster-installation.md` |
-| React implementation | `ambari-web/latest`, Module 07 based on `4fb6dadf190007b831fdd2d08a9a9c6431b252b9` |
+| React implementation | `ambari-web/latest`, Module 07 implemented on `AMBARI-26629` from `4fb6dadf190007b831fdd2d08a9a9c6431b252b9` |
 | Feature IDs | 79 IDs from `INST-MODE-001` through `INST-10-002` |
 | Review date | 2026-08-17 |
 | Deployment modes | New cluster, Add Host, and Add Service |
@@ -35,71 +35,72 @@ to locate candidates. The authoritative network review combined AJAX
 definitions, AJAX call sites, direct HTTP, browser entry points, and realtime
 channels.
 
-## Initial Static Conclusion
+## Post-Implementation Static Conclusion
 
 | Status | Meaning | Count |
 | --- | --- | ---: |
-| `STATICALLY_ALIGNED` | The reviewed React path matches the static Classic contract but still requires live acceptance | 13 |
-| `PARTIAL` | A user-reachable path exists, but a condition, payload, branch, recovery path, or test is incomplete | 40 |
-| `INCORRECT` | React can issue a wrong request, transition at the wrong time, or expose a materially different result | 14 |
-| `MISSING` | No user-reachable implementation exists for the Feature ID | 12 |
+| `STATICALLY_ALIGNED` | The reviewed React path matches the static Classic contract but still requires live acceptance | 51 |
+| `PARTIAL` | A user-reachable path exists, but a condition, payload, branch, recovery path, or test is incomplete | 28 |
+| `INCORRECT` | React can issue a wrong request, transition at the wrong time, or expose a materially different result | 0 |
+| `MISSING` | No user-reachable implementation exists for the Feature ID | 0 |
 | Total |  | 79 |
 
-The highest-risk gap is Review deployment. Classic uses an abort-on-error serial
-resource queue after destructive cleanup. React starts a mixture of already
-running promises and delayed requests, converts several rejected mutations into
-successful promise settlement, has an empty config-group creation function, and
-can invoke the install phase after an incomplete resource graph. New-cluster
-version APIs are also hard-coded to `VDP`, and Deploy permits Summary while work
-is still active.
+The confirmed destructive gaps were implemented. Review now checkpoints and
+runs an abort-on-error deployment plan, persists completed operation IDs for
+retry, retains the validated VDF source, synchronizes configuration groups, and
+stores the install request before navigation. Deploy owns a single phase and
+request, serializes polling, restores persisted work, blocks navigation while
+active, and gates Retry and Summary by terminal status. Remaining partial items
+are primarily stack-dependent validation/configuration permutations, detailed
+host reconciliation and task-log ergonomics, and behavior that requires the
+runtime matrix below.
 
 ## Complete Wizard State Machines
 
 ### New Cluster
 
-| State | Forward condition and side effects | Back/cancel condition | Recovery contract | Initial React result |
+| State | Forward condition and side effects | Back/cancel condition | Recovery contract | Current React result |
 | --- | --- | --- | --- | --- |
-| 0 Name | Valid name and at least one installable stack; store name, then enter Version | Cancel confirms and navigates to Admin View | `CLUSTER_CURRENT` plus `CLUSTER_STATE.stepName=NAME` | Name validation exists; stack availability is not a Step 0 gate |
-| 1 Version | Visible version definition selected; repository rows syntactically valid; URL checks pass or are explicitly skipped; JDK warning accepted; persist VDF source and repository edits | Back clears Version and all downstream state | Restore stack, definition, repository source, OS rows, validation result, and flags | State restores, but APIs are `VDP`-specific, JDK validation is absent, and VDF source is lost |
-| 2 Install Options | At least one new normalized host; automatic mode has required credentials; suspicious or installed hosts are explicitly accepted | Back clears hosts and downstream state | Restore normalized hosts and registration mode without replaying a mutation | Linux SSH/manual paths exist; new-cluster HDPWIN and support-derived Agent user are absent |
-| 3 Confirm Hosts | At least one `REGISTERED` host; bootstrap/registration has settled; generic warnings accepted | Back stops timers; remove/retry affects only selected local wizard hosts | Restore request ID, host states/logs, registration deadline, check request, and results | Timers stop on unmount, but active bootstrap/check identity is not persisted and refresh can replay work |
+| 0 Name | Valid name and at least one installable stack; store name, then enter Version | Cancel confirms and navigates to Admin View | `CLUSTER_CURRENT` plus `CLUSTER_STATE.stepName=NAME` | Name validation and persistence-before-navigation align; stack availability is resolved on Version |
+| 1 Version | Visible version definition selected; repository rows syntactically valid; URL checks pass or are explicitly skipped; JDK warning accepted; persist VDF source and repository edits | Back clears Version and all downstream state | Restore stack, definition, repository source, OS rows, validation result, and flags | Dynamic stack APIs, Public defaults, VDF retention, Satellite, and JDK acceptance are implemented and focused-tested |
+| 2 Install Options | At least one new normalized host; automatic mode has required credentials; suspicious or installed hosts are explicitly accepted | Back clears hosts and downstream state | Restore normalized hosts and registration mode without replaying a mutation | Linux SSH, manual Agent, HDPWIN, and support-derived Agent user branches are implemented |
+| 3 Confirm Hosts | At least one `REGISTERED` host; bootstrap/registration has settled; generic warnings accepted | Back stops timers; remove/retry affects only selected local wizard hosts | Restore request ID, host states/logs, registration deadline, check request, and results | Bootstrap request/deadline and host-check recovery are persisted; generic and independent JDK checks remain separate |
 | 4 Services | At least one installable non-Metrics service; CRITICAL dependency/filesystem conflicts fixed; WARNING accepted | Back returns to hosts; change clears assignments/configs | Restore selection and accepted warnings | Service selection exists; complete stack-specific validation evidence is absent |
-| 5 Masters | Advisor result loaded; assignment is cardinality-valid; current matching WARN/ERROR explicitly accepted | Back clears master and later data | Restore recommendation and manual moves; recalculate after service changes | Advisor and validation exist; React hard-blocks some server errors and adds non-metadata placement rules |
+| 5 Masters | Advisor result loaded; assignment is cardinality-valid; current matching WARN/ERROR explicitly accepted | Back clears master and later data | Restore recommendation and manual moves; recalculate after service changes | Matching non-installed component issues and Continue Anyway align; React still adds non-metadata placement rules |
 | 6 Slaves/Clients | Required matrix selection valid; server mapping WARN/ERROR explicitly accepted | Back preserves master assignments and clears later data | Restore matrix, hidden components, and accepted validation | Core matrix and validation exist; restoration and dependency permutations are incomplete |
-| 7 Configs | Required values valid; required recommendations applied; dependent changes accepted; external tests pass or are consciously retried | Dirty Back confirms discard | Restore tabs, values, overrides, recommendations, validation, and dynamic assignments | Main config surface exists; pre-install shell, complete overrides, and dirty-state behavior are incomplete |
-| 8 Review | Checkpoint `CLUSTER_DEPLOY_PREP_2`; complete destructive cleanup; non-dry-run VDF; abort-on-error serial resource queue; install request accepted | Back enabled only before successful submission; failures reopen Back/Deploy without rollback | Persist checkpoint and completed resource/request identity | Cleanup exists, but the creation order and failure accounting are incorrect |
-| 9 Deploy | Install terminal; optionally start/check terminal; only defined terminal states enable Next; write `CLUSTER_INSTALLED_4` | No ordinary Back; only Classic Admin View/Views route exceptions; Retry only `INSTALL FAILED` | Resume current request and phase from server state and persisted request IDs | Polling/request identity, Next gating, route blocking, and completion checkpoint are incorrect or missing |
-| 10 Summary | Complete attempts provisioning `INSTALLED`, clears wizard and cluster state, then enters Dashboard | No reachable Back; Cancel is not a second completion path | Restore static summary at `CLUSTER_INSTALLED_4` | Summary exists; provisioning failure and cluster-state reset semantics differ |
+| 7 Configs | Required values valid; required recommendations applied; dependent changes accepted; external tests pass or are consciously retried | Dirty Back confirms discard | Restore tabs, values, overrides, recommendations, validation, and dynamic assignments | Main config surface and support-gated Pre Install Checks shell exist; complete overrides and dirty-state behavior remain partial |
+| 8 Review | Checkpoint `CLUSTER_DEPLOY_PREP_2`; complete destructive cleanup; non-dry-run VDF; abort-on-error serial resource queue; install request accepted | Back enabled only before successful submission; failures reopen Back/Deploy without rollback | Persist checkpoint and completed resource/request identity | Serial abort-on-error preparation, retry checkpoints, config groups, Print, Blueprint ZIP, and VDF retention are implemented |
+| 9 Deploy | Install terminal; optionally start/check terminal; only defined terminal states enable Next; write `CLUSTER_INSTALLED_4` | No ordinary Back; only Classic Admin View/Views route exceptions; Retry only `INSTALL FAILED` | Resume current request and phase from server state and persisted request IDs | Phase/request recovery, serialized polling, exact Retry, route blocking, terminal gating, and checkpoints are implemented |
+| 10 Summary | Complete attempts provisioning `INSTALLED`, clears wizard and cluster state, then enters Dashboard | No reachable Back; Cancel is not a second completion path | Restore static summary at `CLUSTER_INSTALLED_4` | New-cluster-only provisioning and retryable completion cleanup are implemented |
 
 ### Add Host
 
-| Step | Forward condition and branch | Back/cancel and recovery | Initial React result |
+| Step | Forward condition and branch | Back/cancel and recovery | Current React result |
 | --- | --- | --- | --- |
-| 1 Install Options | Same Linux SSH, HDPWIN PowerShell, and manual paths as new cluster; optional Classic `Skip host checks` | No Back; cancel clears Add Host state; resume from `ADD_HOST` | Modes and serialized persistence exist; Skip Host Checks is missing |
-| 2 Confirm Hosts | Registration/check rules from core Step 3 | Back stops polling; resume host/check request state | Registration is shared, but in-flight bootstrap/check recovery is incomplete |
+| 1 Install Options | Same Linux SSH, HDPWIN PowerShell, and manual paths as new cluster; optional Classic `Skip host checks` | No Back; cancel clears Add Host state; resume from `ADD_HOST` | Modes, Skip Host Checks, and serialized persistence are implemented |
+| 2 Confirm Hosts | Registration/check rules from core Step 3 | Back stops polling; resume host/check request state | Registration, bootstrap/check recovery, and independent JDK checks are shared |
 | 3 Slaves/Clients | Assign only slave/client components to new hosts; client-only/no-component is valid | Back preserves registered hosts | Core matrix is reused and covered by focused Add Host utility tests |
 | 4 Config Groups | Skip automatically when no selected component; otherwise choose existing/default groups by affected service | Back to assignments; persist exact group choice | Dedicated React page and persisted selection exist |
 | 5 Review | Write `ADD_HOSTS_DEPLOY_PREP_2`; register hosts/components; apply full config-group memberships; obtain KDC session before install | Resource/config-group failure remains retryable on Review | Dedicated React deployment is serial and tested; KDC/real-cluster behavior remains conditional |
 | 6 Deploy | Poll install, optional keytab regeneration, start selected non-client components; Retry failed phase | No Back; persist phase/request; Add Host may proceed after terminal install failure | Dedicated React flow persists phase/request and is focused-tested |
 | 7 Summary | Show host/task outcome; clear Add Host state; refresh Hosts; never write cluster provisioning state | No Back | Dedicated React summary follows this boundary |
 
-Classic server-state mappings are intentionally recorded for runtime tests:
+Classic server-state mappings are implemented and retained for runtime tests:
 `ADD_HOSTS_DEPLOY_PREP_2 -> Step 4`, `ADD_HOSTS_INSTALLING_3` and
 `SERVICE_STARTING_3 -> Step 5`, and `ADD_HOSTS_INSTALLED_4 -> Step 6`. React
-currently restores its own `ADD_HOST.activeStep`; it does not independently map
-these Classic server states.
+restores both its serialized active step and these Classic server states.
 
 ### Add Service
 
-| Step | Forward condition and conditional skip | Back/cancel and recovery | Initial React result |
+| Step | Forward condition and conditional skip | Back/cancel and recovery | Current React result |
 | --- | --- | --- | --- |
 | 1 Services | Show only uninstalled/installable services and enforce dependencies | No Back; cancel owns `ADD_SERVICE` cleanup | Selection filtering exists |
-| 2 Masters | Skip when selected services have no assignable masters | Back to Services | React always enters this step |
-| 3 Slaves/Clients | Skip when selected services have no slave/client components | Back to last applicable step | React always enters this step |
-| 4 Configs | Skip when no selected service config is required; on Kerberos, validate/update descriptor | Back to last applicable assignment step | React always enters; descriptor handling is incomplete |
-| 5 Review | Write `ADD_SERVICES_DEPLOY_PREP_2`; show Manual KDC responsibility; offer CSV for every non-empty `kdc_type`; create service resources serially | Failure reopens Review; persist completed boundary | CSV/manual confirmation are missing and the shared queue is incorrect |
-| 6 Deploy | Install/start/check only added services; Retry `INSTALL FAILED`; persist request IDs | No Back; terminal states only | Shared Step 9 has request, polling, and Next defects |
-| 7 Summary | Show results; clear Add Service state; refresh cluster; never write provisioning state | No Back | Provisioning boundary is correct; summary/recovery remains partial |
+| 2 Masters | Skip when selected services have no assignable masters | Back to Services | Metadata-derived conditional navigation is implemented and tested |
+| 3 Slaves/Clients | Skip when selected services have no slave/client components | Back to last applicable step | Metadata-derived conditional navigation is implemented and tested |
+| 4 Configs | Skip when no selected service config is required; on Kerberos, validate/update descriptor | Back to last applicable assignment step | Config skipping and secure descriptor value propagation are implemented |
+| 5 Review | Write `ADD_SERVICES_DEPLOY_PREP_2`; show Manual KDC responsibility; offer CSV for every non-empty `kdc_type`; create service resources serially | Failure reopens Review; persist completed boundary | Real KDC type, descriptor POST/PUT, CSV, Manual responsibility, and serial retry are implemented and tested |
+| 6 Deploy | Install/start/check only added services; Retry `INSTALL FAILED`; persist request IDs | No Back; terminal states only | Shared phase/request state machine owns polling, retry, and recovery |
+| 7 Summary | Show results; clear Add Service state; refresh cluster; never write provisioning state | No Back | Add Service clears only its state and never writes provisioning state |
 
 Classic maps `ADD_SERVICES_DEPLOY_PREP_2 -> Step 5`, and all of
 `ADD_SERVICES_INSTALLING_3`, `SERVICE_STARTING_3`, and
@@ -111,67 +112,67 @@ must reconcile the active server request before presenting completion.
 
 ### Modes, Entries, and Recovery
 
-| ID | Initial status | Classic behavior versus current React |
+| ID | Current status | Classic behavior versus current React |
 | --- | --- | --- |
 | `INST-MODE-001` | `PARTIAL` | Eleven-step new-cluster UI exists, but version selection, Review ordering, Deploy recovery, and final state are not equivalent |
-| `INST-MODE-002` | `PARTIAL` | Seven-step Add Host is substantially implemented; Skip Host Checks and server-state mapping remain |
-| `INST-MODE-003` | `PARTIAL` | Seven-step Add Service exists; conditional step skipping, complete Kerberos branch, deploy queue, and recovery remain |
-| `INST-MODE-004` | `INCORRECT` | Public Repository exists, but React initially selects Local, loads blank OS URLs through hard-coded `VDP`, and lacks the JDK branch |
-| `INST-MODE-005` | `INCORRECT` | XML dry-run exists, but raw XML/source metadata is not retained for the required non-dry-run Review POST |
-| `INST-MODE-006` | `INCORRECT` | URL dry-run exists, but Review posts a synthetic `VersionDefinition.available` payload instead of the retained URL source |
-| `INST-MODE-007` | `PARTIAL` | Linux bootstrap fields and payload helper exist; new-cluster support flag wiring and refresh recovery are incomplete |
-| `INST-MODE-008` | `PARTIAL` | Manual mode skips bootstrap and uses the 15-second timeout; in-flight recovery remains incomplete |
-| `INST-MODE-009` | `PARTIAL` | Dedicated Add Host install can regenerate keytabs, but KDC session/runtime prerequisites need live acceptance |
-| `INST-MODE-010` | `PARTIAL` | Add Service reads security and descriptor data, but KDC type, CSV, Manual responsibility, and blocking error behavior are incomplete |
-| `INST-MODE-011` | `PARTIAL` | Add Host derives HDPWIN and sends automatic bootstrap; new-cluster Step 2 never derives HDPWIN from the selected stack |
-| `INST-ENTRY-001` | `MISSING` | `/installer/:stepNumber` has no `AMBARI.ADD_DELETE_CLUSTERS` route guard |
+| `INST-MODE-002` | `STATICALLY_ALIGNED` | Add Host implements conditional host checks, checkpoints, serial preparation, phased deployment, retry, and owned completion |
+| `INST-MODE-003` | `PARTIAL` | Add Service conditional navigation, Kerberos, deployment, and recovery are implemented; shared stack-specific config permutations remain |
+| `INST-MODE-004` | `STATICALLY_ALIGNED` | Public Repository is the default, dynamic stack APIs preserve server URLs, and incompatible JDKs require explicit acceptance |
+| `INST-MODE-005` | `STATICALLY_ALIGNED` | XML dry-run retains the exact body and content type for the non-dry-run Review POST |
+| `INST-MODE-006` | `STATICALLY_ALIGNED` | URL dry-run retains the exact `VersionDefinition.version_url` payload for Review |
+| `INST-MODE-007` | `STATICALLY_ALIGNED` | Linux bootstrap uses runtime Agent-user support and persists request/deadline state for refresh |
+| `INST-MODE-008` | `STATICALLY_ALIGNED` | Manual mode skips bootstrap, uses the shorter deadline, and restores registration/check state |
+| `INST-MODE-009` | `STATICALLY_ALIGNED` | Add Host waits for the KDC session and runs keytab regeneration as a persisted deployment phase |
+| `INST-MODE-010` | `STATICALLY_ALIGNED` | Add Service loads real `kdc_type`, validates and POSTs/PUTs the descriptor, prefetches CSV, and exposes Manual ownership |
+| `INST-MODE-011` | `STATICALLY_ALIGNED` | Both new-cluster and Add Host derive HDPWIN from stack state and retain automatic PowerShell bootstrap semantics |
+| `INST-ENTRY-001` | `STATICALLY_ALIGNED` | `/installer/:stepNumber` requires `AMBARI.ADD_DELETE_CLUSTERS` and passes the active-operation guard |
 | `INST-ENTRY-002` | `STATICALLY_ALIGNED` | Add Service route has feature, permission, and operation guards |
-| `INST-ENTRY-003` | `PARTIAL` | Host list hides Add Host without permission, but the direct React route has no authorization or operation guard |
+| `INST-ENTRY-003` | `STATICALLY_ALIGNED` | Add Host direct entry requires `HOST.ADD_DELETE_HOSTS` and passes the active-operation guard |
 | `INST-FLOW-001` | `PARTIAL` | Landing can select Installer and local persisted step can restore; complete provisioning-state routing is not reconciled here |
-| `INST-FLOW-002` | `INCORRECT` | New-cluster and Add Service step changes do not await persistence and can write a stale pre-dispatch snapshot |
-| `INST-FLOW-003` | `MISSING` | React does not map `wizardControllerName` plus Classic cluster states to all three actual recovery steps |
-| `INST-FLOW-004` | `INCORRECT` | React Cancel clears persisted wizard state before Admin View, while Classic Cancel only navigates and retains recovery state |
-| `INST-FLOW-005` | `MISSING` | Common Back/Next controls have no in-flight click lock and handlers commonly advance before persistence settles |
-| `INST-FLOW-006` | `MISSING` | AppContext reads `wizard-data`, but installation providers never claim/release it; multi-window ownership is therefore not complete |
+| `INST-FLOW-002` | `STATICALLY_ALIGNED` | Providers synchronously update state snapshots, serialize writes, and handlers await destination persistence before navigation |
+| `INST-FLOW-003` | `STATICALLY_ALIGNED` | All three providers map Classic deployment checkpoints to their actual React Deploy or Summary steps |
+| `INST-FLOW-004` | `PARTIAL` | Cancel serializes owned cleanup before navigation; this accepted React ownership policy intentionally differs from Classic retention |
+| `INST-FLOW-005` | `PARTIAL` | Persistence and deployment handlers lock or await transitions, but a single generic footer-level double-click lock is not yet universal |
+| `INST-FLOW-006` | `STATICALLY_ALIGNED` | Installation providers claim and release their Classic-compatible wizard owner names and reject conflicting operation entry |
 
 ### Steps 0 Through 3
 
-| ID | Initial status | Classic behavior versus current React |
+| ID | Current status | Classic behavior versus current React |
 | --- | --- | --- |
 | `INST-0-001` | `STATICALLY_ALIGNED` | Name required, length, whitespace, and special-character validation exist |
 | `INST-0-002` | `PARTIAL` | Version definitions load in Step 1 rather than stacks in Step 0; load failure has no focused recovery UI |
-| `INST-1-001` | `INCORRECT` | React filters through the API but hard-codes `stack_name=VDP` and does not safely handle an empty definition set |
-| `INST-1-002` | `PARTIAL` | Public/Local controls and network warning exist; initial selection/default repository population differs |
-| `INST-1-003` | `INCORRECT` | File/URL dry-run UI exists, but source type/content is not retained for Review submission |
+| `INST-1-001` | `STATICALLY_ALIGNED` | React queries definitions and operating systems with the selected stack and returns to Name on an empty or failed inventory |
+| `INST-1-002` | `STATICALLY_ALIGNED` | Public/Local controls, Public default, server repository URLs, and network warning align statically |
+| `INST-1-003` | `STATICALLY_ALIGNED` | File and URL dry-run source type, payload, and headers persist through Review submission |
 | `INST-1-004` | `PARTIAL` | Edit/add/remove/restore and syntax validation exist; uniqueness, autocomplete, and server contract are incomplete |
 | `INST-1-005` | `PARTIAL` | Next can rerun validation, but there is no explicit failed-repository Retry lifecycle |
-| `INST-1-006` | `MISSING` | No Ambari Server JDK versus `min_jdk`/`max_jdk` warning and Proceed Anyway branch |
-| `INST-1-007` | `INCORRECT` | Satellite toggle exists, but repository submission still sends `verify_base_url=true` and control locking differs |
+| `INST-1-006` | `STATICALLY_ALIGNED` | Ambari Server JDK is compared with inclusive stack ranges and an explicit Proceed Anyway branch |
+| `INST-1-007` | `STATICALLY_ALIGNED` | Satellite disables URL verification and produces unmanaged operating-system repository payloads |
 | `INST-2-001` | `STATICALLY_ALIGNED` | Input is lowercased, whitespace-split, pattern-expanded, deduplicated, and installed hosts are filtered |
-| `INST-2-002` | `PARTIAL` | SSH fields validate, but new-cluster Agent user does not consume `customizeAgentUserAccount` |
+| `INST-2-002` | `STATICALLY_ALIGNED` | SSH fields validate and Agent user visibility/defaults consume `customizeAgentUserAccount` |
 | `INST-2-003` | `STATICALLY_ALIGNED` | Manual instructions, no bootstrap, and registration-only wait exist |
 | `INST-2-004` | `STATICALLY_ALIGNED` | Suspicious FQDN and mixed installed-host confirmations exist |
-| `INST-2-005` | `MISSING` | Add Host has no Skip Host Checks checkbox or independent-JDK boundary |
-| `INST-3-001` | `PARTIAL` | Bootstrap POST and serialized 3-second polling exist with timer cleanup; request identity is not persisted for refresh |
+| `INST-2-005` | `STATICALLY_ALIGNED` | Add Host persists Skip Host Checks, confirms the risk, and still runs the independent JDK boundary |
+| `INST-3-001` | `STATICALLY_ALIGNED` | Bootstrap request ID, host states, registration deadline, serialized polling, and cleanup persist across refresh |
 | `INST-3-002` | `STATICALLY_ALIGNED` | Registration poll is serialized and uses 120-second automatic/15-second manual timeouts |
 | `INST-3-003` | `STATICALLY_ALIGNED` | Status filters and read-only bootstrap logs exist |
 | `INST-3-004` | `PARTIAL` | Retry resets all failed hosts; selected-subset retry and refresh continuity are absent |
 | `INST-3-005` | `STATICALLY_ALIGNED` | Removal is local only and at least one registered host gates Next |
 | `INST-3-006` | `PARTIAL` | Preinstalled request/task polling and warning parsing exist; complete category and warning-acceptance parity needs tests |
-| `INST-3-007` | `MISSING` | No separate `/requests` JDK check and result phase parses `java_home_check.exit_code` |
+| `INST-3-007` | `STATICALLY_ALIGNED` | A separate custom-JDK `/requests` action is polled and `java_home_check.exit_code` is parsed per host |
 | `INST-3-008` | `STATICALLY_ALIGNED` | Other registered Agents are discovered and can be included |
 
 ### Steps 4 Through 7
 
-| ID | Initial status | Classic behavior versus current React |
+| ID | Current status | Classic behavior versus current React |
 | --- | --- | --- |
 | `INST-4-001` | `PARTIAL` | Installable service list and selection exist; complete filesystem grouping and cancel behavior remain |
 | `INST-4-002` | `PARTIAL` | Required-service prompts exist; transitive and already-installed dependency cases lack focused evidence |
 | `INST-4-003` | `PARTIAL` | Several filesystem/service conflicts are checked; the complete stack-conditional matrix remains |
 | `INST-4-004` | `STATICALLY_ALIGNED` | Choose Services validation remains client-side and does not invent Advisor validation |
 | `INST-5-001` | `PARTIAL` | Advisor recommendations load, but React adds a hard-coded ZooKeeper placement and assumes response topology |
-| `INST-5-002` | `INCORRECT` | React can hard-block validation errors and retains general issues; Classic attaches only matching host-component ERROR/WARN and permits Continue Anyway |
-| `INST-5-003` | `PARTIAL` | Re-entry can recalculate, but stale-request ordering and dynamic service changes are not tested |
+| `INST-5-002` | `STATICALLY_ALIGNED` | React attaches only matching non-installed host-component ERROR/WARN issues and requires explicit Continue Anyway acceptance without hard-blocking |
+| `INST-5-003` | `PARTIAL` | Validation discards stale responses, but complete re-entry and dynamic service-change recommendation behavior remains untested |
 | `INST-6-001` | `STATICALLY_ALIGNED` | Host/component matrix, All/None, required, and disabled selections exist |
 | `INST-6-002` | `STATICALLY_ALIGNED` | Master plus slave/client Blueprint and hidden required components are produced |
 | `INST-6-003` | `PARTIAL` | Server validation and Continue Anyway modal exist; exact general/host/component issue mapping needs coverage |
@@ -181,32 +182,32 @@ must reconcile the active server request before presenting completion.
 | `INST-7-003` | `PARTIAL` | Recommendations, dependencies, and required values exist; rejection/required matrices remain |
 | `INST-7-004` | `PARTIAL` | Shared connection test paths exist; all conditional services and recovery remain |
 | `INST-7-005` | `PARTIAL` | Existing values/overrides are loaded for Add Service; host override/config-group parity is incomplete |
-| `INST-7-006` | `MISSING` | React has no `preInstallChecks`-gated placeholder modal matching Classic's shell |
+| `INST-7-006` | `STATICALLY_ALIGNED` | The new-cluster-only `preInstallChecks` flag exposes Classic's placeholder and warns before an unchecked Next |
 | `INST-7-007` | `PARTIAL` | Config-derived assignments are calculated, but Review Blueprint propagation lacks focused evidence |
 | `INST-7-008` | `PARTIAL` | Generic sidebar warning always claims data loss; it does not detect actual dirty configuration state |
 
 ### Review, Deploy, and Summary
 
-| ID | Initial status | Classic behavior versus current React |
+| ID | Current status | Classic behavior versus current React |
 | --- | --- | --- |
 | `INST-8-001` | `PARTIAL` | Review shows cluster, hosts, repositories, services, and assignments; complete config and expandable host detail are absent |
-| `INST-8-002` | `MISSING` | No Print Review action |
-| `INST-8-003` | `MISSING` | No Kerberos CSV prefetch/download for non-empty `kdc_type` |
-| `INST-8-004` | `MISSING` | No local Blueprint and cluster-template ZIP export |
-| `INST-8-005` | `PARTIAL` | New cluster queries and deletes all clusters; GET failure has no recoverable UI and locks Deploy |
-| `INST-8-008` | `PARTIAL` | Deletes are parallel and non-transactional; partial failures are not aggregated for explicit retry |
-| `INST-8-009` | `PARTIAL` | Definitions and repository versions are deleted; failure is only a rejected chain with no recovery presentation |
-| `INST-8-006` | `INCORRECT` | React does not implement the dependency-ordered abort-on-error serial queue and `createConfigurationGroups()` is empty |
-| `INST-8-007` | `INCORRECT` | Review loses the selected XML/URL source, posts a synthetic payload, and treats repository update failure differently |
-| `INST-9-001` | `INCORRECT` | The new-cluster start query is malformed, one poll starts with an empty request ID, and phase/check flags are inverted or incomplete |
+| `INST-8-002` | `STATICALLY_ALIGNED` | Print Review invokes the browser print workflow before deployment locks navigation |
+| `INST-8-003` | `STATICALLY_ALIGNED` | Review prefetches identities for every non-empty KDC type and downloads `kerberos.csv` with visible retry |
+| `INST-8-004` | `STATICALLY_ALIGNED` | Review generates a local ZIP containing `blueprint.json` and `clustertemplate.json` from current assignments and configs |
+| `INST-8-005` | `STATICALLY_ALIGNED` | Cluster inventory and parallel deletion failures stop preparation, remain visible, and retry from reconciled server inventory |
+| `INST-8-008` | `STATICALLY_ALIGNED` | Cluster deletes run as an awaited parallel stage; only a wholly successful stage is checkpointed |
+| `INST-8-009` | `STATICALLY_ALIGNED` | Repository-version inventory/deletion is an awaited stage with visible failure and retry |
+| `INST-8-006` | `STATICALLY_ALIGNED` | Dependency stages run serially, abort on first failed prerequisite, checkpoint completion IDs, and synchronize config groups |
+| `INST-8-007` | `STATICALLY_ALIGNED` | Review reuses the validated XML or URL source and persists repository artifacts before later stages |
+| `INST-9-001` | `STATICALLY_ALIGNED` | Deploy owns explicit install/keytab/start phases, valid queries, request IDs, and serialized polling |
 | `INST-9-002` | `PARTIAL` | Task modal exists, but lazy log loading returns when a task ID exists and there is no Classic copy/new-window parity |
 | `INST-9-003` | `PARTIAL` | Host status filters and failures exist; heartbeat and failed-master branches contain unsafe model-style calls on plain objects |
-| `INST-9-004` | `INCORRECT` | Retry can appear for failed hosts independent of exact `INSTALL FAILED`; Step 9 Next is always enabled, including active and failed new-cluster states |
-| `INST-9-005` | `MISSING` | React has no route blocker during Deploy |
-| `INST-9-006` | `INCORRECT` | Next does not persist `*_INSTALLED_4`, does not wait for persistence, and has no terminal-state gate |
+| `INST-9-004` | `STATICALLY_ALIGNED` | Retry appears only for exact `INSTALL FAILED`; Summary uses wizard-specific terminal gates |
+| `INST-9-005` | `STATICALLY_ALIGNED` | React Router and `beforeunload` blockers protect active deployment, with an explicit Leave decision |
+| `INST-9-006` | `STATICALLY_ALIGNED` | Next waits for the wizard-specific `*_INSTALLED_4` checkpoint and is disabled outside defined terminal states |
 | `INST-10-001` | `PARTIAL` | Summary derives host/master/start results, but service-check and recovered-request fidelity remain incomplete |
 | `INST-10-003` | `STATICALLY_ALIGNED` | No Back entry is rendered on Summary |
-| `INST-10-002` | `PARTIAL` | New cluster writes provisioning `INSTALLED` and Add modes do not; React does not reset the Classic cluster state and blocks navigation on PUT failure instead of Classic `.complete()` |
+| `INST-10-002` | `STATICALLY_ALIGNED` | Only new-cluster completion writes provisioning `INSTALLED`; completion flushes owned state and failures stay visibly retryable |
 
 ## Authoritative API Contract and Order
 
@@ -216,23 +217,23 @@ display labels.
 
 ### Selection, Bootstrap, and Validation
 
-| Order | Method and URL | Query/payload | React gap |
+| Order | Method and URL | Query/payload | Current React result |
 | ---: | --- | --- | --- |
-| 1 | `GET /stacks` | None | React skips the explicit stack inventory |
-| 2 | `GET /version_definitions` | `fields=VersionDefinition/stack_default,...` and `VersionDefinition/show_available=true&VersionDefinition/stack_name={stackName}` | React hard-codes `VDP` and a cache-buster |
-| 3 | `GET /stacks/{stack}/versions/{version}` | `fields=operating_systems/repositories/Repositories` | React hard-codes `/stacks/VDP` |
-| 4a | `POST /version_definitions?dry_run=true` | XML body with `Content-Type: text/xml` | React adds `skip_url_check=true` and does not retain XML |
-| 4b | `POST /version_definitions?dry_run=true` | `{VersionDefinition:{version_url}}` JSON | React does not retain URL/source mode |
-| 5 | `PUT /stacks/{stack}/versions/{version}/operating_systems/{os}/repositories/{repo}` | `{Repositories:{base_url,repo_name,verify_base_url}}` | React validation uses POST `?validate_only=true`, then always submits `verify_base_url:true`; managed-repository semantics differ |
-| 6 | `GET /services/AMBARI/components/AMBARI_SERVER{fields}` | Ambari Java home, JDK location/version, and skip-check properties | Loaded in parts; Step 1 JDK compatibility is absent |
-| 7 | `POST /bootstrap` | `{verbose,sshKey,hosts,user,userRunAs,sshPort}`; HDPWIN retains automatic mode with empty SSH fields | Payload helper aligns for Add Host; new-cluster flag/Windows derivation is absent |
-| 8 | `GET /bootstrap/{requestId}` | Poll only after prior call settles; stop on unmount/step exit | Request ID/deadline is not persisted |
+| 1 | `GET /stacks` | None | Loaded at Version entry; failure returns to Name instead of presenting an empty selector |
+| 2 | `GET /version_definitions` | `fields=VersionDefinition/stack_default,...` and `VersionDefinition/show_available=true&VersionDefinition/stack_name={stackName}` | Uses the selected encoded stack and exact fields without a cache-buster |
+| 3 | `GET /stacks/{stack}/versions/{version}` | `fields=operating_systems/repositories/Repositories` | Uses encoded selected stack/version and preserves returned URLs |
+| 4a | `POST /version_definitions?dry_run=true` | XML body with `Content-Type: text/xml` | Exact XML and header are retained for final submission |
+| 4b | `POST /version_definitions?dry_run=true` | `{VersionDefinition:{version_url}}` JSON | Exact URL payload is retained for final submission |
+| 5 | `PUT /stacks/{stack}/versions/{version}/operating_systems/{os}/repositories/{repo}` | `{Repositories:{base_url,repo_name,verify_base_url}}` | React performs a validation-only POST before the PUT; skip/Satellite correctly control verification and management flags |
+| 6 | `GET /services/AMBARI/components/AMBARI_SERVER{fields}` | Ambari Java home, JDK location/version, and skip-check properties | Runtime values drive Agent user visibility and inclusive JDK acceptance |
+| 7 | `POST /bootstrap` | `{verbose,sshKey,hosts,user,userRunAs,sshPort}`; HDPWIN retains automatic mode with empty SSH fields | Shared payload covers new cluster/Add Host, support-derived Agent user, manual bypass, and HDPWIN |
+| 8 | `GET /bootstrap/{requestId}` | Poll only after prior call settles; stop on unmount/step exit | Request ID, host status, and registration deadline persist for recovery |
 | 9 | `GET /hosts?fields=Hosts/host_status` | Registration poll; 120 seconds automatic, 15 seconds manual | Static behavior aligns |
 | 10 | `POST /requests` | `RequestInfo.action=check_host`, check list and host resource filters | Implemented by `useHostChecks` |
-| 11 | `GET /requests/{requestId}` | Request status and host-check structured output fields | Implemented; complete parsing needs runtime acceptance |
-| 12 | `POST /requests` then `GET /requests/{id}` | Separate JDK check with `java_home`, `jdk_location`, and `java_home_check.exit_code` | Missing |
+| 11 | `GET /requests/{requestId}` | Request status and host-check structured output fields | Request ID and parsed results persist; complete stack categories remain in runtime acceptance |
+| 12 | `POST /requests` then `GET /requests/{id}` | Separate JDK check with `java_home`, `jdk_location`, and `java_home_check.exit_code` | Implemented as an independent request even when generic Add Host checks are skipped |
 | 13 | `POST {stackVersionUrl}/recommendations` | Hosts, services, Blueprint, bindings, and configuration properties according to step | Present across assignment/config screens; payload permutations need tests |
-| 14 | `POST {stackVersionUrl}/validations` | Current hosts/services/Blueprint/bindings | Present; Step 5 issue filtering differs |
+| 14 | `POST {stackVersionUrl}/validations` | Current hosts/services/Blueprint/bindings | Present; Step 5 filters to matching non-installed assignments and exposes Continue Anyway |
 
 ### Review Submission
 
@@ -257,7 +258,7 @@ install mutation after a resource-stage rejection.
 | C5 | `POST /clusters/{cluster}/hosts` | `{RequestInfo:{query},Body:{host_components:[...]}}` | One component association at a time |
 | C6 | `PUT /clusters/{cluster}` | Array of `{Clusters:{desired_config:[...]}}` | Configs before installation |
 | C7 | `POST /clusters/{cluster}/config_groups` or `PUT /clusters/{cluster}/config_groups/{id}` | Full group plus host membership payload | Required for created groups and Add Host selected existing groups |
-| C8 | `POST` or `PUT /clusters/{cluster}/artifacts/kerberos_descriptor` | `{Artifacts:{artifact_data}}` | Conditional Add Service Kerberos resource |
+| C8 | `POST` or `PUT /clusters/{cluster}/artifacts/kerberos_descriptor` | `{artifact_data:{...}}` | Conditional Add Service Kerberos resource; Manual saves before Review use and managed KDC saves in the deployment plan |
 | D | `PUT /clusters/{cluster}/services?...` or `/host_components?...` | Install desired state plus `RequestInfo.context/query` | Only after every applicable C resource succeeds; persist returned request ID before entering Deploy |
 
 ### Deploy Polling and Completion
@@ -292,7 +293,7 @@ wizard reach a terminal state.
 | Upgrade state | Blocks ordinary mutation when required | Blocks | Blocks | Route plus mutation guard, with server authorization |
 | Stack `HDPWIN` | PowerShell automatic bootstrap | PowerShell automatic bootstrap | Not applicable | Derived from selected/current stack, not a manual toggle |
 | Component metadata | Assignment and step presence | Slave/client eligibility | Filter and conditional step skips | Cardinality, master/slave/client, HA-only, dependencies, installable/installed flags |
-| Security/KDC | Initial configs may enable Kerberos later | KDC session before deploy | Descriptor, KDC type, CSV, and Manual responsibility | Failures block deploy and remain retryable |
+| Security/KDC | Initial configs may enable Kerberos later | KDC session before deploy | Descriptor, KDC type, CSV, and Manual responsibility | KDC/descriptor failures block deploy; CSV failure is visible/retryable but nonblocking like Classic |
 | HA prerequisites | Selected services/configs can establish HA topology | Existing HA topology limits eligible component changes | Added service may expose HA prerequisites | Advisor/validation and live topology decide eligibility; no extra HA wizard is embedded |
 
 React's authorization helpers correctly implement comma-separated OR behavior
@@ -323,11 +324,11 @@ unguarded Add Host deep link.
 
 | Pass | Independent inputs | Findings that determine implementation |
 | --- | --- | --- |
-| 1. Routes, pages, controls, navigation | Classic router/three route files/templates; React `RoutesList`, menus, StepWizard and footers | Installer and Add Host direct routes are unguarded; URL step input is overwritten by local active state; common sidebar click ignores `canJumpFromCurrentStep`; Deploy lacks a route blocker |
-| 2. Controller/service/model state | Classic installer/add controllers, persist and watcher; three React providers/reducers | Only Add Host serializes same-event checkpoints; new cluster can overwrite failed hydration; Add Service closes over stale state; no provider claims `wizard-data`; Classic server-state mappings are absent |
-| 3. API definitions, calls, order | All five generated network inventories plus Classic AJAX registry/callers and React APIs | `VDP` is hard-coded; VDF source is lost; no separate JDK check; Review is not serial/abort-on-error; config-group creation is empty; Deploy uses an empty request ID and malformed start query |
-| 4. Modes, permissions, flags | Generated permission/flag inventories, `13-permissions-flags.md`, stack metadata and React AppContext | Add Service gate is present; Installer/Add Host route gates are absent; new cluster misses HDPWIN/support wiring; Add Service step skips and KDC type/CSV/Manual branches are absent |
-| 5. Error, retry, refresh, back, interruption, tests | Classic tests and route/controller error paths; React Vitest inventory and error handlers | Focused tests cover Add Host persistence/deploy and registration serialization only; no Step 1, Review queue, Step 9, route gate, new-cluster persistence, Add Service recovery, or completion-state tests exist |
+| 1. Routes, pages, controls, navigation | Classic router/three route files/templates; React `RoutesList`, menus, StepWizard and footers | Direct route permission/operation gates, conditional Add Service navigation, persistence-before-navigation, Review controls, and Deploy blockers are implemented; generic double-click locking remains partial |
+| 2. Controller/service/model state | Classic installer/add controllers, persist and watcher; three React providers/reducers | All providers hydrate before writing, maintain synchronous snapshots, serialize persistence, claim ownership, and map Classic checkpoints; runtime cross-window behavior remains to be exercised |
+| 3. API definitions, calls, order | All five generated network inventories plus Classic AJAX registry/callers and React APIs | Dynamic stack/VDF/JDK contracts, serial Review prerequisites, request persistence, and phase polling are implemented and focused-tested; server reconciliation after an unpersisted successful mutation remains a runtime risk |
+| 4. Modes, permissions, flags | Generated permission/flag inventories, `13-permissions-flags.md`, stack metadata and React AppContext | Installer/Add Host/Add Service gates, HDPWIN, Agent user, Pre Install Checks, start-skip, conditional steps, and KDC branches are wired; stack/service permutations remain in the runtime matrix |
+| 5. Error, retry, refresh, back, interruption, tests | Classic tests and route/controller error paths; React Vitest inventory and error handlers | Focused tests cover route contracts, persistence, VDF/JDK, bootstrap recovery, JDK checks, Review retry/Kerberos/export, deployment phase gates, Add Host, Add Service navigation, and completion; real request/task failures remain runtime acceptance |
 
 The Ember baseline validator passed with 1,002 feature IDs, 288 non-Metrics AJAX
 definitions, 394 AJAX call sites, 19 direct HTTP calls, 56 browser entry points,

--- a/docs/frontend-refactor/react-current/issues/07-cluster-installation.md
+++ b/docs/frontend-refactor/react-current/issues/07-cluster-installation.md
@@ -1,0 +1,147 @@
+<!---
+   Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+
+## Problem
+
+The React cluster installation module exposes New Cluster, Add Host, and Add
+Service wizards, but it does not yet provide a reliable equivalent to the
+Classic Ember workflows. Direct routes are not consistently protected,
+wizard state can be lost or overwritten during navigation and reload, version
+definition requests use a hard-coded stack, and installation can advance after
+failed resource creation. Deploy polling also loses request identity, exposes
+invalid transitions, and does not restore the Classic completion checkpoints.
+
+Several conditional branches are incomplete, including Linux, manual Agent,
+and Windows host registration, JDK checks, managed repositories, services with
+no assignable components or configurations, Kerberos descriptor and credential
+flows, configuration groups, and installation with component start disabled.
+The result is a wizard that can render every numbered page without preserving
+the state machine, API ordering, and failure-recovery guarantees of Classic.
+
+This issue covers the complete non-Metrics Cluster Installation module defined
+by the audited Classic baseline. Metrics services, metric widgets, charts, and
+Metrics data APIs are outside this scope.
+
+## Scope
+
+* Enforce New Cluster, Add Host, and Add Service route permissions, feature
+  flags, active-operation conflicts, and wizard ownership at direct-entry and
+  mutation boundaries.
+* Serialize wizard hydration and persistence so every forward or backward
+  transition stores the resulting data and destination step before navigation,
+  and restore Classic server checkpoints without replaying mutations.
+* Use the selected stack for stack, version, operating-system, repository, and
+  Advisor requests; retain XML or URL version-definition sources through the
+  non-dry-run Review submission.
+* Match public, local XML, local URL, Satellite, managed-repository, URL-skip,
+  and Ambari Server JDK compatibility branches.
+* Match Linux SSH, manual Agent, and HDPWIN PowerShell registration, runtime
+  Agent-user support, host normalization, installed/suspicious host handling,
+  bootstrap, registration, host checks, the independent JDK check, selective
+  retry/removal, timeout, polling cleanup, and reload recovery.
+* Preserve service dependencies, filesystem conflicts, master and slave/client
+  cardinality, Advisor recommendations, matching validation warnings, manual
+  assignments, configuration recommendations, external tests, overrides, and
+  dirty-state navigation.
+* Skip Add Service assignment or configuration steps when component metadata
+  makes them inapplicable, and complete Kerberos descriptor, KDC type, CSV, and
+  Manual KDC responsibility behavior.
+* Make Review cleanup recoverable, retain validated repository input, create
+  clusters, services, components, hosts, host components, configurations,
+  configuration groups, and Kerberos artifacts in dependency order, and abort
+  before installation on the first failed prerequisite.
+* Add Review print, Blueprint archive, and applicable Kerberos CSV exports.
+* Persist install, start, and service-check request identities and phases; poll
+  one request at a time; restore on reload; load task logs lazily; expose Retry
+  only for the applicable failed phase; block route exit; and enable Summary
+  only at a defined terminal state.
+* Persist the correct `*_INSTALLED_4` checkpoint, update provisioning state only
+  for a new cluster, clear only the completed wizard, and refresh the correct
+  destination for Add Host or Add Service.
+* Add focused tests for request contracts, permission and branch boundaries,
+  state persistence, serial deployment, polling, retry, cancellation, reload,
+  and completion.
+
+## Classic UI Baseline
+
+The acceptance baseline is
+`docs/frontend-refactor/ember-baseline/07-cluster-installation.md`, feature IDs
+`INST-MODE-001` through `INST-10-002`. The detailed React comparison, complete
+state machines, API sequence, five-pass audit, and runtime matrix are recorded
+in
+`docs/frontend-refactor/react-current/07-cluster-installation-gap.md`.
+
+The audit found no new conflict between the written Module 07 baseline and the
+executable Classic source. The authoritative network review combines the AJAX
+registry and callers, direct HTTP calls, browser entry points, route and action
+inventories, permissions, feature flags, and REST polling behavior.
+
+## Acceptance Criteria
+
+* Direct wizard routes and mutations enforce the documented permission,
+  feature, ownership, and active-operation gates.
+* Hydration failures never overwrite persisted data, transitions persist the
+  resulting snapshot and destination step, and every documented Classic
+  checkpoint restores the correct workflow and request phase.
+* Version, repository, VDF, bootstrap, registration, host-check, JDK, Advisor,
+  validation, resource, install, start, check, task-log, and completion requests
+  match the documented URL, method, query, payload, and order.
+* New Cluster and Add Host cover Linux, manual, and HDPWIN onboarding with the
+  applicable support flags, timers, retries, removals, warnings, and reload
+  behavior.
+* Service selection and assignment preserve dependencies and cardinality;
+  Add Service skips inapplicable steps and completes all Kerberos branches.
+* Review creates every applicable resource serially, aborts on the first
+  failure, never starts installation after a failed prerequisite, and provides
+  recoverable errors without duplicating completed destructive work.
+* Deploy owns one current request and poll loop, restores the exact phase after
+  reload, prevents duplicate requests, gates Retry and Summary by terminal
+  state, blocks unsupported route exits, and cleans timers on unmount.
+* Summary reports the final host, component, service, and check outcomes,
+  persists the correct completion state, and applies new-cluster-only
+  provisioning behavior.
+* Focused Vitest suites, the full frontend test suite, the production build,
+  the Ember baseline validator, and whitespace checks pass.
+* The runtime acceptance matrix in the React gap document passes against a real
+  Ambari Server for representative stacks, roles, scale, failures, Kerberos,
+  HA prerequisites, and all three installation modes.
+
+## Compatibility Decisions
+
+The React implementation must not reproduce Classic failure modes that allow
+work to continue after a rejected prerequisite. Configuration-group writes and
+all dependency-ordered resource mutations are awaited, cleanup errors become
+visible and retryable, unsafe task output is not rendered as HTML, and stale
+Advisor or polling responses cannot overwrite newer state. These are deliberate
+reliability corrections, not missing parity.
+
+## Out of Scope
+
+* Ambari Metrics, Ganglia, Metrics services, metric widgets, charts, and metric
+  data APIs.
+* Standalone HA, Kerberos administration, Upgrade, and Reassign Master wizards;
+  Module 07 implements only their installation entry conditions and shared
+  prerequisites.
+* Module 05, Module 06, and other parallel module gap documents or workflows.
+
+## Verification Boundary
+
+Static code and unit tests are not sufficient to mark the 79 Feature IDs
+covered. All items remain subject to the real-cluster runtime matrix, including
+public and local repositories, Linux/manual/Windows hosts, failures at every
+Review stage, install/start/check interruption, reload and retry, permissions,
+multi-window ownership, large host sets, Kerberos, and conditional HA topology.


### PR DESCRIPTION
Issue: [AMBARI-26629](https://issues.apache.org/jira/browse/AMBARI-26629)

## What changes were proposed in this pull request?

Complete the audited non-Metrics Module 07 Cluster Installation workflow across New Cluster, Add Host, and Add Service. The patch adds permission and active-operation route guards, wizard ownership and serialized recovery, dynamic stack/version/repository handling, all supported host registration branches, conditional service assignment, Kerberos preparation and exports, recoverable serial Review deployment, phased request polling, retry gates, and correct completion ownership.

The React gap document records all 79 Feature IDs, full state machines, API order, permissions and feature conditions, asynchronous recovery behavior, executable acceptance criteria, the five-pass audit, and the real-cluster runtime matrix. Shared router, API, wizard component, and application-context files contain only the Module 07 integration changes required by these workflows; Module 05, Module 06, and Metrics implementations are unchanged.

## How was this patch tested?

Passed the full React suite: 67 test files and 217 tests. The production build, TypeScript project build, targeted ESLint for every newly added helper and test, Ember baseline validator, and git diff whitespace validation passed. The baseline validator reported 1,002 Feature IDs with no warnings or errors.

Repository-wide npm run lint remains a pre-existing baseline failure with 6,255 problems (5,799 errors and 456 warnings); this patch does not attempt unrelated lint cleanup. npm reported 22 existing audit findings after adding jszip. Real-cluster scenarios remain explicitly tracked in the runtime acceptance matrix.

```shell
cd ambari-web/latest
npm test -- --run
npm run build
npx tsc -b --pretty false
npx eslint \
  src/Utils/wizardOwnership.ts \
  src/hooks/useHostChecks.test.tsx \
  src/router/RoutesList.test.tsx \
  src/screens/ClusterWizard/Step0.test.tsx \
  src/screens/ClusterWizard/Step10.test.tsx \
  src/screens/ClusterWizard/Step5.test.tsx \
  src/screens/ClusterWizard/Step8.test.tsx \
  src/screens/ClusterWizard/blueprintExport.test.ts \
  src/screens/ClusterWizard/blueprintExport.ts \
  src/screens/ClusterWizard/deploymentQueue.test.ts \
  src/screens/ClusterWizard/deploymentQueue.ts \
  src/screens/ClusterWizard/installationProgress.test.ts \
  src/screens/ClusterWizard/installationProgress.ts \
  src/screens/ClusterWizard/masterValidation.test.ts \
  src/screens/ClusterWizard/masterValidation.ts \
  src/screens/ClusterWizard/preInstallChecks.test.ts \
  src/screens/ClusterWizard/preInstallChecks.ts \
  src/screens/ClusterWizard/versionSelection.test.ts \
  src/screens/ClusterWizard/versionSelection.ts \
  src/screens/ClusterWizard/wizardRecovery.test.ts \
  src/screens/ClusterWizard/wizardRecovery.ts \
  src/screens/Services/AddServiceWizard/addServiceNavigation.test.ts \
  src/screens/Services/AddServiceWizard/addServiceNavigation.ts
cd ../..
node docs/frontend-refactor/ember-baseline/tools/validate-ember-baseline.mjs
git diff --check
cd ambari-web/latest && npm run lint  # expected repository baseline failure
```

The production build completed with existing Sass deprecations, duplicate ServiceLoader case warnings, eval warnings, and the existing large-chunk warning.
Static verification does not replace the real-cluster runtime acceptance matrix documented in docs/frontend-refactor/react-current/07-cluster-installation-gap.md.

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.