### PR TITLE
AMBARI-26639: Restore Ambari test suites after React frontend refactor

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -110,29 +110,32 @@ pipeline {
             }
         }
 
-        stage('Parallel Unit Tests') {
-            parallel {
-                stage('Ambari Agent Tests') {
-                    steps {
-                        sh 'pip3 install distro'
-                        sh 'mvn -Dmaven.test.failure.ignore=true -am test -pl ambari-agent -DskipAdminWebTests=true -DskipUiBuild=true -Dmaven.artifact.threads=10 -Drat.skip'
-                    }
-                }
-
-                stage('Ambari Server PyTests') {
-                    steps {
-                        sh '''
-                           # Install pyOpenSSL in one step
-                           pip3 install --user --upgrade pyOpenSSL
-                           # Verify installations
-                           pip3 --version
-                           openssl version
-                           '''
-                        sh 'mvn clean -am test -pl ambari-server -DskipSurefireTests -Dmaven.test.failure.ignore -Dmaven.artifact.threads=10 -Drat.skip -Dcheckstyle.skip -DskipAdminWebTests=true -DskipUiBuild=true'
-                    }
-                }
+        stage('Ambari Agent Tests') {
+            steps {
+                sh 'pip3 install distro'
+                sh 'mvn -Dmaven.test.failure.ignore=true -am test -pl ambari-agent -DskipAdminWebTests=true -DskipUiBuild=true -Dmaven.artifact.threads=10 -Drat.skip'
             }
         }
+
+        stage('Ambari Server PyTests') {
+            steps {
+                sh '''
+                   # Install pyOpenSSL in one step
+                   pip3 install --user --upgrade pyOpenSSL
+                   # Verify installations
+                   pip3 --version
+                   openssl version
+                   '''
+                sh 'mvn clean -am test -pl ambari-server -DskipSurefireTests -Dmaven.test.failure.ignore -Dmaven.artifact.threads=10 -Drat.skip -Dcheckstyle.skip -DskipAdminWebTests=true -DskipUiBuild=true'
+            }
+        }
+
+        stage('Ambari Java Tests') {
+            steps {
+                sh 'mvn -am test -pl ambari-server,ambari-funtest -DskipPythonTests -DskipFunctionalTests=false -Dmaven.artifact.threads=10 -Drat.skip -DskipAdminWebTests=true -DskipUiBuild=true'
+            }
+        }
+
         stage('React UI Tests') {
             parallel {
                 stage('Ambari Admin React UI') {
@@ -175,11 +178,6 @@ pipeline {
                         }
                     }
                 }
-            }
-        }
-        stage('Ambari Java Tests') {
-            steps {
-                sh 'mvn -am test -pl ambari-server,ambari-funtest -DskipPythonTests -DskipFunctionalTests=false -Dmaven.artifact.threads=10 -Drat.skip -DskipAdminWebTests=true -DskipUiBuild=true'
             }
         }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -133,10 +133,47 @@ pipeline {
                 }
             }
         }
-        stage('Ambari WebUI Tests') {
-            steps {
-                withEnv(['CHROME_BIN=/usr/bin/chromium-browser']) {
-                    sh 'mvn -T 2C -am test -pl ambari-web,ambari-admin -Dmaven.artifact.threads=10 -Drat.skip'
+        stage('React UI Tests') {
+            parallel {
+                stage('Ambari Admin React UI') {
+                    steps {
+                        sh 'mvn -B -pl ambari-admin com.github.eirslett:frontend-maven-plugin:1.11.0:install-node-and-npm@install-node-and-npm-react'
+                        dir('ambari-admin/src/main/resources/ui/ambari-admin') {
+                            sh './node/node ./node/node_modules/npm/bin/npm-cli.js ci --no-audit --no-fund'
+                            sh './node/node ./node/node_modules/npm/bin/npm-cli.js test -- --run'
+                            sh './node/node ./node/node_modules/npm/bin/npm-cli.js run build'
+                        }
+                    }
+                }
+                stage('Ambari React UI') {
+                    steps {
+                        sh 'mvn -B -pl ambari-web com.github.eirslett:frontend-maven-plugin:1.11.0:install-node-and-npm@install-node-and-npm-react'
+                        dir('ambari-web/latest') {
+                            sh './node/node ./node/node_modules/npm/bin/npm-cli.js ci --no-audit --no-fund'
+                            sh './node/node ./node/node_modules/npm/bin/npm-cli.js test'
+                            sh './node/node ./node/node_modules/npm/bin/npm-cli.js run build'
+                        }
+                    }
+                }
+                stage('Files React View') {
+                    steps {
+                        sh 'mvn -B -f contrib/views/files/pom.xml com.github.eirslett:frontend-maven-plugin:1.11.0:install-node-and-npm@install-node-and-npm'
+                        dir('contrib/views/files/src/main/resources/ui') {
+                            sh './node/node ./node/node_modules/npm/bin/npm-cli.js ci --no-audit --no-fund'
+                            sh './node/node ./node/node_modules/npm/bin/npm-cli.js test'
+                            sh './node/node ./node/node_modules/npm/bin/npm-cli.js run build'
+                        }
+                    }
+                }
+                stage('Capacity Scheduler React View') {
+                    steps {
+                        sh 'mvn -B -f contrib/views/capacity-scheduler/pom.xml com.github.eirslett:frontend-maven-plugin:1.11.0:install-node-and-npm@install-node-and-npm'
+                        dir('contrib/views/capacity-scheduler/src/main/resources/ui') {
+                            sh './node/node ./node/node_modules/npm/bin/npm-cli.js ci --no-audit --no-fund'
+                            sh './node/node ./node/node_modules/npm/bin/npm-cli.js test'
+                            sh './node/node ./node/node_modules/npm/bin/npm-cli.js run build'
+                        }
+                    }
                 }
             }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -97,7 +97,7 @@ pipeline {
                 }
                 stage('Ambari Service Advisor') {
                     steps {
-                        sh 'mvn -T 3C -am install -pl ambari-serviceadvisor -DskipSurefireTests -DskipPythonTests -Dmaven.test.failure.ignore -DskipTests -Dfindbugs.skip -Drat.skip -Dmaven.artifact.threads=10'
+                        sh 'mvn -T 3C -am install -pl ambari-serviceadvisor -DskipSurefireTests -DskipPythonTests -Dmaven.test.failure.ignore -DskipTests -DskipUiBuild=true -Dfindbugs.skip -Drat.skip -Dmaven.artifact.threads=10'
                     }
                 }
             }
@@ -115,7 +115,7 @@ pipeline {
                 stage('Ambari Agent Tests') {
                     steps {
                         sh 'pip3 install distro'
-                        sh 'mvn -Dmaven.test.failure.ignore=true -am test -pl ambari-agent -Dmaven.artifact.threads=10 -Drat.skip'
+                        sh 'mvn -Dmaven.test.failure.ignore=true -am test -pl ambari-agent -DskipAdminWebTests=true -DskipUiBuild=true -Dmaven.artifact.threads=10 -Drat.skip'
                     }
                 }
 
@@ -128,7 +128,7 @@ pipeline {
                            pip3 --version
                            openssl version
                            '''
-                        sh 'mvn clean -am test -pl ambari-server -DskipSurefireTests -Dmaven.test.failure.ignore -Dmaven.artifact.threads=10 -Drat.skip -Dcheckstyle.skip -DskipAdminWebTests=true'
+                        sh 'mvn clean -am test -pl ambari-server -DskipSurefireTests -Dmaven.test.failure.ignore -Dmaven.artifact.threads=10 -Drat.skip -Dcheckstyle.skip -DskipAdminWebTests=true -DskipUiBuild=true'
                     }
                 }
             }
@@ -177,9 +177,9 @@ pipeline {
                 }
             }
         }
-        stage('Ambari Server JTests') {
+        stage('Ambari Java Tests') {
             steps {
-                sh 'mvn -am test -pl ambari-server -DskipPythonTests -Dmaven.test.failure.ignore -Dmaven.artifact.threads=10 -Drat.skip -DskipAdminWebTests=true'
+                sh 'mvn -am test -pl ambari-server,ambari-funtest -DskipPythonTests -DskipFunctionalTests=false -Dmaven.artifact.threads=10 -Drat.skip -DskipAdminWebTests=true -DskipUiBuild=true'
             }
         }
     }

--- a/ambari-admin/pom.xml
+++ b/ambari-admin/pom.xml
@@ -27,6 +27,9 @@
   <packaging>jar</packaging>
   <name>Ambari Admin View</name>
   <description>Admin control panel</description>
+  <properties>
+    <skipUiBuild>false</skipUiBuild>
+  </properties>
   <build>
     <plugins>
       <plugin>
@@ -61,6 +64,7 @@
         <artifactId>frontend-maven-plugin</artifactId>
         <version>1.11.0</version>
         <configuration>
+          <skip>${skipUiBuild}</skip>
           <nodeVersion>v4.5.0</nodeVersion>
           <npmVersion>2.15.0</npmVersion>
           <workingDirectory>src/main/resources/ui/admin-web/</workingDirectory>
@@ -124,6 +128,9 @@
       <plugin>
         <artifactId>exec-maven-plugin</artifactId>
         <groupId>org.codehaus.mojo</groupId>
+        <configuration>
+          <skip>${skipUiBuild}</skip>
+        </configuration>
         <executions>
           <execution>
             <id>Bower install</id>
@@ -331,6 +338,18 @@
     </resources>
   </build>
   <profiles>
+    <profile>
+      <id>skip-ui-build</id>
+      <activation>
+        <property>
+          <name>skipUiBuild</name>
+          <value>true</value>
+        </property>
+      </activation>
+      <properties>
+        <skipTests>true</skipTests>
+      </properties>
+    </profile>
     <profile>
       <id>windows</id>
       <activation>

--- a/ambari-admin/pom.xml
+++ b/ambari-admin/pom.xml
@@ -91,8 +91,8 @@
               <goal>install-node-and-npm</goal>
             </goals>
             <configuration>
-              <nodeVersion>v20.11.0</nodeVersion>
-              <npmVersion>10.8.3</npmVersion>
+              <nodeVersion>v22.23.1</nodeVersion>
+              <npmVersion>10.9.8</npmVersion>
               <workingDirectory>src/main/resources/ui/ambari-admin/</workingDirectory>
               <npmInheritsProxyConfigFromMaven>false</npmInheritsProxyConfigFromMaven>
             </configuration>
@@ -104,7 +104,7 @@
               <goal>npm</goal>
             </goals>
             <configuration>
-              <arguments>install</arguments>
+              <arguments>ci --no-audit --no-fund</arguments>
               <workingDirectory>src/main/resources/ui/ambari-admin/</workingDirectory>
             </configuration>
           </execution>
@@ -281,13 +281,6 @@
                             </resources>
                         </configuration>
                     </execution>
-                </executions>
-        </plugin>
-        <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-resources-plugin</artifactId>
-                <version>3.2.0</version>
-                <executions>
                     <execution>
                         <id>copy-react-resources</id>
                         <phase>process-resources</phase>
@@ -304,36 +297,6 @@
                             </resources>
                         </configuration>
                     </execution>
-                </executions>
-        </plugin>
-        <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-resources-plugin</artifactId>
-                <version>3.2.0</version>
-                <executions>
-                    <execution>
-                        <id>copy-react-resources</id>
-                        <phase>process-resources</phase>
-                        <goals>
-                            <goal>copy-resources</goal>
-                        </goals>
-                        <configuration>
-                            <outputDirectory>${project.build.directory}/classes/latest</outputDirectory>
-                            <resources>
-                                <resource>
-                                    <directory>src/main/resources/ui/ambari-admin/dist</directory>
-                                    <filtering>false</filtering>
-                                </resource>
-                            </resources>
-                        </configuration>
-                    </execution>
-                </executions>
-        </plugin>
-        <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-resources-plugin</artifactId>
-                <version>3.2.0</version>
-                <executions>
                     <execution>
                         <id>copy-public-folder</id>
                         <phase>process-resources</phase>
@@ -354,7 +317,7 @@
                         </configuration>
                     </execution>
                 </executions>
-        </plugin>
+            </plugin>
     </plugins>
     
     <resources>

--- a/ambari-admin/src/main/resources/ui/ambari-admin/src/InactivityTimeout.tsx
+++ b/ambari-admin/src/main/resources/ui/ambari-admin/src/InactivityTimeout.tsx
@@ -1,3 +1,21 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React, { useState, useEffect, useRef } from 'react';
 import {Button, Modal} from 'react-bootstrap';
 import { latestAmbariUrl } from './utils/navigation';

--- a/ambari-admin/src/main/resources/ui/ambari-admin/src/tests/ClusterInformation/ClusterIsNotInstalled.test.tsx
+++ b/ambari-admin/src/main/resources/ui/ambari-admin/src/tests/ClusterInformation/ClusterIsNotInstalled.test.tsx
@@ -136,15 +136,16 @@ describe('Cluster is not installed', () => {
                 </AppContent.Provider>
             </Router>
         );
-        await waitFor(async () => {
-            const launchInstallWizardButton = await screen.findByRole('button', {name: /launch install wizard/i});
-            expect(launchInstallWizardButton).toBeInTheDocument();
+        const launchInstallWizardButton = await screen.findByRole(
+            'button',
+            {name: /launch install wizard/i},
+            {timeout: 5000},
+        );
+        expect(launchInstallWizardButton).toBeInTheDocument();
 
-            await userEvent.click(launchInstallWizardButton);
+        await userEvent.click(launchInstallWizardButton);
 
-            // Wait for the URL to change
-            expect(window.location.href).toBe('/latest/#/installer/step0');
-        });
+        expect(window.location.href).toBe('/latest/#/installer/step0');
     });
 
     it('renders installBox image when conditions are met', async () => {

--- a/ambari-admin/src/main/resources/ui/ambari-admin/src/tests/RemoteClusters.test.tsx
+++ b/ambari-admin/src/main/resources/ui/ambari-admin/src/tests/RemoteClusters.test.tsx
@@ -60,7 +60,7 @@ describe("RemoteClusters component", () => {
   it("display appropriate message when no cluster is rendered.", async () => {
     RemoteClusterApi.getRemoteClusters = async () => [];
     renderRemoteCluster();
-    expect(screen.findByText(/No Remote Cluster to show/i));
+    expect(await screen.findByText(/No Remote Clusters to display/i)).toBeInTheDocument();
   });
 
   it("renders correct number of items ", async () => {

--- a/ambari-admin/src/main/resources/ui/ambari-admin/src/tests/components/ClusterManagement/RemoteCluster/RemoteClusters.test.tsx
+++ b/ambari-admin/src/main/resources/ui/ambari-admin/src/tests/components/ClusterManagement/RemoteCluster/RemoteClusters.test.tsx
@@ -61,7 +61,7 @@ describe("RemoteClusters component", () => {
   it("display appropriate message when no cluster is rendered.", async () => {
     RemoteClusterApi.getRemoteClusters = async () => [];
     renderRemoteCluster();
-    expect(screen.findByText(/No Remote Cluster to show/i));
+    expect(await screen.findByText(/No Remote Clusters to display/i)).toBeInTheDocument();
   });
 
   it("renders correct number of items ", async () => {

--- a/ambari-agent/src/main/python/ambari_agent/AmbariConfig.py
+++ b/ambari-agent/src/main/python/ambari_agent/AmbariConfig.py
@@ -106,7 +106,7 @@ class AmbariConfig:
   def __init__(self):
     global content
     self.config = configparser.RawConfigParser()
-    self.config.readfp(io.StringIO(content))
+    self.config.read_file(io.StringIO(content))
 
     # initialize derived paths for the cache directories
     self._recalculate_cache_paths()

--- a/ambari-agent/src/main/python/ambari_agent/alerts/ams_alert.py
+++ b/ambari-agent/src/main/python/ambari_agent/alerts/ams_alert.py
@@ -20,7 +20,7 @@ limitations under the License.
 
 import http.client
 
-import imp
+from ambari_commons import import_utils as imp
 import time
 from alerts.metric_alert import MetricAlert, REALCODE_REGEXP
 import urllib.request, urllib.parse, urllib.error

--- a/ambari-agent/src/main/python/ambari_agent/alerts/metric_alert.py
+++ b/ambari-agent/src/main/python/ambari_agent/alerts/metric_alert.py
@@ -18,7 +18,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-import imp
+from ambari_commons import import_utils as imp
 import ambari_simplejson as json
 import logging
 import re

--- a/ambari-agent/src/main/python/ambari_agent/alerts/script_alert.py
+++ b/ambari-agent/src/main/python/ambari_agent/alerts/script_alert.py
@@ -18,7 +18,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-import imp
+from ambari_commons import import_utils as imp
 import logging
 import os
 import re

--- a/ambari-agent/src/test/python/ambari_agent/TestDataCleaner.py
+++ b/ambari-agent/src/test/python/ambari_agent/TestDataCleaner.py
@@ -78,7 +78,7 @@ class TestDataCleaner(unittest.TestCase):
     config.get.side_effect = [1, (3600 - 1), (10000 + 1), "test_path"]
     DataCleaner.logger.reset_mock()
     cleaner = DataCleaner.DataCleaner(config)
-    self.assertTrue(DataCleaner.logger.warn.called)
+    self.assertTrue(DataCleaner.logger.warning.called)
     self.assertTrue(cleaner.file_max_age == 86400)
     self.assertTrue(cleaner.cleanup_interval == 3600)
     self.assertTrue(cleaner.cleanup_max_size_MB == 10000)

--- a/ambari-common/src/main/python/ambari_commons/import_utils.py
+++ b/ambari-common/src/main/python/ambari_commons/import_utils.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+
+"""
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import importlib.util
+import sys
+import types
+
+
+PY_SOURCE = 1
+
+
+def load_source(name, path):
+  """Load a Python source file using the behavior expected from imp.load_source."""
+  spec = importlib.util.spec_from_file_location(name, path)
+  if spec is None or spec.loader is None:
+    raise ImportError(f"Cannot load module {name} from {path}")
+
+  previous_module = sys.modules.get(name)
+  previous_namespace = None
+  if previous_module is None:
+    module = importlib.util.module_from_spec(spec)
+  else:
+    module = previous_module
+    previous_namespace = module.__dict__.copy()
+    module.__file__ = path
+    module.__loader__ = spec.loader
+    module.__package__ = spec.parent
+    module.__spec__ = spec
+
+  sys.modules[name] = module
+  try:
+    spec.loader.exec_module(module)
+  except Exception:
+    if previous_module is None:
+      sys.modules.pop(name, None)
+    else:
+      module.__dict__.clear()
+      module.__dict__.update(previous_namespace)
+    raise
+  return module
+
+
+def load_module(name, file, path, description):
+  """Compatibility wrapper for the source-module form of imp.load_module."""
+  del file, description
+  return load_source(name, path)
+
+
+def new_module(name):
+  return types.ModuleType(name)
+
+
+def get_magic():
+  return importlib.util.MAGIC_NUMBER

--- a/ambari-common/src/main/python/ambari_jinja2/ambari_jinja2/environment.py
+++ b/ambari-common/src/main/python/ambari_jinja2/ambari_jinja2/environment.py
@@ -604,9 +604,11 @@ class Environment(object):
       log_function = lambda x: None
 
     if py_compile:
-      import imp, struct, marshal
+      import marshal
+      import struct
+      from importlib.util import MAGIC_NUMBER
 
-      py_header = imp.get_magic() + "\xff\xff\xff\xff".encode("iso-8859-15")
+      py_header = MAGIC_NUMBER + "\xff\xff\xff\xff".encode("iso-8859-15")
 
     def write_file(filename, data, mode):
       if zip:

--- a/ambari-common/src/main/python/ambari_simplejson/compat.py
+++ b/ambari-common/src/main/python/ambari_simplejson/compat.py
@@ -25,7 +25,7 @@ else:
   if sys.version_info[:2] >= (3, 4):
     from importlib import reload as reload_module
   else:
-    from imp import reload as reload_module
+    from importlib import reload as reload_module
 
   def b(s):
     return bytes(s, "latin1")

--- a/ambari-common/src/main/python/resource_management/libraries/functions/security_commons.py
+++ b/ambari-common/src/main/python/resource_management/libraries/functions/security_commons.py
@@ -198,7 +198,7 @@ def get_params_from_filesystem(conf_dir, config_files):
         config_string = "[root]\n" + f.read()
       ini_fp = io.StringIO(re.sub(r"\\\s*\n", "\\\n ", config_string))
       config = configparser.RawConfigParser()
-      config.readfp(ini_fp)
+      config.read_file(ini_fp)
       props = config.items("root")
       result[file_name] = {}
       for key, value in props:

--- a/ambari-common/src/main/repo/install_ambari_tarball.py
+++ b/ambari-common/src/main/repo/install_ambari_tarball.py
@@ -182,7 +182,7 @@ class Installer:
 
     cp = configparser.SafeConfigParser()
     with open(OS_PACKAGE_DEPENDENCIES) as fp:
-      cp.readfp(FakePropertiesHeader(fp))
+      cp.read_file(FakePropertiesHeader(fp))
 
     properties = dict(cp.items(FakePropertiesHeader.FAKE_SECTION_NAME))
 

--- a/ambari-common/src/test/python/TestImportUtils.py
+++ b/ambari-common/src/test/python/TestImportUtils.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+
+"""
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import os
+import sys
+import tempfile
+from unittest import TestCase
+
+from ambari_commons import import_utils
+
+
+class TestImportUtils(TestCase):
+  def test_load_source_registers_and_executes_module(self):
+    module_name = "ambari_test_dynamic_module"
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".py", delete=False) as source:
+      source.write("VALUE = 42\n")
+      source_path = source.name
+
+    try:
+      module = import_utils.load_source(module_name, source_path)
+      self.assertEqual(42, module.VALUE)
+      self.assertIs(module, sys.modules[module_name])
+    finally:
+      sys.modules.pop(module_name, None)
+      os.unlink(source_path)
+
+  def test_new_module_creates_named_module(self):
+    module = import_utils.new_module("ambari_test_empty_module")
+    self.assertEqual("ambari_test_empty_module", module.__name__)
+
+  def test_load_source_reuses_namespace_for_inheritance(self):
+    module_name = "ambari_test_inherited_module"
+    source_paths = []
+    try:
+      for content in ("class Parent: pass\n", "class Child(Parent): pass\n"):
+        with tempfile.NamedTemporaryFile(
+          mode="w", suffix=".py", delete=False
+        ) as source:
+          source.write(content)
+          source_paths.append(source.name)
+
+      parent_module = import_utils.load_source(module_name, source_paths[0])
+      child_module = import_utils.load_source(module_name, source_paths[1])
+
+      self.assertIs(parent_module, child_module)
+      self.assertTrue(issubclass(child_module.Child, child_module.Parent))
+    finally:
+      sys.modules.pop(module_name, None)
+      for source_path in source_paths:
+        os.unlink(source_path)

--- a/ambari-funtest/pom.xml
+++ b/ambari-funtest/pom.xml
@@ -74,12 +74,62 @@
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
           <skip>${skipFunctionalTests}</skip>
+          <forkCount>1</forkCount>
+          <reuseForks>true</reuseForks>
+          <argLine>
+            ${surefire.argLine}
+            --add-opens java.base/java.lang=ALL-UNNAMED
+            --add-opens java.base/java.lang.reflect=ALL-UNNAMED
+            --add-opens java.management/java.lang.management=ALL-UNNAMED
+            --add-opens java.base/java.io=ALL-UNNAMED
+            --add-opens java.base/java.nio=ALL-UNNAMED
+            --add-opens java.base/java.util=ALL-UNNAMED
+            --add-opens java.base/java.util.regex=ALL-UNNAMED
+            --add-opens java.base/java.util.concurrent=ALL-UNNAMED
+            --add-opens java.base/java.net=ALL-UNNAMED
+            --add-opens java.base/java.util.stream=ALL-UNNAMED
+            --add-opens java.base/java.math=ALL-UNNAMED
+            --add-opens java.base/java.util.concurrent.locks=ALL-UNNAMED
+            --add-opens java.base/java.nio.charset=ALL-UNNAMED
+            --add-opens java.logging/java.util.logging=ALL-UNNAMED
+            --add-opens java.base/java.nio.file=ALL-UNNAMED
+            --add-opens java.base/java.text=ALL-UNNAMED
+            --add-opens java.xml/jdk.xml.internal=ALL-UNNAMED
+            --add-opens java.naming/com.sun.jndi.ldap=ALL-UNNAMED
+            --add-opens java.base/java.security=ALL-UNNAMED
+            --add-opens java.base/sun.nio.fs=ALL-UNNAMED
+          </argLine>
         </configuration>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-failsafe-plugin</artifactId>
         <configuration>
+          <forkCount>1</forkCount>
+          <reuseForks>true</reuseForks>
+          <argLine>
+            ${surefire.argLine}
+            --add-opens java.base/java.lang=ALL-UNNAMED
+            --add-opens java.base/java.lang.reflect=ALL-UNNAMED
+            --add-opens java.management/java.lang.management=ALL-UNNAMED
+            --add-opens java.base/java.io=ALL-UNNAMED
+            --add-opens java.base/java.nio=ALL-UNNAMED
+            --add-opens java.base/java.util=ALL-UNNAMED
+            --add-opens java.base/java.util.regex=ALL-UNNAMED
+            --add-opens java.base/java.util.concurrent=ALL-UNNAMED
+            --add-opens java.base/java.net=ALL-UNNAMED
+            --add-opens java.base/java.util.stream=ALL-UNNAMED
+            --add-opens java.base/java.math=ALL-UNNAMED
+            --add-opens java.base/java.util.concurrent.locks=ALL-UNNAMED
+            --add-opens java.base/java.nio.charset=ALL-UNNAMED
+            --add-opens java.logging/java.util.logging=ALL-UNNAMED
+            --add-opens java.base/java.nio.file=ALL-UNNAMED
+            --add-opens java.base/java.text=ALL-UNNAMED
+            --add-opens java.xml/jdk.xml.internal=ALL-UNNAMED
+            --add-opens java.naming/com.sun.jndi.ldap=ALL-UNNAMED
+            --add-opens java.base/java.security=ALL-UNNAMED
+            --add-opens java.base/sun.nio.fs=ALL-UNNAMED
+          </argLine>
           <includes>
             <include>**/*.java</include>
           </includes>

--- a/ambari-funtest/src/test/java/org/apache/ambari/funtest/server/tests/RoleBasedAccessControlBasicTest.java
+++ b/ambari-funtest/src/test/java/org/apache/ambari/funtest/server/tests/RoleBasedAccessControlBasicTest.java
@@ -48,6 +48,8 @@ import com.google.gson.JsonElement;
  */
 public class RoleBasedAccessControlBasicTest extends ServerTestBase {
 
+    private static final String TEST_USER_PASSWORD = "AmbariTest1!";
+
     private String clusterName = "c1";
     private String hostName = "host1";
     private String clusterVersion = "HDP-2.2.0";
@@ -76,7 +78,7 @@ public class RoleBasedAccessControlBasicTest extends ServerTestBase {
         JsonElement jsonResponse;
         ConnectionParams adminConnectionParams = createAdminConnectionParams();
         String anonUserName = "nothing";
-        String anonUserPwd = "nothing";
+        String anonUserPwd = TEST_USER_PASSWORD;
 
         /**
          * Create a new user (non-admin)
@@ -111,7 +113,7 @@ public class RoleBasedAccessControlBasicTest extends ServerTestBase {
     public void testAddClusterConfigAsAnonUser() throws Exception {
         ConnectionParams adminConnectionParams = createAdminConnectionParams();
         String anonUserName = "nothing";
-        String anonUserPwd = "nothing";
+        String anonUserPwd = TEST_USER_PASSWORD;
 
         /**
          * Create a new user (non-admin)
@@ -157,7 +159,7 @@ public class RoleBasedAccessControlBasicTest extends ServerTestBase {
         ConnectionParams adminConnectionParams = createAdminConnectionParams();
 
         String clusterAdminName = "clusterAdmin";
-        String clusterAdminPwd = "clusterAdmin";
+        String clusterAdminPwd = TEST_USER_PASSWORD;
 
         /**
          * Create a user with cluster admin role

--- a/ambari-funtest/src/test/java/org/apache/ambari/funtest/server/tests/ServerTestBase.java
+++ b/ambari-funtest/src/test/java/org/apache/ambari/funtest/server/tests/ServerTestBase.java
@@ -27,6 +27,8 @@ import java.sql.DriverManager;
 import java.sql.SQLException;
 import java.sql.SQLNonTransientConnectionException;
 import java.util.Properties;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 
 import com.google.common.base.Charsets;
 import org.apache.ambari.funtest.server.LocalAmbariServer;
@@ -57,6 +59,8 @@ import com.google.inject.persist.PersistService;
  */
 public class ServerTestBase {
     private static Log LOG = LogFactory.getLog(ServerTestBase.class);
+    private static final long SERVER_START_TIMEOUT_SECONDS = 120;
+    private static final AtomicReference<Throwable> SERVER_FAILURE = new AtomicReference<>();
 
     /**
      * Run the ambari server on a thread.
@@ -121,7 +125,9 @@ public class ServerTestBase {
             initDB();
 
             server = injector.getInstance(LocalAmbariServer.class);
-            serverThread = new Thread(server);
+            SERVER_FAILURE.set(null);
+            serverThread = new Thread(server, "ambari-funtest-server");
+            serverThread.setUncaughtExceptionHandler((thread, throwable) -> SERVER_FAILURE.set(throwable));
             serverThread.start();
             waitForServer();
 
@@ -207,12 +213,23 @@ public class ServerTestBase {
      * @throws Exception
      */
     private static void waitForServer() throws Exception {
-        int count = 1;
+        long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(SERVER_START_TIMEOUT_SECONDS);
 
         while (!isServerUp()) {
-            serverThread.join(count * 10000);     // Give a few seconds for the ambari server to start up
-            //count += 1; // progressive back off
-            //count *= 2; // exponential back off
+            Throwable failure = SERVER_FAILURE.get();
+            if (failure != null) {
+                throw new IllegalStateException("Ambari server failed during startup", failure);
+            }
+            if (!serverThread.isAlive()) {
+                throw new IllegalStateException("Ambari server stopped during startup");
+            }
+
+            long remaining = deadline - System.nanoTime();
+            if (remaining <= 0) {
+                throw new IllegalStateException(
+                    "Ambari server did not start within " + SERVER_START_TIMEOUT_SECONDS + " seconds");
+            }
+            serverThread.join(Math.min(TimeUnit.NANOSECONDS.toMillis(remaining), 1000));
         }
     }
 

--- a/ambari-server/src/main/java/org/apache/ambari/server/api/AmbariErrorHandler.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/api/AmbariErrorHandler.java
@@ -24,6 +24,7 @@ import java.io.Writer;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.UUID;
+import java.util.function.Supplier;
 
 import jakarta.servlet.RequestDispatcher;
 import jakarta.servlet.http.HttpServletRequest;
@@ -36,7 +37,6 @@ import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.eclipse.jetty.http.HttpStatus;
 import org.eclipse.jetty.http.MimeTypes;
 import org.eclipse.jetty.server.HttpChannel;
-import org.eclipse.jetty.server.HttpConnection;
 import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.handler.ErrorHandler;
 import org.slf4j.Logger;
@@ -53,19 +53,28 @@ public class AmbariErrorHandler extends ErrorHandler {
   private static final Logger LOG = LoggerFactory.getLogger(AmbariErrorHandler.class);
 
   private final Gson gson;
+  private final Logger logger;
+  private final Supplier<UUID> requestIdSupplier;
 
   private JwtAuthenticationPropertiesProvider jwtAuthenticationPropertiesProvider;
 
   @Inject
   public AmbariErrorHandler(@Named("prettyGson") Gson prettyGson, JwtAuthenticationPropertiesProvider jwtAuthenticationPropertiesProvider) {
+    this(prettyGson, jwtAuthenticationPropertiesProvider, LOG, UUID::randomUUID);
+  }
+
+  AmbariErrorHandler(Gson prettyGson, JwtAuthenticationPropertiesProvider jwtAuthenticationPropertiesProvider,
+      Logger logger, Supplier<UUID> requestIdSupplier) {
     this.gson = prettyGson;
     this.jwtAuthenticationPropertiesProvider = jwtAuthenticationPropertiesProvider;
+    this.logger = logger;
+    this.requestIdSupplier = requestIdSupplier;
   }
 
   @Override
   public void handle(String target, Request baseRequest, HttpServletRequest request, HttpServletResponse response) throws IOException {
-    HttpChannel connection = HttpConnection.getCurrentConnection().getHttpChannel();
-    connection.getRequest().setHandled(true);
+    HttpChannel connection = baseRequest.getHttpChannel();
+    baseRequest.setHandled(true);
 
     response.setContentType(MimeTypes.Type.TEXT_PLAIN.asString());
 
@@ -82,10 +91,10 @@ public class AmbariErrorHandler extends ErrorHandler {
     Throwable th = (Throwable) request.getAttribute(RequestDispatcher.ERROR_EXCEPTION);
     if (th != null) {
       if (code == org.apache.http.HttpStatus.SC_INTERNAL_SERVER_ERROR) {
-        UUID requestId = UUID.randomUUID();
+        UUID requestId = requestIdSupplier.get();
         message = "Internal server error, please refer the exception by " + requestId + " in the server log file";
         errorMap.put("message", message);
-        LOG.error(message + ", requestURI: " + request.getRequestURI(), th);
+        logger.error(message + ", requestURI: " + request.getRequestURI(), th);
       }
 
       if (this.isShowStacks()) {
@@ -103,9 +112,9 @@ public class AmbariErrorHandler extends ErrorHandler {
         String originalUrl = jwtProperties.getOriginalUrlQueryParam();
 
         if (StringUtils.isEmpty(providerUrl)) {
-          LOG.warn("The SSO provider URL is not available, forwarding to the SSO provider is not possible");
+          logger.warn("The SSO provider URL is not available, forwarding to the SSO provider is not possible");
         } else if (StringUtils.isEmpty(originalUrl)) {
-          LOG.warn("The original URL parameter name is not available, forwarding to the SSO provider is not possible");
+          logger.warn("The original URL parameter name is not available, forwarding to the SSO provider is not possible");
         } else {
           errorMap.put("jwtProviderUrl", String.format("%s?%s=", providerUrl, originalUrl));
         }

--- a/ambari-server/src/main/java/org/apache/ambari/server/security/authentication/kerberos/AmbariKerberosAuthenticationFilter.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/security/authentication/kerberos/AmbariKerberosAuthenticationFilter.java
@@ -158,6 +158,6 @@ public class AmbariKerberosAuthenticationFilter extends SpnegoAuthenticationProc
       eventHandler.beforeAttemptAuthentication(this, request, response);
     }
 
-    super.doFilter(request, response, filterChain);
+    super.doFilterInternal(request, response, filterChain);
   }
 }

--- a/ambari-server/src/main/resources/common-services/AMBARI_INFRA_SOLR/3.0.0/service_advisor.py
+++ b/ambari-server/src/main/resources/common-services/AMBARI_INFRA_SOLR/3.0.0/service_advisor.py
@@ -18,7 +18,7 @@ limitations under the License.
 """
 
 # Python imports
-import imp
+from ambari_commons import import_utils as imp
 import os
 import traceback
 

--- a/ambari-server/src/main/resources/common-services/AMBARI_METRICS/3.0.0/service_advisor.py
+++ b/ambari-server/src/main/resources/common-services/AMBARI_METRICS/3.0.0/service_advisor.py
@@ -18,7 +18,7 @@ limitations under the License.
 """
 
 # Python imports
-import imp
+from ambari_commons import import_utils as imp
 import re
 import os
 import sys

--- a/ambari-server/src/main/resources/scripts/stack_advisor.py
+++ b/ambari-server/src/main/resources/scripts/stack_advisor.py
@@ -152,7 +152,7 @@ def main(argv=None):
 
 def instantiateStackAdvisor(stackName, stackVersion, parentVersions):
   """Instantiates StackAdvisor implementation for the specified Stack"""
-  import imp
+  from ambari_commons import import_utils as imp
 
   with open(AMBARI_CONFIGURATION_PATH, "r") as fp:
     imp.load_module(

--- a/ambari-server/src/main/resources/scripts/takeover_config_merge.py
+++ b/ambari-server/src/main/resources/scripts/takeover_config_merge.py
@@ -109,7 +109,7 @@ class PropertiesParser(Parser):  # Used ConfigParser parser to read data into a 
 
       cp = configparser.ConfigParser()
       cp.optionxform = str
-      cp.readfp(properties_file_content)
+      cp.read_file(properties_file_content)
 
       for section in cp._sections:
         for name, value in cp._sections[section].items():

--- a/ambari-server/src/main/resources/stacks/BIGTOP/3.2.0/services/ALLUXIO/service_advisor.py
+++ b/ambari-server/src/main/resources/stacks/BIGTOP/3.2.0/services/ALLUXIO/service_advisor.py
@@ -19,7 +19,7 @@ limitations under the License.
 
 # Python imports
 from ast import Param
-import imp
+from ambari_commons import import_utils as imp
 import os
 import traceback
 import re

--- a/ambari-server/src/main/resources/stacks/BIGTOP/3.2.0/services/HBASE/service_advisor.py
+++ b/ambari-server/src/main/resources/stacks/BIGTOP/3.2.0/services/HBASE/service_advisor.py
@@ -18,7 +18,7 @@ limitations under the License.
 """
 
 # Python imports
-import imp
+from ambari_commons import import_utils as imp
 import math
 import os
 import traceback

--- a/ambari-server/src/main/resources/stacks/BIGTOP/3.2.0/services/HDFS/service_advisor.py
+++ b/ambari-server/src/main/resources/stacks/BIGTOP/3.2.0/services/HDFS/service_advisor.py
@@ -18,7 +18,7 @@ limitations under the License.
 """
 
 # Python imports
-import imp
+from ambari_commons import import_utils as imp
 import os
 import traceback
 import inspect

--- a/ambari-server/src/main/resources/stacks/BIGTOP/3.2.0/services/HIVE/service_advisor.py
+++ b/ambari-server/src/main/resources/stacks/BIGTOP/3.2.0/services/HIVE/service_advisor.py
@@ -18,7 +18,7 @@ limitations under the License.
 """
 
 # Python imports
-import imp
+from ambari_commons import import_utils as imp
 import os
 import traceback
 import re

--- a/ambari-server/src/main/resources/stacks/BIGTOP/3.2.0/services/KAFKA/service_advisor.py
+++ b/ambari-server/src/main/resources/stacks/BIGTOP/3.2.0/services/KAFKA/service_advisor.py
@@ -18,7 +18,7 @@ limitations under the License.
 """
 
 # Python imports
-import imp
+from ambari_commons import import_utils as imp
 import os
 import traceback
 import re

--- a/ambari-server/src/main/resources/stacks/BIGTOP/3.2.0/services/SOLR/service_advisor.py
+++ b/ambari-server/src/main/resources/stacks/BIGTOP/3.2.0/services/SOLR/service_advisor.py
@@ -18,7 +18,7 @@ limitations under the License.
 """
 
 # Python imports
-import imp
+from ambari_commons import import_utils as imp
 import os
 import traceback
 

--- a/ambari-server/src/main/resources/stacks/BIGTOP/3.2.0/services/SPARK/service_advisor.py
+++ b/ambari-server/src/main/resources/stacks/BIGTOP/3.2.0/services/SPARK/service_advisor.py
@@ -18,7 +18,7 @@ limitations under the License.
 """
 
 # Python imports
-import imp
+from ambari_commons import import_utils as imp
 import os
 import traceback
 import re

--- a/ambari-server/src/main/resources/stacks/BIGTOP/3.2.0/services/TEZ/service_advisor.py
+++ b/ambari-server/src/main/resources/stacks/BIGTOP/3.2.0/services/TEZ/service_advisor.py
@@ -18,7 +18,7 @@ limitations under the License.
 """
 
 # Python imports
-import imp
+from ambari_commons import import_utils as imp
 import os
 import traceback
 import re

--- a/ambari-server/src/main/resources/stacks/BIGTOP/3.2.0/services/YARN/service_advisor.py
+++ b/ambari-server/src/main/resources/stacks/BIGTOP/3.2.0/services/YARN/service_advisor.py
@@ -18,7 +18,7 @@ limitations under the License.
 """
 
 # Python imports
-import imp
+from ambari_commons import import_utils as imp
 import os
 import traceback
 import inspect

--- a/ambari-server/src/main/resources/stacks/BIGTOP/3.2.0/services/ZEPPELIN/service_advisor.py
+++ b/ambari-server/src/main/resources/stacks/BIGTOP/3.2.0/services/ZEPPELIN/service_advisor.py
@@ -18,7 +18,7 @@ limitations under the License.
 """
 
 # Python imports
-import imp
+from ambari_commons import import_utils as imp
 import os
 import traceback
 import re

--- a/ambari-server/src/main/resources/stacks/BIGTOP/3.2.0/services/ZOOKEEPER/service_advisor.py
+++ b/ambari-server/src/main/resources/stacks/BIGTOP/3.2.0/services/ZOOKEEPER/service_advisor.py
@@ -18,7 +18,7 @@ limitations under the License.
 """
 
 # Python imports
-import imp
+from ambari_commons import import_utils as imp
 import os
 import traceback
 import inspect

--- a/ambari-server/src/main/resources/stacks/BIGTOP/3.3.0/services/RANGER/service_advisor.py
+++ b/ambari-server/src/main/resources/stacks/BIGTOP/3.3.0/services/RANGER/service_advisor.py
@@ -18,7 +18,7 @@ limitations under the License.
 """
 
 # Python imports
-import imp
+from ambari_commons import import_utils as imp
 import os
 import traceback
 import re

--- a/ambari-server/src/main/resources/stacks/BIGTOP/3.3.0/services/RANGER_KMS/service_advisor.py
+++ b/ambari-server/src/main/resources/stacks/BIGTOP/3.3.0/services/RANGER_KMS/service_advisor.py
@@ -18,7 +18,7 @@ limitations under the License.
 """
 
 # Python imports
-import imp
+from ambari_commons import import_utils as imp
 import os
 import traceback
 import re

--- a/ambari-server/src/main/resources/stacks/stack_advisor.py
+++ b/ambari-server/src/main/resources/stacks/stack_advisor.py
@@ -18,7 +18,7 @@ limitations under the License.
 """
 
 # Python Imports
-import imp
+from ambari_commons import import_utils as imp
 import os
 import random
 import re

--- a/ambari-server/src/test/java/org/apache/ambari/server/api/AmbariErrorHandlerTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/api/AmbariErrorHandlerTest.java
@@ -23,7 +23,6 @@ import static org.easymock.EasyMock.eq;
 import static org.easymock.EasyMock.expect;
 import static org.easymock.EasyMock.expectLastCall;
 import static org.junit.Assert.assertEquals;
-import static org.powermock.api.easymock.PowerMock.mockStatic;
 
 import java.io.IOException;
 import java.io.PrintWriter;
@@ -40,26 +39,18 @@ import org.easymock.Capture;
 import org.easymock.EasyMock;
 import org.easymock.EasyMockSupport;
 import org.eclipse.jetty.server.HttpChannel;
-import org.eclipse.jetty.server.HttpConnection;
 import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.Response;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import com.google.gson.Gson;
 
-@RunWith(PowerMockRunner.class)
-@PrepareForTest({AmbariErrorHandler.class, LoggerFactory.class, HttpConnection.class, UUID.class})
 public class AmbariErrorHandlerTest extends EasyMockSupport {
   private Gson gson = new Gson();
 
   private Logger logger = createNiceMock(Logger.class);
 
-  private HttpConnection httpConnection = createNiceMock(HttpConnection.class);
   private HttpChannel httpChannel = createNiceMock(HttpChannel.class);
 
   private Response response = createNiceMock(Response.class);
@@ -77,21 +68,15 @@ public class AmbariErrorHandlerTest extends EasyMockSupport {
     //given
     final UUID requestId = UUID.fromString("4db659b2-7902-477b-b8e6-c35261d3334a");
 
-    mockStatic(HttpConnection.class);
-    mockStatic(UUID.class);
-    mockStatic(LoggerFactory.class);
-    expect(HttpConnection.getCurrentConnection()).andReturn(httpConnection);
-    expect(UUID.randomUUID()).andReturn(requestId);
-    expect(LoggerFactory.getLogger(AmbariErrorHandler.class)).andReturn(logger);
-
     Throwable th = createNiceMock(Throwable.class);
 
     Capture<String> captureLogMessage = EasyMock.newCapture();
     logger.error(capture(captureLogMessage), eq(th));
     expectLastCall().anyTimes();
 
-    expect(httpConnection.getHttpChannel()).andReturn(httpChannel);
-    expect(httpChannel.getRequest()).andReturn(request);
+    expect(request.getHttpChannel()).andReturn(httpChannel);
+    request.setHandled(true);
+    expectLastCall().once();
     expect(httpChannel.getResponse()).andReturn(response).times(2);
     expect(response.getStatus()).andReturn(HttpStatus.SC_INTERNAL_SERVER_ERROR);
 
@@ -109,7 +94,7 @@ public class AmbariErrorHandlerTest extends EasyMockSupport {
     final String expectedResponse = "{\"status\":500,\"message\":\"Internal server error, please refer the exception by " + requestId + " in the server log file\"}";
     final String expectedErrorMessage = "Internal server error, please refer the exception by " + requestId + " in the server log file, requestURI: " + requestUri;
 
-    AmbariErrorHandler ambariErrorHandler = new AmbariErrorHandler(gson, propertiesProvider);
+    AmbariErrorHandler ambariErrorHandler = new AmbariErrorHandler(gson, propertiesProvider, logger, () -> requestId);
     ambariErrorHandler.setShowStacks(false);
 
     //when
@@ -125,11 +110,9 @@ public class AmbariErrorHandlerTest extends EasyMockSupport {
   public void testHandleGeneralError() throws Exception {
 
     //given
-    mockStatic(HttpConnection.class);
-    expect(HttpConnection.getCurrentConnection()).andReturn(httpConnection);
-
-    expect(httpConnection.getHttpChannel()).andReturn(httpChannel);
-    expect(httpChannel.getRequest()).andReturn(request);
+    expect(request.getHttpChannel()).andReturn(httpChannel);
+    request.setHandled(true);
+    expectLastCall().once();
     expect(httpChannel.getResponse()).andReturn(response).anyTimes();
     expect(response.getStatus()).andReturn(HttpStatus.SC_BAD_REQUEST);
 
@@ -142,7 +125,7 @@ public class AmbariErrorHandlerTest extends EasyMockSupport {
 
     final String expectedResponse = "{\"status\":400,\"message\":\"Bad Request\"}";
 
-    AmbariErrorHandler ambariErrorHandler = new AmbariErrorHandler(gson, propertiesProvider);
+    AmbariErrorHandler ambariErrorHandler = new AmbariErrorHandler(gson, propertiesProvider, logger, UUID::randomUUID);
 
     //when
     ambariErrorHandler.handle(target, request, httpServletRequest, httpServletResponse);

--- a/ambari-server/src/test/java/org/apache/ambari/server/api/MethodOverrideFilterTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/api/MethodOverrideFilterTest.java
@@ -18,8 +18,8 @@
 
 package org.apache.ambari.server.api;
 
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
 

--- a/ambari-server/src/test/java/org/apache/ambari/server/api/services/ActionServiceTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/api/services/ActionServiceTest.java
@@ -41,14 +41,14 @@ public class ActionServiceTest extends BaseServiceTest {
 
     //getActionDefinition
     ActionService service = new TestActionDefinitionService("actionName");
-    Method m = service.getClass().getMethod("getActionDefinition", String.class, HttpHeaders.class, UriInfo.class, String.class);
-    Object[] args = new Object[] {null, getHttpHeaders(), getUriInfo(), "actionName"};
+    Method m = service.getClass().getMethod("getActionDefinition", HttpHeaders.class, UriInfo.class, String.class);
+    Object[] args = new Object[] {getHttpHeaders(), getUriInfo(), "actionName"};
     listInvocations.add(new ServiceTestInvocation(Request.Type.GET, service, m, args, null));
 
     //getActionDefinitions
     service = new TestActionDefinitionService(null);
-    m = service.getClass().getMethod("getActionDefinitions", String.class, HttpHeaders.class, UriInfo.class);
-    args = new Object[] {null, getHttpHeaders(), getUriInfo()};
+    m = service.getClass().getMethod("getActionDefinitions", HttpHeaders.class, UriInfo.class);
+    args = new Object[] {getHttpHeaders(), getUriInfo()};
     listInvocations.add(new ServiceTestInvocation(Request.Type.GET, service, m, args, null));
 
     //createActionDefinition

--- a/ambari-server/src/test/java/org/apache/ambari/server/api/services/BlueprintServiceTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/api/services/BlueprintServiceTest.java
@@ -42,14 +42,14 @@ public class BlueprintServiceTest extends BaseServiceTest {
 
     //getBlueprint
     BlueprintService BlueprintService = new TestBlueprintService("blueprintName");
-    Method m = BlueprintService.getClass().getMethod("getBlueprint", String.class, HttpHeaders.class, UriInfo.class, String.class);
-    Object[] args = new Object[] {null, getHttpHeaders(), getUriInfo(), "blueprintName"};
+    Method m = BlueprintService.getClass().getMethod("getBlueprint", HttpHeaders.class, UriInfo.class, String.class);
+    Object[] args = new Object[] {getHttpHeaders(), getUriInfo(), "blueprintName"};
     listInvocations.add(new ServiceTestInvocation(Request.Type.GET, BlueprintService, m, args, null));
 
     //getBlueprints
     BlueprintService = new TestBlueprintService(null);
-    m = BlueprintService.getClass().getMethod("getBlueprints", String.class, HttpHeaders.class, UriInfo.class);
-    args = new Object[] {null, getHttpHeaders(), getUriInfo()};
+    m = BlueprintService.getClass().getMethod("getBlueprints", HttpHeaders.class, UriInfo.class);
+    args = new Object[] {getHttpHeaders(), getUriInfo()};
     listInvocations.add(new ServiceTestInvocation(Request.Type.GET, BlueprintService, m, args, null));
 
     //createBlueprint

--- a/ambari-server/src/test/java/org/apache/ambari/server/api/services/ClusterServiceTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/api/services/ClusterServiceTest.java
@@ -65,14 +65,14 @@ public class ClusterServiceTest extends BaseServiceTest {
 
     //getCluster
     clusterService = new TestClusterService(clusters, "clusterName");
-    m = clusterService.getClass().getMethod("getCluster", String.class, HttpHeaders.class, UriInfo.class, String.class);
-    args = new Object[] {null, getHttpHeaders(), getUriInfo(), "clusterName"};
+    m = clusterService.getClass().getMethod("getCluster", HttpHeaders.class, UriInfo.class, String.class);
+    args = new Object[] {getHttpHeaders(), getUriInfo(), "clusterName"};
     listInvocations.add(new ServiceTestInvocation(Request.Type.GET, clusterService, m, args, null));
 
     //getClusters
     clusterService = new TestClusterService(clusters, null);
-    m = clusterService.getClass().getMethod("getClusters", String.class, HttpHeaders.class, UriInfo.class);
-    args = new Object[] {null, getHttpHeaders(), getUriInfo()};
+    m = clusterService.getClass().getMethod("getClusters", HttpHeaders.class, UriInfo.class);
+    args = new Object[] {getHttpHeaders(), getUriInfo()};
     listInvocations.add(new ServiceTestInvocation(Request.Type.GET, clusterService, m, args, null));
 
     //createCluster
@@ -101,15 +101,15 @@ public class ClusterServiceTest extends BaseServiceTest {
 
     //getClusterArtifact
     clusterService = new TestClusterService(clusters, "clusterName");
-    m = clusterService.getClass().getMethod("getClusterArtifact", String.class, HttpHeaders.class, UriInfo.class, String.class, String.class);
-    args = new Object[] {"body", getHttpHeaders(), getUriInfo(), "clusterName", "artifact_name"};
-    listInvocations.add(new ServiceTestInvocation(Request.Type.GET, clusterService, m, args, "body"));
+    m = clusterService.getClass().getMethod("getClusterArtifact", HttpHeaders.class, UriInfo.class, String.class, String.class);
+    args = new Object[] {getHttpHeaders(), getUriInfo(), "clusterName", "artifact_name"};
+    listInvocations.add(new ServiceTestInvocation(Request.Type.GET, clusterService, m, args, null));
 
     //getClusterArtifacts
     clusterService = new TestClusterService(clusters, "clusterName");
-    m = clusterService.getClass().getMethod("getClusterArtifacts", String.class, HttpHeaders.class, UriInfo.class, String.class);
-    args = new Object[] {"body", getHttpHeaders(), getUriInfo(), "clusterName"};
-    listInvocations.add(new ServiceTestInvocation(Request.Type.GET, clusterService, m, args, "body"));
+    m = clusterService.getClass().getMethod("getClusterArtifacts", HttpHeaders.class, UriInfo.class, String.class);
+    args = new Object[] {getHttpHeaders(), getUriInfo(), "clusterName"};
+    listInvocations.add(new ServiceTestInvocation(Request.Type.GET, clusterService, m, args, null));
 
     //updateClusterArtifact
     clusterService = new TestClusterService(clusters, "clusterName");

--- a/ambari-server/src/test/java/org/apache/ambari/server/api/services/ExtensionsServiceTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/api/services/ExtensionsServiceTest.java
@@ -42,26 +42,26 @@ public class ExtensionsServiceTest extends BaseServiceTest {
 
     // getExtension
     ExtensionsService service = new TestExtensionsService("extensionName", null);
-    Method m = service.getClass().getMethod("getExtension", String.class, HttpHeaders.class, UriInfo.class, String.class);
-    Object[] args = new Object[] {null, getHttpHeaders(), getUriInfo(), "extensionName"};
+    Method m = service.getClass().getMethod("getExtension", HttpHeaders.class, UriInfo.class, String.class);
+    Object[] args = new Object[] {getHttpHeaders(), getUriInfo(), "extensionName"};
     listInvocations.add(new ServiceTestInvocation(Request.Type.GET, service, m, args, null));
 
     //getExtensions
     service = new TestExtensionsService(null, null);
-    m = service.getClass().getMethod("getExtensions", String.class, HttpHeaders.class, UriInfo.class);
-    args = new Object[] {null, getHttpHeaders(), getUriInfo()};
+    m = service.getClass().getMethod("getExtensions", HttpHeaders.class, UriInfo.class);
+    args = new Object[] {getHttpHeaders(), getUriInfo()};
     listInvocations.add(new ServiceTestInvocation(Request.Type.GET, service, m, args, null));
 
     // getExtensionVersion
     service = new TestExtensionsService("extensionName", "extensionVersion");
-    m = service.getClass().getMethod("getExtensionVersion", String.class, HttpHeaders.class, UriInfo.class, String.class, String.class);
-    args = new Object[] {null, getHttpHeaders(), getUriInfo(), "extensionName", "extensionVersion"};
+    m = service.getClass().getMethod("getExtensionVersion", HttpHeaders.class, UriInfo.class, String.class, String.class);
+    args = new Object[] {getHttpHeaders(), getUriInfo(), "extensionName", "extensionVersion"};
     listInvocations.add(new ServiceTestInvocation(Request.Type.GET, service, m, args, null));
 
     // getExtensionVersions
     service = new TestExtensionsService("extensionName", null);
-    m = service.getClass().getMethod("getExtensionVersions", String.class, HttpHeaders.class, UriInfo.class, String.class);
-    args = new Object[] {null, getHttpHeaders(), getUriInfo(), "extensionName"};
+    m = service.getClass().getMethod("getExtensionVersions", HttpHeaders.class, UriInfo.class, String.class);
+    args = new Object[] {getHttpHeaders(), getUriInfo(), "extensionName"};
     listInvocations.add(new ServiceTestInvocation(Request.Type.GET, service, m, args, null));
 
     return listInvocations;

--- a/ambari-server/src/test/java/org/apache/ambari/server/api/services/FeedServiceTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/api/services/FeedServiceTest.java
@@ -43,14 +43,14 @@ public class FeedServiceTest extends BaseServiceTest {
 
     //getFeed
     FeedService feedService = new TestFeedService("feedName");
-    Method m = feedService.getClass().getMethod("getFeed", String.class, HttpHeaders.class, UriInfo.class, String.class);
-    Object[] args = new Object[] {null, getHttpHeaders(), getUriInfo(), "feedName"};
+    Method m = feedService.getClass().getMethod("getFeed", HttpHeaders.class, UriInfo.class, String.class);
+    Object[] args = new Object[] {getHttpHeaders(), getUriInfo(), "feedName"};
     listInvocations.add(new ServiceTestInvocation(Request.Type.GET, feedService, m, args, null));
 
     //getFeeds
     feedService = new TestFeedService(null);
-    m = feedService.getClass().getMethod("getFeeds", String.class, HttpHeaders.class, UriInfo.class);
-    args = new Object[] {null, getHttpHeaders(), getUriInfo()};
+    m = feedService.getClass().getMethod("getFeeds", HttpHeaders.class, UriInfo.class);
+    args = new Object[] {getHttpHeaders(), getUriInfo()};
     listInvocations.add(new ServiceTestInvocation(Request.Type.GET, feedService, m, args, null));
 
     //createFeed

--- a/ambari-server/src/test/java/org/apache/ambari/server/api/services/HostServiceTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/api/services/HostServiceTest.java
@@ -42,14 +42,14 @@ public class HostServiceTest extends BaseServiceTest {
 
     //getHost
     HostService service = new TestHostService("clusterName", "hostName");
-    Method m = service.getClass().getMethod("getHost", String.class, HttpHeaders.class, UriInfo.class, String.class);
-    Object[] args = new Object[] {null, getHttpHeaders(), getUriInfo(), "hostName"};
+    Method m = service.getClass().getMethod("getHost", HttpHeaders.class, UriInfo.class, String.class);
+    Object[] args = new Object[] {getHttpHeaders(), getUriInfo(), "hostName"};
     listInvocations.add(new ServiceTestInvocation(Request.Type.GET, service, m, args, null));
 
     //getHosts
     service = new TestHostService("clusterName", null);
-    m = service.getClass().getMethod("getHosts", String.class, HttpHeaders.class, UriInfo.class);
-    args = new Object[] {null, getHttpHeaders(), getUriInfo()};
+    m = service.getClass().getMethod("getHosts", HttpHeaders.class, UriInfo.class);
+    args = new Object[] {getHttpHeaders(), getUriInfo()};
     listInvocations.add(new ServiceTestInvocation(Request.Type.GET, service, m, args, null));
 
     //createHost
@@ -118,5 +118,4 @@ public class HostServiceTest extends BaseServiceTest {
     }
   }
 }
-
 

--- a/ambari-server/src/test/java/org/apache/ambari/server/api/services/InstanceServiceTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/api/services/InstanceServiceTest.java
@@ -42,14 +42,14 @@ public class InstanceServiceTest extends BaseServiceTest {
 
     //getInstance
     InstanceService service = new TestInstanceService("clusterName", "instanceName");
-    Method m = service.getClass().getMethod("getInstance", String.class, HttpHeaders.class, UriInfo.class, String.class);
-    Object[] args = new Object[] {null, getHttpHeaders(), getUriInfo(), "instanceName"};
+    Method m = service.getClass().getMethod("getInstance", HttpHeaders.class, UriInfo.class, String.class);
+    Object[] args = new Object[] {getHttpHeaders(), getUriInfo(), "instanceName"};
     listInvocations.add(new ServiceTestInvocation(Request.Type.GET, service, m, args, null));
 
     //getInstances
     service = new TestInstanceService("clusterName", null);
-    m = service.getClass().getMethod("getInstances", String.class, HttpHeaders.class, UriInfo.class);
-    args = new Object[] {null, getHttpHeaders(), getUriInfo()};
+    m = service.getClass().getMethod("getInstances", HttpHeaders.class, UriInfo.class);
+    args = new Object[] {getHttpHeaders(), getUriInfo()};
     listInvocations.add(new ServiceTestInvocation(Request.Type.GET, service, m, args, null));
 
     //createInstance
@@ -106,5 +106,4 @@ public class InstanceServiceTest extends BaseServiceTest {
     }
   }
 }
-
 

--- a/ambari-server/src/test/java/org/apache/ambari/server/api/services/MpacksServiceTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/api/services/MpacksServiceTest.java
@@ -40,14 +40,14 @@ public class MpacksServiceTest extends BaseServiceTest{
 
     // getMpacks
     MpacksService service = new TestMpacksService("null");
-    Method m = service.getClass().getMethod("getMpacks", String.class, HttpHeaders.class, UriInfo.class);
-    Object[] args = new Object[]{null, getHttpHeaders(), getUriInfo()};
+    Method m = service.getClass().getMethod("getMpacks", HttpHeaders.class, UriInfo.class);
+    Object[] args = new Object[]{getHttpHeaders(), getUriInfo()};
     listInvocations.add(new ServiceTestInvocation(Request.Type.GET, service, m, args, null));
 
     // getMpack
     service = new TestMpacksService("1");
-    m = service.getClass().getMethod("getMpack", String.class, HttpHeaders.class, UriInfo.class, String.class);
-    args = new Object[]{null, getHttpHeaders(), getUriInfo(), ""};
+    m = service.getClass().getMethod("getMpack", HttpHeaders.class, UriInfo.class, String.class);
+    args = new Object[]{getHttpHeaders(), getUriInfo(), ""};
     listInvocations.add(new ServiceTestInvocation(Request.Type.GET, service, m, args, null));
 
     //createMpacks

--- a/ambari-server/src/test/java/org/apache/ambari/server/api/services/RootServiceServiceTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/api/services/RootServiceServiceTest.java
@@ -42,44 +42,44 @@ public class RootServiceServiceTest extends BaseServiceTest {
     
     //getServices
     RootServiceService service = new TestRootServiceService(null, null, null);
-    Method m = service.getClass().getMethod("getRootServices", String.class, HttpHeaders.class, UriInfo.class);
-    Object[] args = new Object[] {null, getHttpHeaders(), getUriInfo()};
+    Method m = service.getClass().getMethod("getRootServices", HttpHeaders.class, UriInfo.class);
+    Object[] args = new Object[] {getHttpHeaders(), getUriInfo()};
     listInvocations.add(new ServiceTestInvocation(Request.Type.GET, service, m, args, null));
     
     //getService
     service = new TestRootServiceService("AMBARI", null, null);
-    m = service.getClass().getMethod("getRootService", String.class, HttpHeaders.class, UriInfo.class, String.class);
-    args = new Object[] {null, getHttpHeaders(), getUriInfo(), "AMBARI"};
+    m = service.getClass().getMethod("getRootService", HttpHeaders.class, UriInfo.class, String.class);
+    args = new Object[] {getHttpHeaders(), getUriInfo(), "AMBARI"};
     listInvocations.add(new ServiceTestInvocation(Request.Type.GET, service, m, args, null));
     
     //getServiceComponents
     service = new TestRootServiceService("AMBARI", null, null);
-    m = service.getClass().getMethod("getRootServiceComponents", String.class, HttpHeaders.class, UriInfo.class, String.class);
-    args = new Object[] {null, getHttpHeaders(), getUriInfo(), "AMBARI"};
+    m = service.getClass().getMethod("getRootServiceComponents", HttpHeaders.class, UriInfo.class, String.class);
+    args = new Object[] {getHttpHeaders(), getUriInfo(), "AMBARI"};
     listInvocations.add(new ServiceTestInvocation(Request.Type.GET, service, m, args, null));
     
     //getServiceComponent
     service = new TestRootServiceService("AMBARI", "AMBARI_SERVER", null);
-    m = service.getClass().getMethod("getRootServiceComponent", String.class, HttpHeaders.class, UriInfo.class, String.class, String.class);
-    args = new Object[] {null, getHttpHeaders(), getUriInfo(), "AMBARI", "AMBARI_SERVER"};
+    m = service.getClass().getMethod("getRootServiceComponent", HttpHeaders.class, UriInfo.class, String.class, String.class);
+    args = new Object[] {getHttpHeaders(), getUriInfo(), "AMBARI", "AMBARI_SERVER"};
     listInvocations.add(new ServiceTestInvocation(Request.Type.GET, service, m, args, null));
     
     //getRootHostComponents
     service = new TestRootServiceService("AMBARI", "AMBARI_SERVER", null);
-    m = service.getClass().getMethod("getRootServiceComponentHosts", String.class, HttpHeaders.class, UriInfo.class, String.class, String.class);
-    args = new Object[] {null, getHttpHeaders(), getUriInfo(), "AMBARI", "AMBARI_SERVER"};
+    m = service.getClass().getMethod("getRootServiceComponentHosts", HttpHeaders.class, UriInfo.class, String.class, String.class);
+    args = new Object[] {getHttpHeaders(), getUriInfo(), "AMBARI", "AMBARI_SERVER"};
     listInvocations.add(new ServiceTestInvocation(Request.Type.GET, service, m, args, null));
     
     //getRootHosts
     service = new TestRootServiceService("AMBARI", "AMBARI_SERVER", null);
-    m = service.getClass().getMethod("getRootHosts", String.class, HttpHeaders.class, UriInfo.class);
-    args = new Object[] {null, getHttpHeaders(), getUriInfo()};
+    m = service.getClass().getMethod("getRootHosts", HttpHeaders.class, UriInfo.class);
+    args = new Object[] {getHttpHeaders(), getUriInfo()};
     listInvocations.add(new ServiceTestInvocation(Request.Type.GET, service, m, args, null));
     
     //getRootHost
     service = new TestRootServiceService("AMBARI", "AMBARI_SERVER", "host1");
-    m = service.getClass().getMethod("getRootHost", String.class, HttpHeaders.class, UriInfo.class, String.class);
-    args = new Object[] {null, getHttpHeaders(), getUriInfo(), "host1"};
+    m = service.getClass().getMethod("getRootHost", HttpHeaders.class, UriInfo.class, String.class);
+    args = new Object[] {getHttpHeaders(), getUriInfo(), "host1"};
     listInvocations.add(new ServiceTestInvocation(Request.Type.GET, service, m, args, null));
     
     

--- a/ambari-server/src/test/java/org/apache/ambari/server/api/services/SettingServiceTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/api/services/SettingServiceTest.java
@@ -40,14 +40,14 @@ public class SettingServiceTest extends BaseServiceTest {
 
     //getSetting
     SettingService settingService = new TestSettingService("settingName");
-    Method m = settingService.getClass().getMethod("getSetting", String.class, HttpHeaders.class, UriInfo.class, String.class);
-    Object[] args = new Object[] {null, getHttpHeaders(), getUriInfo(), "settingName"};
+    Method m = settingService.getClass().getMethod("getSetting", HttpHeaders.class, UriInfo.class, String.class);
+    Object[] args = new Object[] {getHttpHeaders(), getUriInfo(), "settingName"};
     listInvocations.add(new ServiceTestInvocation(Request.Type.GET, settingService, m, args, null));
 
     //getSettings
     settingService = new TestSettingService(null);
-    m = settingService.getClass().getMethod("getSettings", String.class, HttpHeaders.class, UriInfo.class);
-    args = new Object[] {null, getHttpHeaders(), getUriInfo()};
+    m = settingService.getClass().getMethod("getSettings", HttpHeaders.class, UriInfo.class);
+    args = new Object[] {getHttpHeaders(), getUriInfo()};
     listInvocations.add(new ServiceTestInvocation(Request.Type.GET, settingService, m, args, null));
 
     //createSetting

--- a/ambari-server/src/test/java/org/apache/ambari/server/api/services/StacksServiceTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/api/services/StacksServiceTest.java
@@ -42,94 +42,94 @@ public class StacksServiceTest extends BaseServiceTest {
 
     // getStack
     StacksService service = new TestStacksService("stackName", null);
-    Method m = service.getClass().getMethod("getStack", String.class, HttpHeaders.class, UriInfo.class, String.class);
-    Object[] args = new Object[] {null, getHttpHeaders(), getUriInfo(), "stackName"};
+    Method m = service.getClass().getMethod("getStack", HttpHeaders.class, UriInfo.class, String.class);
+    Object[] args = new Object[] {getHttpHeaders(), getUriInfo(), "stackName"};
     listInvocations.add(new ServiceTestInvocation(Request.Type.GET, service, m, args, null));
 
     //getStacks
     service = new TestStacksService(null, null);
-    m = service.getClass().getMethod("getStacks", String.class, HttpHeaders.class, UriInfo.class);
-    args = new Object[] {null, getHttpHeaders(), getUriInfo()};
+    m = service.getClass().getMethod("getStacks", HttpHeaders.class, UriInfo.class);
+    args = new Object[] {getHttpHeaders(), getUriInfo()};
     listInvocations.add(new ServiceTestInvocation(Request.Type.GET, service, m, args, null));
 
     // getStackVersion
     service = new TestStacksService("stackName", "stackVersion");
-    m = service.getClass().getMethod("getStackVersion", String.class, HttpHeaders.class, UriInfo.class, String.class, String.class);
-    args = new Object[] {null, getHttpHeaders(), getUriInfo(), "stackName", "stackVersion"};
+    m = service.getClass().getMethod("getStackVersion", HttpHeaders.class, UriInfo.class, String.class, String.class);
+    args = new Object[] {getHttpHeaders(), getUriInfo(), "stackName", "stackVersion"};
     listInvocations.add(new ServiceTestInvocation(Request.Type.GET, service, m, args, null));
 
     // getStackVersions
     service = new TestStacksService("stackName", null);
-    m = service.getClass().getMethod("getStackVersions", String.class, HttpHeaders.class, UriInfo.class, String.class);
-    args = new Object[] {null, getHttpHeaders(), getUriInfo(), "stackName"};
+    m = service.getClass().getMethod("getStackVersions", HttpHeaders.class, UriInfo.class, String.class);
+    args = new Object[] {getHttpHeaders(), getUriInfo(), "stackName"};
     listInvocations.add(new ServiceTestInvocation(Request.Type.GET, service, m, args, null));
 
     // getStackService
     service = new TestStacksService("stackName", null);
-    m = service.getClass().getMethod("getStackService", String.class, HttpHeaders.class, UriInfo.class, String.class,
+    m = service.getClass().getMethod("getStackService", HttpHeaders.class, UriInfo.class, String.class,
         String.class, String.class);
-    args = new Object[] {null, getHttpHeaders(), getUriInfo(), "stackName", "stackVersion", "service-name"};
+    args = new Object[] {getHttpHeaders(), getUriInfo(), "stackName", "stackVersion", "service-name"};
     listInvocations.add(new ServiceTestInvocation(Request.Type.GET, service, m, args, null));
 
     // getStackServices
     service = new TestStacksService("stackName", null);
-    m = service.getClass().getMethod("getStackServices", String.class, HttpHeaders.class, UriInfo.class, String.class, String.class);
-    args = new Object[] {null, getHttpHeaders(), getUriInfo(), "stackName", "stackVersion"};
+    m = service.getClass().getMethod("getStackServices", HttpHeaders.class, UriInfo.class, String.class, String.class);
+    args = new Object[] {getHttpHeaders(), getUriInfo(), "stackName", "stackVersion"};
     listInvocations.add(new ServiceTestInvocation(Request.Type.GET, service, m, args, null));
 
     // getStackConfiguration
     service = new TestStacksService("stackName", "stackVersion");
-    m = service.getClass().getMethod("getStackConfiguration", String.class, HttpHeaders.class, UriInfo.class,
+    m = service.getClass().getMethod("getStackConfiguration", HttpHeaders.class, UriInfo.class,
         String.class, String.class, String.class, String.class);
-    args = new Object[] {null, getHttpHeaders(), getUriInfo(), "stackName", "stackVersion", "service-name", "property-name"};
+    args = new Object[] {getHttpHeaders(), getUriInfo(), "stackName", "stackVersion", "service-name", "property-name"};
     listInvocations.add(new ServiceTestInvocation(Request.Type.GET, service, m, args, null));
 
     // getStackConfigurations
     service = new TestStacksService("stackName", null);
-    m = service.getClass().getMethod("getStackConfigurations", String.class, HttpHeaders.class, UriInfo.class,
+    m = service.getClass().getMethod("getStackConfigurations", HttpHeaders.class, UriInfo.class,
         String.class, String.class, String.class);
-    args = new Object[] {null, getHttpHeaders(), getUriInfo(), "stackName", "stackVersion", "service-name"};
+    args = new Object[] {getHttpHeaders(), getUriInfo(), "stackName", "stackVersion", "service-name"};
     listInvocations.add(new ServiceTestInvocation(Request.Type.GET, service, m, args, null));
 
     // getServiceComponent
     service = new TestStacksService("stackName", "stackVersion");
-    m = service.getClass().getMethod("getServiceComponent", String.class, HttpHeaders.class, UriInfo.class,
+    m = service.getClass().getMethod("getServiceComponent", HttpHeaders.class, UriInfo.class,
         String.class, String.class, String.class, String.class);
-    args = new Object[] {null, getHttpHeaders(), getUriInfo(), "stackName", "stackVersion", "service-name", "component-name"};
+    args = new Object[] {getHttpHeaders(), getUriInfo(), "stackName", "stackVersion", "service-name", "component-name"};
     listInvocations.add(new ServiceTestInvocation(Request.Type.GET, service, m, args, null));
 
     // getServiceComponents
     service = new TestStacksService("stackName", "stackVersion");
-    m = service.getClass().getMethod("getServiceComponents", String.class, HttpHeaders.class, UriInfo.class,
+    m = service.getClass().getMethod("getServiceComponents", HttpHeaders.class, UriInfo.class,
         String.class, String.class, String.class);
-    args = new Object[] {null, getHttpHeaders(), getUriInfo(), "stackName", "stackVersion", "service-name"};
+    args = new Object[] {getHttpHeaders(), getUriInfo(), "stackName", "stackVersion", "service-name"};
     listInvocations.add(new ServiceTestInvocation(Request.Type.GET, service, m, args, null));
 
     //get stack artifacts
     service = new TestStacksService("stackName", null);
-    m = service.getClass().getMethod("getStackArtifacts", String.class, HttpHeaders.class, UriInfo.class, String.class, String.class);
-    args = new Object[] {null, getHttpHeaders(), getUriInfo(), "stackName", "stackVersion"};
+    m = service.getClass().getMethod("getStackArtifacts", HttpHeaders.class, UriInfo.class, String.class, String.class);
+    args = new Object[] {getHttpHeaders(), getUriInfo(), "stackName", "stackVersion"};
     listInvocations.add(new ServiceTestInvocation(Request.Type.GET, service, m, args, null));
 
     //get stack artifact
     service = new TestStacksService("stackName", null);
-    m = service.getClass().getMethod("getStackArtifact", String.class, HttpHeaders.class, UriInfo.class, String.class,
+    m = service.getClass().getMethod("getStackArtifact", HttpHeaders.class, UriInfo.class, String.class,
         String.class, String.class);
-    args = new Object[] {null, getHttpHeaders(), getUriInfo(), "stackName", "stackVersion", "artifact-name"};
+    args = new Object[] {getHttpHeaders(), getUriInfo(), "stackName", "stackVersion", "artifact-name"};
     listInvocations.add(new ServiceTestInvocation(Request.Type.GET, service, m, args, null));
 
     //get stack service artifacts
     service = new TestStacksService("stackName", "stackVersion");
-    m = service.getClass().getMethod("getStackServiceArtifacts", String.class, HttpHeaders.class, UriInfo.class,
+    m = service.getClass().getMethod("getStackServiceArtifacts", HttpHeaders.class, UriInfo.class,
         String.class, String.class, String.class);
-    args = new Object[] {null, getHttpHeaders(), getUriInfo(), "stackName", "stackVersion", "service-name"};
+    args = new Object[] {getHttpHeaders(), getUriInfo(), "stackName", "stackVersion", "service-name"};
     listInvocations.add(new ServiceTestInvocation(Request.Type.GET, service, m, args, null));
 
     //get stack service artifact
     service = new TestStacksService("stackName", "stackVersion");
-    m = service.getClass().getMethod("getStackServiceArtifact", String.class, HttpHeaders.class, UriInfo.class,
+    m = service.getClass().getMethod("getStackServiceArtifact", HttpHeaders.class, UriInfo.class,
         String.class, String.class, String.class, String.class);
-    args = new Object[] {null, getHttpHeaders(), getUriInfo(), "stackName", "stackVersion", "service-name", "artifact-name"};
+    args = new Object[] {getHttpHeaders(), getUriInfo(), "stackName", "stackVersion", "service-name", "artifact-name"};
     listInvocations.add(new ServiceTestInvocation(Request.Type.GET, service, m, args, null));
 
     return listInvocations;

--- a/ambari-server/src/test/java/org/apache/ambari/server/api/services/TargetClusterServiceTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/api/services/TargetClusterServiceTest.java
@@ -43,14 +43,14 @@ public class TargetClusterServiceTest extends BaseServiceTest {
 
     //getTargetCluster
     TargetClusterService targetClusterService = new TestTargetClusterService("targetClusterName");
-    Method m = targetClusterService.getClass().getMethod("getTargetCluster", String.class, HttpHeaders.class, UriInfo.class, String.class);
-    Object[] args = new Object[] {null, getHttpHeaders(), getUriInfo(), "targetClusterName"};
+    Method m = targetClusterService.getClass().getMethod("getTargetCluster", HttpHeaders.class, UriInfo.class, String.class);
+    Object[] args = new Object[] {getHttpHeaders(), getUriInfo(), "targetClusterName"};
     listInvocations.add(new ServiceTestInvocation(Request.Type.GET, targetClusterService, m, args, null));
 
     //getTargetClusters
     targetClusterService = new TestTargetClusterService(null);
-    m = targetClusterService.getClass().getMethod("getTargetClusters", String.class, HttpHeaders.class, UriInfo.class);
-    args = new Object[] {null, getHttpHeaders(), getUriInfo()};
+    m = targetClusterService.getClass().getMethod("getTargetClusters", HttpHeaders.class, UriInfo.class);
+    args = new Object[] {getHttpHeaders(), getUriInfo()};
     listInvocations.add(new ServiceTestInvocation(Request.Type.GET, targetClusterService, m, args, null));
 
     //createTargetCluster

--- a/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/ThemeArtifactResourceProviderTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/ThemeArtifactResourceProviderTest.java
@@ -31,7 +31,6 @@ import static org.easymock.EasyMock.replay;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
 
 import java.util.Arrays;
 import java.util.Collections;

--- a/ambari-server/src/test/java/org/apache/ambari/server/security/authentication/kerberos/AmbariKerberosAuthenticationFilterTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/security/authentication/kerberos/AmbariKerberosAuthenticationFilterTest.java
@@ -31,6 +31,7 @@ import static org.easymock.EasyMock.startsWith;
 import java.io.IOException;
 import java.util.List;
 
+import jakarta.servlet.DispatcherType;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -150,7 +151,15 @@ public class AmbariKerberosAuthenticationFilterTest extends EasyMockSupport {
     HttpServletResponse response = createMock(HttpServletResponse.class);
     HttpSession session = createMock(HttpSession.class);
     FilterChain filterChain = createMock(FilterChain.class);
+    String alreadyFilteredAttribute = AmbariKerberosAuthenticationFilter.class.getName() + ".FILTERED";
 
+    expect(request.getDispatcherType()).andReturn(DispatcherType.REQUEST).once();
+    expect(request.getAttribute("jakarta.servlet.error.request_uri")).andReturn(null).once();
+    expect(request.getAttribute(alreadyFilteredAttribute)).andReturn(null).once();
+    request.setAttribute(alreadyFilteredAttribute, Boolean.TRUE);
+    expectLastCall().once();
+    request.removeAttribute(alreadyFilteredAttribute);
+    expectLastCall().once();
     expect(request.getHeader("Authorization")).andReturn("Negotiate ").once();
     expect(request.getHeader(startsWith("X-Forwarded-"))).andReturn(null).times(6);
     expect(request.getRemoteAddr()).andReturn("1.2.3.4").once();
@@ -200,7 +209,15 @@ public class AmbariKerberosAuthenticationFilterTest extends EasyMockSupport {
     HttpServletResponse response = createMock(HttpServletResponse.class);
     HttpSession session = createMock(HttpSession.class);
     FilterChain filterChain = createMock(FilterChain.class);
+    String alreadyFilteredAttribute = AmbariKerberosAuthenticationFilter.class.getName() + ".FILTERED";
 
+    expect(request.getDispatcherType()).andReturn(DispatcherType.REQUEST).once();
+    expect(request.getAttribute("jakarta.servlet.error.request_uri")).andReturn(null).once();
+    expect(request.getAttribute(alreadyFilteredAttribute)).andReturn(null).once();
+    request.setAttribute(alreadyFilteredAttribute, Boolean.TRUE);
+    expectLastCall().once();
+    request.removeAttribute(alreadyFilteredAttribute);
+    expectLastCall().once();
     expect(request.getHeader("Authorization")).andReturn("Negotiate ").once();
     expect(request.getHeader(startsWith("X-Forwarded-"))).andReturn(null).times(6);
     expect(request.getRemoteAddr()).andReturn("1.2.3.4").once();

--- a/ambari-server/src/test/python/TestAmbariConfiguration.py
+++ b/ambari-server/src/test/python/TestAmbariConfiguration.py
@@ -24,7 +24,7 @@ from unittest import TestCase
 
 class TestAmbariConfiguration(TestCase):
   def setUp(self):
-    import imp
+    from ambari_commons import import_utils as imp
 
     self.test_directory = os.path.dirname(os.path.abspath(__file__))
 

--- a/ambari-server/src/test/python/TestConfigs.py
+++ b/ambari-server/src/test/python/TestConfigs.py
@@ -18,7 +18,7 @@ limitations under the License.
 """
 
 import io
-import imp
+from ambari_commons import import_utils as imp
 import os
 import sys
 import json

--- a/ambari-server/src/test/python/TestMpacks.py
+++ b/ambari-server/src/test/python/TestMpacks.py
@@ -509,22 +509,22 @@ class TestMpacks(TestCase):
     ]
 
     os_mkdir_calls = [
-      call(stacks_directory),
-      call(common_services_directory),
-      call(mpacks_directory),
-      call(mpacks_directory + "/cache"),
-      call(dashboards_directory),
-      call(os.path.join(dashboards_directory, GRAFANA_DASHBOARDS_DIRNAME)),
-      call(os.path.join(dashboards_directory, SERVICE_METRICS_DIRNAME)),
-      call(os.path.join(common_services_directory, "SERVICEA")),
-      call(os.path.join(common_services_directory, "SERVICEB")),
-      call(os.path.join(stacks_directory, "MYSTACK")),
-      call(os.path.join(stacks_directory, "MYSTACK/1.0")),
-      call(os.path.join(stacks_directory, "MYSTACK/1.0/services")),
-      call(os.path.join(stacks_directory, "MYSTACK/1.1")),
-      call(os.path.join(stacks_directory, "MYSTACK/1.1/services")),
-      call(os.path.join(stacks_directory, "MYSTACK/2.0")),
-      call(os.path.join(stacks_directory, "MYSTACK/2.0/services")),
+      call(stacks_directory, 0o755),
+      call(common_services_directory, 0o755),
+      call(mpacks_directory, 0o755),
+      call(mpacks_directory + "/cache", 0o755),
+      call(dashboards_directory, 0o755),
+      call(os.path.join(dashboards_directory, GRAFANA_DASHBOARDS_DIRNAME), 0o755),
+      call(os.path.join(dashboards_directory, SERVICE_METRICS_DIRNAME), 0o755),
+      call(os.path.join(common_services_directory, "SERVICEA"), 0o755),
+      call(os.path.join(common_services_directory, "SERVICEB"), 0o755),
+      call(os.path.join(stacks_directory, "MYSTACK"), 0o755),
+      call(os.path.join(stacks_directory, "MYSTACK/1.0"), 0o755),
+      call(os.path.join(stacks_directory, "MYSTACK/1.0/services"), 0o755),
+      call(os.path.join(stacks_directory, "MYSTACK/1.1"), 0o755),
+      call(os.path.join(stacks_directory, "MYSTACK/1.1/services"), 0o755),
+      call(os.path.join(stacks_directory, "MYSTACK/2.0"), 0o755),
+      call(os.path.join(stacks_directory, "MYSTACK/2.0/services"), 0o755),
     ]
     create_symlink_calls = [
       call(
@@ -691,13 +691,13 @@ class TestMpacks(TestCase):
     ]
 
     os_mkdir_calls = [
-      call(extensions_directory),
-      call(mpacks_directory),
-      call(mpacks_directory + "/cache"),
-      call(dashboards_directory),
-      call(os.path.join(dashboards_directory, GRAFANA_DASHBOARDS_DIRNAME)),
-      call(os.path.join(dashboards_directory, SERVICE_METRICS_DIRNAME)),
-      call(os.path.join(extensions_directory, "MYEXTENSION")),
+      call(extensions_directory, 0o755),
+      call(mpacks_directory, 0o755),
+      call(mpacks_directory + "/cache", 0o755),
+      call(dashboards_directory, 0o755),
+      call(os.path.join(dashboards_directory, GRAFANA_DASHBOARDS_DIRNAME), 0o755),
+      call(os.path.join(dashboards_directory, SERVICE_METRICS_DIRNAME), 0o755),
+      call(os.path.join(extensions_directory, "MYEXTENSION"), 0o755),
     ]
     create_symlink_calls = [
       call(
@@ -837,10 +837,10 @@ class TestMpacks(TestCase):
     ]
 
     os_mkdir_calls = [
-      call(dashboards_directory),
-      call(os.path.join(dashboards_directory, GRAFANA_DASHBOARDS_DIRNAME)),
-      call(os.path.join(dashboards_directory, SERVICE_METRICS_DIRNAME)),
-      call(os.path.join(common_services_directory, "MYSERVICE")),
+      call(dashboards_directory, 0o755),
+      call(os.path.join(dashboards_directory, GRAFANA_DASHBOARDS_DIRNAME), 0o755),
+      call(os.path.join(dashboards_directory, SERVICE_METRICS_DIRNAME), 0o755),
+      call(os.path.join(common_services_directory, "MYSERVICE"), 0o755),
     ]
     create_symlink_calls = [
       call(
@@ -1126,12 +1126,12 @@ class TestMpacks(TestCase):
     ]
 
     os_mkdir_calls = [
-      call(dashboards_directory),
-      call(os.path.join(dashboards_directory, GRAFANA_DASHBOARDS_DIRNAME)),
-      call(os.path.join(dashboards_directory, SERVICE_METRICS_DIRNAME)),
-      call(os.path.join(common_services_directory, "SERVICEC")),
-      call(os.path.join(stacks_directory, "MYSTACK/3.0")),
-      call(os.path.join(stacks_directory, "MYSTACK/3.0/services")),
+      call(dashboards_directory, 0o755),
+      call(os.path.join(dashboards_directory, GRAFANA_DASHBOARDS_DIRNAME), 0o755),
+      call(os.path.join(dashboards_directory, SERVICE_METRICS_DIRNAME), 0o755),
+      call(os.path.join(common_services_directory, "SERVICEC"), 0o755),
+      call(os.path.join(stacks_directory, "MYSTACK/3.0"), 0o755),
+      call(os.path.join(stacks_directory, "MYSTACK/3.0/services"), 0o755),
     ]
     create_symlink_calls = [
       call(

--- a/ambari-server/src/test/python/TestServiceAdvisor.py
+++ b/ambari-server/src/test/python/TestServiceAdvisor.py
@@ -17,7 +17,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-import imp
+from ambari_commons import import_utils as imp
 import json
 import os
 from unittest import TestCase

--- a/ambari-server/src/test/python/TestStackAdvisor.py
+++ b/ambari-server/src/test/python/TestStackAdvisor.py
@@ -23,7 +23,7 @@ import os
 
 class TestStackAdvisorInitialization(TestCase):
   def setUp(self):
-    import imp
+    from ambari_commons import import_utils as imp
 
     self.test_directory = os.path.dirname(os.path.abspath(__file__))
     resources_path = os.path.join(self.test_directory, "../../main/resources")

--- a/ambari-server/src/test/python/TestVersion.py
+++ b/ambari-server/src/test/python/TestVersion.py
@@ -31,7 +31,7 @@ class TestVersion(TestCase):
   """
 
   def setUp(self):
-    import imp
+    from ambari_commons import import_utils as imp
 
     self.test_directory = os.path.dirname(os.path.abspath(__file__))
     test_file_path = os.path.join(

--- a/ambari-server/src/test/python/TestVersionSelectUtil.py
+++ b/ambari-server/src/test/python/TestVersionSelectUtil.py
@@ -30,7 +30,7 @@ class TestVersionSelectUtil(TestCase):
   """
 
   def setUp(self):
-    import imp
+    from ambari_commons import import_utils as imp
 
     Logger.logger = MagicMock()
 

--- a/ambari-server/src/test/python/stacks/test_stack_adviser.py
+++ b/ambari-server/src/test/python/stacks/test_stack_adviser.py
@@ -23,7 +23,7 @@ from unittest import TestCase
 
 class TestBasicAdvisor(TestCase):
   def setUp(self):
-    import imp
+    from ambari_commons import import_utils as imp
 
     self.maxDiff = None
     self.testDirectory = os.path.dirname(os.path.abspath(__file__))

--- a/ambari-server/src/test/python/stacks/utils/RMFTestCase.py
+++ b/ambari-server/src/test/python/stacks/utils/RMFTestCase.py
@@ -32,7 +32,7 @@ __all__ = [
 from unittest import TestCase
 import json
 import os
-import imp
+from ambari_commons import import_utils as imp
 import sys
 import pprint
 import itertools

--- a/ambari-utility/pom.xml
+++ b/ambari-utility/pom.xml
@@ -160,6 +160,18 @@
         </exclusion>
       </exclusions>
     </dependency>
+    <dependency>
+      <groupId>com.sun.jersey</groupId>
+      <artifactId>jersey-server</artifactId>
+      <version>1.13</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.sun.jersey.contribs</groupId>
+      <artifactId>jersey-multipart</artifactId>
+      <version>1.13</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/ambari-utility/src/test/java/org/apache/ambari/swagger/AmbariSwaggerReaderTest.java
+++ b/ambari-utility/src/test/java/org/apache/ambari/swagger/AmbariSwaggerReaderTest.java
@@ -191,77 +191,104 @@ public class AmbariSwaggerReaderTest {
 
 }
 
+// Ambari uses Jakarta JAX-RS, while the legacy Swagger 1.x reader under test
+// still discovers paths and parameters through the javax annotations.
 @Path("/toplevel")
+@javax.ws.rs.Path("/toplevel")
 @Api(value = "Top Level", description = "A top level API")
 abstract class TopLevelAPI {
 
   @GET
+  @javax.ws.rs.GET
   @Path("/top")
+  @javax.ws.rs.Path("/top")
   @ApiOperation(value = "list")
   public abstract Response getList();
 
   @Path("{param}/nested")
-  public abstract NestedAPI getNested(@ApiParam @PathParam(value = "param") String param);
+  @javax.ws.rs.Path("{param}/nested")
+  public abstract NestedAPI getNested(
+      @ApiParam @PathParam(value = "param") @javax.ws.rs.PathParam(value = "param") String param);
 
   @Path("{param}/nestedWithPreferredParent")
-  public abstract NestedWithPreferredParentAPI getNestedWithPreferredParent(@ApiParam @PathParam(value = "param")
-                                                                                      String param);
+  @javax.ws.rs.Path("{param}/nestedWithPreferredParent")
+  public abstract NestedWithPreferredParentAPI getNestedWithPreferredParent(
+      @ApiParam @PathParam(value = "param") @javax.ws.rs.PathParam(value = "param") String param);
 
   @Path("{param}/nestedWithSamePreferredParent")
-  public abstract NestedWithSamePreferredParentAPI getNestedWithSamePreferredParent(@ApiParam @PathParam(value =
-          "param") String param);
+  @javax.ws.rs.Path("{param}/nestedWithSamePreferredParent")
+  public abstract NestedWithSamePreferredParentAPI getNestedWithSamePreferredParent(
+      @ApiParam @PathParam(value = "param") @javax.ws.rs.PathParam(value = "param") String param);
 }
 
 @Path("/toplevel2")
+@javax.ws.rs.Path("/toplevel2")
 @Api(value = "Top Level 2", description = "Another top level API")
 abstract class AnotherTopLevelAPI {
 
   @GET
+  @javax.ws.rs.GET
   @Path("/anotherTop")
+  @javax.ws.rs.Path("/anotherTop")
   @ApiOperation(value = "list")
   public abstract Response getList();
 
   @Path("{param}/anotherNested")
-  public abstract NestedAPI getSecondNested(@ApiParam @PathParam(value = "param") String param);
+  @javax.ws.rs.Path("{param}/anotherNested")
+  public abstract NestedAPI getSecondNested(
+      @ApiParam @PathParam(value = "param") @javax.ws.rs.PathParam(value = "param") String param);
 
   @Path("{param}/nestedWithPreferredParent")
-  public abstract NestedWithPreferredParentAPI getNestedWithPreferredParent(@ApiParam @PathParam(value = "param")
-                                                                                      String param);
+  @javax.ws.rs.Path("{param}/nestedWithPreferredParent")
+  public abstract NestedWithPreferredParentAPI getNestedWithPreferredParent(
+      @ApiParam @PathParam(value = "param") @javax.ws.rs.PathParam(value = "param") String param);
 
   @Path("{param}/nestedWithSamePreferredParent")
-  public abstract NestedWithSamePreferredParentAPI getNestedWithSamePreferredParent(@ApiParam @PathParam(value =
-          "param") String param);
+  @javax.ws.rs.Path("{param}/nestedWithSamePreferredParent")
+  public abstract NestedWithSamePreferredParentAPI getNestedWithSamePreferredParent(
+      @ApiParam @PathParam(value = "param") @javax.ws.rs.PathParam(value = "param") String param);
 
   @Path("{param}/nestedWithBadPreferredParent")
-  public abstract NestedWithBadPreferredParentAPI getNestedWithBadPreferredParent(@ApiParam @PathParam(value =
-          "param") String param);
+  @javax.ws.rs.Path("{param}/nestedWithBadPreferredParent")
+  public abstract NestedWithBadPreferredParentAPI getNestedWithBadPreferredParent(
+      @ApiParam @PathParam(value = "param") @javax.ws.rs.PathParam(value = "param") String param);
 }
 
 @Path("/toplevel3")
+@javax.ws.rs.Path("/toplevel3")
 @Api(value = "Top Level 3", description = "Yet another top level API")
 abstract class YetAnotherTopLevelAPI {
 
   @GET
+  @javax.ws.rs.GET
   @Path("/yetAnotherTop")
+  @javax.ws.rs.Path("/yetAnotherTop")
   @ApiOperation(value = "list")
   public abstract Response getList();
 
   @Path("{param}/nested")
-  public abstract NestedAPI getFirstNested(@ApiParam @PathParam(value = "param") String param);
+  @javax.ws.rs.Path("{param}/nested")
+  public abstract NestedAPI getFirstNested(
+      @ApiParam @PathParam(value = "param") @javax.ws.rs.PathParam(value = "param") String param);
 
 }
 
 @Path("/toplevel4")
+@javax.ws.rs.Path("/toplevel4")
 @Api(value = "Top Level 4", description = "Yet another top level API")
 abstract class TopLevel4API {
 
   @GET
+  @javax.ws.rs.GET
   @Path("/top")
+  @javax.ws.rs.Path("/top")
   @ApiOperation(value = "list")
   public abstract Response getList();
 
   @Path("{param}/nested")
-  public abstract NestedWithOverwrite getNested(@ApiParam @PathParam(value = "param") String param);
+  @javax.ws.rs.Path("{param}/nested")
+  public abstract NestedWithOverwrite getNested(
+      @ApiParam @PathParam(value = "param") @javax.ws.rs.PathParam(value = "param") String param);
 
 }
 
@@ -269,18 +296,23 @@ abstract class TopLevel4API {
 abstract class NestedAPI {
 
   @GET
+  @javax.ws.rs.GET
   @Path("/list")
+  @javax.ws.rs.Path("/list")
   @ApiOperation(value = "list")
   public abstract Response getList();
 
 }
 
 @Path("/canBeReachedFromTopToo")
+@javax.ws.rs.Path("/canBeReachedFromTopToo")
 @Api(value = "Nested and Top Level", description = "An API that is both nested and top level")
 abstract class NestedAndTopLevelAPI {
 
   @GET
+  @javax.ws.rs.GET
   @Path("/list")
+  @javax.ws.rs.Path("/list")
   @ApiOperation(value = "list")
   public abstract Response getList();
 
@@ -291,7 +323,9 @@ abstract class NestedAndTopLevelAPI {
 abstract class NestedWithPreferredParentAPI {
 
   @GET
+  @javax.ws.rs.GET
   @Path("/list")
+  @javax.ws.rs.Path("/list")
   @ApiOperation(value = "list")
   public abstract Response getList();
 
@@ -302,7 +336,9 @@ abstract class NestedWithPreferredParentAPI {
 abstract class NestedWithSamePreferredParentAPI {
 
   @GET
+  @javax.ws.rs.GET
   @Path("/list")
+  @javax.ws.rs.Path("/list")
   @ApiOperation(value = "list")
   public abstract Response getList();
 
@@ -313,7 +349,9 @@ abstract class NestedWithSamePreferredParentAPI {
 abstract class NestedWithBadPreferredParentAPI {
 
   @GET
+  @javax.ws.rs.GET
   @Path("/list")
+  @javax.ws.rs.Path("/list")
   @ApiOperation(value = "list")
   public abstract Response getList();
 
@@ -325,7 +363,9 @@ abstract class NestedWithBadPreferredParentAPI {
 abstract class NestedWithOverwrite {
 
   @GET
+  @javax.ws.rs.GET
   @Path("/list")
+  @javax.ws.rs.Path("/list")
   @ApiOperation(value = "list")
   public abstract Response getList();
 

--- a/ambari-web/latest/src/components/AssignMastersAddable.test.tsx
+++ b/ambari-web/latest/src/components/AssignMastersAddable.test.tsx
@@ -303,9 +303,11 @@ describe("master assignment validation", () => {
     expect((await screen.findByRole("alert")).textContent).toContain(
       "Host API unavailable",
     );
-    expect(onLoadStateChange).toHaveBeenLastCalledWith({
-      status: "error",
-      error: "Host API unavailable",
+    await waitFor(() => {
+      expect(onLoadStateChange).toHaveBeenLastCalledWith({
+        status: "error",
+        error: "Host API unavailable",
+      });
     });
 
     fireEvent.click(screen.getByRole("button", { name: "Retry" }));

--- a/ambari-web/latest/src/hooks/useDebounce.test.tsx
+++ b/ambari-web/latest/src/hooks/useDebounce.test.tsx
@@ -1,0 +1,45 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { useDebounce } from "./useDebounce";
+
+describe("useDebounce", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("uses the latest callback when a pending invocation runs", () => {
+    vi.useFakeTimers();
+    const firstCallback = vi.fn();
+    const latestCallback = vi.fn();
+    const { result, rerender } = renderHook(
+      ({ callback }) => useDebounce(callback, 300),
+      { initialProps: { callback: firstCallback } },
+    );
+
+    act(() => result.current("value"));
+    rerender({ callback: latestCallback });
+    act(() => vi.advanceTimersByTime(300));
+
+    expect(firstCallback).not.toHaveBeenCalled();
+    expect(latestCallback).toHaveBeenCalledOnce();
+    expect(latestCallback).toHaveBeenCalledWith("value");
+  });
+});

--- a/ambari-web/latest/src/hooks/useDebounce.ts
+++ b/ambari-web/latest/src/hooks/useDebounce.ts
@@ -18,28 +18,32 @@
 
 import React from "react";
 
-export const useDebounce = (  callback: (...args: any[]) => void,
+export const useDebounce = <Args extends unknown[]>(
+  callback: (...args: Args) => void,
   delay: number,
 ) => {
   const callbackRef = React.useRef(callback);
+  const timerRef = React.useRef<ReturnType<typeof setTimeout> | undefined>(
+    undefined,
+  );
+
   React.useLayoutEffect(() => {
     callbackRef.current = callback;
   });
-  let timer: ReturnType<typeof setTimeout>;
-  const naiveDebounce = (    func: (...args: any[]) => void,
-    delayMs: number,
-    ...args: any[]
-  ) => {
-    clearTimeout(timer);
-    timer = setTimeout(() => { 
-      func(...args);
-    }, delayMs);  };
-  
-  return React.useMemo(() => (...args: any) => naiveDebounce(
-    callbackRef.current,
-    delay, 
-    ...args,
-  ), [delay]);
+
+  React.useEffect(
+    () => () => {
+      clearTimeout(timerRef.current);
+    },
+    [delay],
+  );
+
+  return React.useCallback(
+    (...args: Args) => {
+      clearTimeout(timerRef.current);
+      timerRef.current = setTimeout(() => callbackRef.current(...args), delay);
+    },
+    [delay],
+  );
 };
- 
  

--- a/ambari-web/latest/src/screens/CommonConfigs/AdvancedConfigs.tsx
+++ b/ambari-web/latest/src/screens/CommonConfigs/AdvancedConfigs.tsx
@@ -19,6 +19,7 @@
 import { Fragment, useEffect, useState } from "react";
 import {
   configGroupOverrides,
+  ConfigPropertiesType,
   InputType,
   PropertyType,
   TruthValues,
@@ -72,7 +73,10 @@ type AdvancedConfigsType = {
   stack?: string;
   stackVersion?: string;
   hosts?: string[];
-  onValueUpdateProp?: () => void;
+  onValueUpdateProp?: (
+    config: PropertyType,
+    configProperties: ConfigPropertiesType,
+  ) => void;
   searchString?: string;
   canEdit?: boolean;
 };

--- a/ambari-web/latest/src/screens/CommonConfigs/Config.theme.test.tsx
+++ b/ambari-web/latest/src/screens/CommonConfigs/Config.theme.test.tsx
@@ -986,7 +986,9 @@ describe("Ember Service Theme page integration", () => {
       target: { value: "hide" },
     });
 
-    expect(await screen.findByDisplayValue("hide")).toBeTruthy();
+    expect(
+      await screen.findByDisplayValue("hide", {}, { timeout: 3000 }),
+    ).toBeTruthy();
     await waitFor(() =>
       expect(screen.queryByDisplayValue("primary value")).toBeNull(),
     );
@@ -1305,10 +1307,18 @@ describe("Ember Service Theme page integration", () => {
 
     expect(await screen.findByText("1.501KB")).toBeTruthy();
     expect(
-      screen.getByRole("button", { name: "Use default value: 0 KB" }),
+      await screen.findByRole(
+        "button",
+        { name: "Use default value: 0 KB" },
+        { timeout: 3000 },
+      ),
     ).toBeTruthy();
     expect(
-      screen.getByRole("button", { name: "Use recommended value: 0 KB" }),
+      await screen.findByRole(
+        "button",
+        { name: "Use recommended value: 0 KB" },
+        { timeout: 3000 },
+      ),
     ).toBeTruthy();
 
     fireEvent.click(

--- a/ambari-web/latest/vite.config.ts
+++ b/ambari-web/latest/vite.config.ts
@@ -25,5 +25,6 @@ export default defineConfig({
   test: {
     environment: 'jsdom',
     setupFiles: ['./src/test/setup.ts'],
+    testTimeout: 10_000,
   },
 })

--- a/ambari-web/pom.xml
+++ b/ambari-web/pom.xml
@@ -112,8 +112,8 @@
                             <goal>install-node-and-npm</goal>
                         </goals>
                         <configuration>
-                            <nodeVersion>v20.11.0</nodeVersion>
-                            <npmVersion>10.8.3</npmVersion>
+                            <nodeVersion>v22.23.1</nodeVersion>
+                            <npmVersion>10.9.8</npmVersion>
                             <workingDirectory>${ui2dir}</workingDirectory>
                             <npmInheritsProxyConfigFromMaven>false</npmInheritsProxyConfigFromMaven>
                         </configuration>
@@ -125,7 +125,7 @@
                         <goal>npm</goal>
                         </goals>
                         <configuration>
-                        <arguments>install</arguments>
+                        <arguments>ci --no-audit --no-fund</arguments>
                         <workingDirectory>${ui2dir}</workingDirectory>
                         </configuration>
                     </execution>
@@ -392,13 +392,6 @@
                             </resources>
                         </configuration>
                     </execution>
-                </executions>
-        </plugin>
-        <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-resources-plugin</artifactId>
-                <version>3.2.0</version>
-                <executions>
                     <execution>
                         <id>copy-react-resources</id>
                         <phase>process-resources</phase>
@@ -415,13 +408,6 @@
                             </resources>
                         </configuration>
                     </execution>
-                </executions>
-        </plugin>
-        <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-resources-plugin</artifactId>
-                <version>3.2.0</version>
-                <executions>
                     <execution>
                         <id>copy-public-folder</id>
                         <phase>process-resources</phase>
@@ -461,7 +447,7 @@
                         </configuration>
                     </execution>
                 </executions>
-        </plugin>
+            </plugin>
     </plugins>
     </build>
     <profiles>

--- a/ambari-web/pom.xml
+++ b/ambari-web/pom.xml
@@ -34,6 +34,7 @@
         <nodemodules.dir>node_modules</nodemodules.dir> <!-- specify -Dnodemodules.dir option to reduce ambari-web build time by not re-downloading npm modules -->
         <uidir>${basedir}/classic</uidir>
         <ui2dir>${basedir}/latest</ui2dir>
+        <skipUiBuild>false</skipUiBuild>
     </properties>
     <build>
         <plugins>
@@ -77,6 +78,7 @@
                 <artifactId>frontend-maven-plugin</artifactId>
                 <version>1.11.0</version>
                 <configuration>
+                    <skip>${skipUiBuild}</skip>
                     <nodeVersion>v4.5.0</nodeVersion>
                     <yarnVersion>v0.23.2</yarnVersion>
                     <workingDirectory>${uidir}</workingDirectory>
@@ -149,6 +151,9 @@
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>exec-maven-plugin</artifactId>
                 <version>1.2.1</version>
+                <configuration>
+                    <skip>${skipUiBuild}</skip>
+                </configuration>
                 <executions>
                     <execution>
                         <id>clean-rmdir</id>
@@ -451,6 +456,18 @@
     </plugins>
     </build>
     <profiles>
+        <profile>
+            <id>skip-ui-build</id>
+            <activation>
+                <property>
+                    <name>skipUiBuild</name>
+                    <value>true</value>
+                </property>
+            </activation>
+            <properties>
+                <skipTests>true</skipTests>
+            </properties>
+        </profile>
         <profile>
             <id>windows</id>
             <activation>

--- a/contrib/management-packs/isilon-onefs-mpack/src/main/resources/addon-services/ONEFS/1.0.0/service_advisor.py
+++ b/contrib/management-packs/isilon-onefs-mpack/src/main/resources/addon-services/ONEFS/1.0.0/service_advisor.py
@@ -18,7 +18,7 @@ limitations under the License.
 """
 import os
 from ambari_commons import inet_utils
-import imp
+from ambari_commons import import_utils as imp
 import traceback
 
 def error(message): return {"level": "ERROR", "message": message}
@@ -103,7 +103,7 @@ try:
     service_advisor = imp.load_module('service_advisor', fp, PARENT_FILE, ('.py', 'rb', imp.PY_SOURCE))
 except Exception as e:
   traceback.print_exc()
-  print "Failed to load parent"
+  print("Failed to load parent")
 else:
   class ONEFSServiceAdvisor(service_advisor.ServiceAdvisor):
     def getServiceConfigurationRecommendations(self, configs, clusterData, services, hosts):

--- a/contrib/management-packs/isilon-onefs-mpack/src/test/python/TestServiceAdvisor.py
+++ b/contrib/management-packs/isilon-onefs-mpack/src/test/python/TestServiceAdvisor.py
@@ -46,23 +46,23 @@ class TestUri(TestCase):
     onefs_host = Uri.onefs(configs)
     default_fs = Uri.default_fs(configs)
     fixed = default_fs.fix_host(onefs_host)
-    self.assertEquals('hdfs://scisilon.fqdn:8020', fixed)
+    self.assertEqual('hdfs://scisilon.fqdn:8020', fixed)
 
   def test_skip_replacing_to_empty_host(self):
     default_fs = Uri.default_fs(configs)
-    self.assertEquals('hdfs://localhost:8020', default_fs.fix_host(Uri("")))
+    self.assertEqual('hdfs://localhost:8020', default_fs.fix_host(Uri("")))
 
   def test_skip_fixing_invalid_host(self):
     default_fs = Uri("hdfs://:8080")
-    self.assertEquals('hdfs://:8080', default_fs.fix_host(Uri("host")))
+    self.assertEqual('hdfs://:8080', default_fs.fix_host(Uri("host")))
 
   def test_core_site_validation_error_on_host_mismatch(self):
     core_site = CoreSite(configs)
     erros = core_site.validate()
-    self.assertEquals(len(erros), 1)
-    self.assertEquals(erros[0]['config-name'], 'fs.defaultFS')
+    self.assertEqual(len(erros), 1)
+    self.assertEqual(erros[0]['config-name'], 'fs.defaultFS')
 
   def test_hdfs_site_no_validation_error(self):
     hdfs_site = HdfsSite(configs)
     erros = hdfs_site.validate()
-    self.assertEquals(len(erros), 0)
+    self.assertEqual(len(erros), 0)

--- a/contrib/management-packs/microsoft-r_mpack/src/main/resources/common-services/MICROSOFT_R_SERVER/8.0.5/service_advisor.py
+++ b/contrib/management-packs/microsoft-r_mpack/src/main/resources/common-services/MICROSOFT_R_SERVER/8.0.5/service_advisor.py
@@ -18,7 +18,7 @@ limitations under the License.
 """
 import os
 import fnmatch
-import imp
+from ambari_commons import import_utils as imp
 import socket
 import sys
 import traceback
@@ -32,7 +32,7 @@ try:
     service_advisor = imp.load_module('service_advisor', fp, PARENT_FILE, ('.py', 'rb', imp.PY_SOURCE))
 except Exception as e:
   traceback.print_exc()
-  print "Failed to load parent"
+  print("Failed to load parent")
 
 class MICROSOFT_R_SERVER805ServiceAdvisor(service_advisor.ServiceAdvisor):
 

--- a/contrib/views/capacity-scheduler/pom.xml
+++ b/contrib/views/capacity-scheduler/pom.xml
@@ -125,6 +125,7 @@
 
     <properties>
       <ambari.dir>${project.parent.parent.parent.basedir}</ambari.dir>
+      <skipUiBuild>false</skipUiBuild>
       <ui.directory>${basedir}/src/main/resources/ui</ui.directory>
     </properties>
 
@@ -153,6 +154,7 @@
         <artifactId>frontend-maven-plugin</artifactId>
         <version>1.11.0</version>
         <configuration>
+          <skip>${skipUiBuild}</skip>
           <nodeVersion>v22.23.1</nodeVersion>
           <npmVersion>10.9.8</npmVersion>
           <workingDirectory>${ui.directory}</workingDirectory>

--- a/contrib/views/capacity-scheduler/pom.xml
+++ b/contrib/views/capacity-scheduler/pom.xml
@@ -109,7 +109,6 @@
         <dependency>
             <groupId>org.easymock</groupId>
             <artifactId>easymock</artifactId>
-            <version>3.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -154,8 +153,8 @@
         <artifactId>frontend-maven-plugin</artifactId>
         <version>1.11.0</version>
         <configuration>
-          <nodeVersion>v20.11.0</nodeVersion>
-          <npmVersion>10.8.3</npmVersion>
+          <nodeVersion>v22.23.1</nodeVersion>
+          <npmVersion>10.9.8</npmVersion>
           <workingDirectory>${ui.directory}</workingDirectory>
           <npmInheritsProxyConfigFromMaven>false</npmInheritsProxyConfigFromMaven>
         </configuration>

--- a/contrib/views/capacity-scheduler/src/main/resources/ui/index.html
+++ b/contrib/views/capacity-scheduler/src/main/resources/ui/index.html
@@ -1,9 +1,19 @@
 <!doctype html>
 <!--
    Licensed to the Apache Software Foundation (ASF) under one or more
-   contributor license agreements. See the NOTICE file distributed with
+   contributor license agreements.  See the NOTICE file distributed with
    this work for additional information regarding copyright ownership.
-   The ASF licenses this file to You under the Apache License, Version 2.0.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
 -->
 <html lang="en">
   <head>

--- a/contrib/views/capacity-scheduler/src/main/resources/ui/src/App.test.tsx
+++ b/contrib/views/capacity-scheduler/src/main/resources/ui/src/App.test.tsx
@@ -1,8 +1,18 @@
 /**
  * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements. See the NOTICE file distributed with
+ * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";

--- a/contrib/views/capacity-scheduler/src/main/resources/ui/src/App.tsx
+++ b/contrib/views/capacity-scheduler/src/main/resources/ui/src/App.tsx
@@ -1,8 +1,18 @@
 /**
  * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements. See the NOTICE file distributed with
+ * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 import {
   AlertTriangle,

--- a/contrib/views/capacity-scheduler/src/main/resources/ui/src/components/Dialog.tsx
+++ b/contrib/views/capacity-scheduler/src/main/resources/ui/src/components/Dialog.tsx
@@ -1,8 +1,18 @@
 /**
  * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements. See the NOTICE file distributed with
+ * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 import { X } from "lucide-react";
 

--- a/contrib/views/capacity-scheduler/src/main/resources/ui/src/components/QueueEditor.tsx
+++ b/contrib/views/capacity-scheduler/src/main/resources/ui/src/components/QueueEditor.tsx
@@ -1,8 +1,18 @@
 /**
  * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements. See the NOTICE file distributed with
+ * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 import { Pencil, RotateCcw } from "lucide-react";
 import { useState } from "react";

--- a/contrib/views/capacity-scheduler/src/main/resources/ui/src/components/QueueTree.tsx
+++ b/contrib/views/capacity-scheduler/src/main/resources/ui/src/components/QueueTree.tsx
@@ -1,8 +1,18 @@
 /**
  * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements. See the NOTICE file distributed with
+ * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 import { ChevronDown, ChevronRight, CirclePause, CirclePlay, Plus, Trash2 } from "lucide-react";
 import { useState } from "react";

--- a/contrib/views/capacity-scheduler/src/main/resources/ui/src/main.tsx
+++ b/contrib/views/capacity-scheduler/src/main/resources/ui/src/main.tsx
@@ -1,8 +1,18 @@
 /**
  * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements. See the NOTICE file distributed with
+ * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";

--- a/contrib/views/capacity-scheduler/src/main/resources/ui/src/styles.css
+++ b/contrib/views/capacity-scheduler/src/main/resources/ui/src/styles.css
@@ -1,8 +1,18 @@
 /**
  * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements. See the NOTICE file distributed with
+ * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 :root {
   font-family: "IBM Plex Sans", "Helvetica Neue", sans-serif;

--- a/contrib/views/files/pom.xml
+++ b/contrib/views/files/pom.xml
@@ -154,6 +154,7 @@
 
   <properties>
     <ambari.dir>${project.parent.parent.parent.basedir}</ambari.dir>
+    <jetty.version>9.4.43.v20210629</jetty.version>
     <ui.directory>${basedir}/src/main/resources/ui</ui.directory>
   </properties>
   <build>
@@ -184,8 +185,8 @@
         <artifactId>frontend-maven-plugin</artifactId>
         <version>1.11.0</version>
         <configuration>
-          <nodeVersion>v20.11.0</nodeVersion>
-          <npmVersion>10.8.3</npmVersion>
+          <nodeVersion>v22.23.1</nodeVersion>
+          <npmVersion>10.9.8</npmVersion>
           <workingDirectory>src/main/resources/ui/</workingDirectory>
           <npmInheritsProxyConfigFromMaven>false</npmInheritsProxyConfigFromMaven>
         </configuration>

--- a/contrib/views/files/pom.xml
+++ b/contrib/views/files/pom.xml
@@ -155,6 +155,7 @@
   <properties>
     <ambari.dir>${project.parent.parent.parent.basedir}</ambari.dir>
     <jetty.version>9.4.43.v20210629</jetty.version>
+    <skipUiBuild>false</skipUiBuild>
     <ui.directory>${basedir}/src/main/resources/ui</ui.directory>
   </properties>
   <build>
@@ -185,6 +186,7 @@
         <artifactId>frontend-maven-plugin</artifactId>
         <version>1.11.0</version>
         <configuration>
+          <skip>${skipUiBuild}</skip>
           <nodeVersion>v22.23.1</nodeVersion>
           <npmVersion>10.9.8</npmVersion>
           <workingDirectory>src/main/resources/ui/</workingDirectory>

--- a/contrib/views/files/src/main/resources/ui/index.html
+++ b/contrib/views/files/src/main/resources/ui/index.html
@@ -1,9 +1,19 @@
 <!doctype html>
 <!--
    Licensed to the Apache Software Foundation (ASF) under one or more
-   contributor license agreements. See the NOTICE file distributed with
+   contributor license agreements.  See the NOTICE file distributed with
    this work for additional information regarding copyright ownership.
-   The ASF licenses this file to You under the Apache License, Version 2.0.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
 -->
 <html lang="en">
   <head>

--- a/contrib/views/files/src/main/resources/ui/src/App.test.tsx
+++ b/contrib/views/files/src/main/resources/ui/src/App.test.tsx
@@ -1,8 +1,18 @@
 /**
  * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements. See the NOTICE file distributed with
+ * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";

--- a/contrib/views/files/src/main/resources/ui/src/App.tsx
+++ b/contrib/views/files/src/main/resources/ui/src/App.tsx
@@ -1,8 +1,18 @@
 /**
  * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements. See the NOTICE file distributed with
+ * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 import {
   ArrowLeft,

--- a/contrib/views/files/src/main/resources/ui/src/components/DirectoryPicker.tsx
+++ b/contrib/views/files/src/main/resources/ui/src/components/DirectoryPicker.tsx
@@ -1,8 +1,18 @@
 /**
  * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements. See the NOTICE file distributed with
+ * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 import { ArrowUp, Folder } from "lucide-react";
 import { useEffect, useState } from "react";

--- a/contrib/views/files/src/main/resources/ui/src/components/FileTable.tsx
+++ b/contrib/views/files/src/main/resources/ui/src/components/FileTable.tsx
@@ -1,8 +1,18 @@
 /**
  * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements. See the NOTICE file distributed with
+ * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 import { ChevronDown, ChevronUp, File, Folder, LockKeyhole, ShieldCheck } from "lucide-react";
 import { basename, formatDate, humanSize } from "../format";

--- a/contrib/views/files/src/main/resources/ui/src/components/Modal.tsx
+++ b/contrib/views/files/src/main/resources/ui/src/components/Modal.tsx
@@ -1,8 +1,18 @@
 /**
  * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements. See the NOTICE file distributed with
+ * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 import { X } from "lucide-react";
 import type { PropsWithChildren, ReactNode } from "react";

--- a/contrib/views/files/src/main/resources/ui/src/main.tsx
+++ b/contrib/views/files/src/main/resources/ui/src/main.tsx
@@ -1,8 +1,18 @@
 /**
  * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements. See the NOTICE file distributed with
+ * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";

--- a/contrib/views/files/src/main/resources/ui/src/styles.css
+++ b/contrib/views/files/src/main/resources/ui/src/styles.css
@@ -1,8 +1,18 @@
 /**
  * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements. See the NOTICE file distributed with
+ * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 :root {
   color: #1d2733;

--- a/contrib/views/pom.xml
+++ b/contrib/views/pom.xml
@@ -183,12 +183,12 @@
       <dependency>
         <groupId>com.google.inject</groupId>
         <artifactId>guice</artifactId>
-        <version>4.0-beta</version>
+        <version>${guice.version}</version>
       </dependency>
       <dependency>
         <groupId>org.easymock</groupId>
         <artifactId>easymock</artifactId>
-        <version>3.2</version>
+        <version>5.2.0</version>
         <scope>test</scope>
       </dependency>
       <dependency>

--- a/contrib/views/utils/pom.xml
+++ b/contrib/views/utils/pom.xml
@@ -245,6 +245,7 @@
 
   <properties>
     <ambari.dir>${project.parent.parent.parent.basedir}</ambari.dir>
+    <jetty.version>9.4.43.v20210629</jetty.version>
   </properties>
   <build>
   </build>


### PR DESCRIPTION
Issue: [AMBARI-26639](https://issues.apache.org/jira/browse/AMBARI-26639)

## What changes were proposed in this pull request?

Restore Python 3.12 compatibility with an importlib-backed compatibility layer, repair Java 17 and Jakarta-related server, utility, functional, and contrib-view tests, stabilize the maintained React tests and builds, and replace the legacy WebUI Jenkins stage with parallel React-only validation for Ambari, Admin, Files, and Capacity Scheduler. Jenkins no longer invokes Ember or Angular tests.

## How was this patch tested?

All maintained Python, Java, and React test suites passed locally. Maven reactor model validation and Apache RAT checks also passed.

```shell
mvn -s /tmp/ambari-maven-central-settings.xml -B -DskipTests -DskipPythonTests=true -DskipAdminWebTests=true validate
mvn -s /tmp/ambari-maven-central-settings.xml -B -DskipTests -DskipPythonTests=true -DskipAdminWebTests=true apache-rat:check
./node/node ./node/node_modules/npm/bin/npm-cli.js test
./node/node ./node/node_modules/npm/bin/npm-cli.js run build
```

Python: 746 tests passed (Agent 386, Server 352, Isilon 5, import helper 3).
Java: Ambari Server ran 5,380 tests with 0 failures and 0 errors; functional tests ran 5 tests with 0 failures and 1 existing skip; agent ZK migrator ran 11 tests.
React: Ambari 993, Admin 223, Files 12, and Capacity Scheduler 16 tests passed; all four production builds passed.

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.