### PR TITLE
AMBARI-26641: Separate Ambari and stack JDK configuration after JDK 17 upgrade

### DIFF
--- a/ambari-agent/src/main/python/ambari_agent/ConfigurationBuilder.py
+++ b/ambari-agent/src/main/python/ambari_agent/ConfigurationBuilder.py
@@ -18,7 +18,15 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+import logging
+import os
+
+import ambari_simplejson as json
+
 from ambari_agent import hostname
+
+
+logger = logging.getLogger(__name__)
 
 
 class ConfigurationBuilder:
@@ -79,9 +87,12 @@ class ConfigurationBuilder:
     else:
       command_dict = {"agentLevelParams": {}}
 
-    command_dict["ambariLevelParams"] = (
+    command_dict["ambariLevelParams"] = dict(
       self.metadata_cache.get_cluster_indepedent_data().clusterLevelParams
     )
+
+    if cluster_id:
+      self._apply_java_home_override(command_dict, service_name, component_name)
 
     command_dict["agentLevelParams"].update(
       {
@@ -96,6 +107,84 @@ class ConfigurationBuilder:
       }
     }
     return command_dict
+
+  @staticmethod
+  def _apply_java_home_override(command_dict, service_name, component_name):
+    raw_overrides = (
+      command_dict.get("configurations", {})
+      .get("cluster-env", {})
+      .get("java_home_overrides")
+    )
+    if not raw_overrides:
+      return
+
+    try:
+      overrides = json.loads(raw_overrides)
+    except (TypeError, ValueError) as exception:
+      logger.warning("Ignoring invalid cluster-env/java_home_overrides: %s", exception)
+      return
+
+    if not isinstance(overrides, dict):
+      logger.warning("Ignoring cluster-env/java_home_overrides because it is not a JSON object")
+      return
+
+    normalized_overrides = {
+      str(key).upper(): value for key, value in overrides.items()
+    }
+    override_key = next(
+      (
+        str(name).upper()
+        for name in (component_name, service_name)
+        if name and str(name).upper() in normalized_overrides
+      ),
+      None,
+    )
+    if override_key is None:
+      return
+
+    override = normalized_overrides[override_key]
+    if not isinstance(override, dict):
+      logger.warning("Ignoring Java home override for %s because it is not an object", override_key)
+      return
+
+    java_home = override.get("home")
+    java_version = override.get("version")
+    if isinstance(java_version, bool) or not isinstance(java_version, (int, str)):
+      java_version = None
+    else:
+      try:
+        java_version = int(java_version)
+      except ValueError:
+        java_version = None
+
+    if not isinstance(java_home, str) or not java_home.strip():
+      logger.warning(
+        "Ignoring Java home override for %s because both home and version are required",
+        override_key,
+      )
+      return
+
+    java_home = java_home.strip()
+    if java_version is None or java_version < 1:
+      logger.warning(
+        "Ignoring Java home override for %s because both home and version are required",
+        override_key,
+      )
+      return
+
+    if not os.path.isfile(os.path.join(java_home, "bin", "java")):
+      logger.warning(
+        "Ignoring Java home override for %s because %s/bin/java is not installed",
+        override_key,
+        java_home,
+      )
+      return
+
+    ambari_level_params = command_dict["ambariLevelParams"]
+    ambari_level_params["java_home"] = java_home
+    ambari_level_params["java_version"] = str(java_version)
+    ambari_level_params["jdk_name"] = None
+    ambari_level_params["jce_name"] = None
 
   @property
   def public_fqdn(self):

--- a/ambari-agent/src/main/python/ambari_agent/CustomServiceOrchestrator.py
+++ b/ambari-agent/src/main/python/ambari_agent/CustomServiceOrchestrator.py
@@ -293,7 +293,7 @@ class CustomServiceOrchestrator(object):
     )
 
     # Set up the variables for the external command to generate a JCEKS file
-    java_home = commandJson["ambariLevelParams"]["java_home"]
+    java_home = commandJson["ambariLevelParams"]["ambari_java_home"]
     java_bin = f"{java_home}/bin/java"
 
     cs_lib_path = self.credential_shell_lib_path

--- a/ambari-agent/src/test/python/ambari_agent/TestConfigurationBuilder.py
+++ b/ambari-agent/src/test/python/ambari_agent/TestConfigurationBuilder.py
@@ -35,3 +35,90 @@ class TestConfigurationBuilder(TestCase):
 
     config_builder = ConfigurationBuilder(initializer_module)
     self.assertEqual("c6401.ambari.apache.org", config_builder.public_fqdn)
+
+  @patch("ambari_agent.ConfigurationBuilder.os.path.isfile", return_value=True)
+  def test_component_java_home_override_takes_precedence(self, isfile_mock):
+    command = self._command_with_overrides(
+      '{"SOLR": {"home": "/java/service", "version": 11}, '
+      '"SOLR_SERVER": {"home": "/java/component", "version": 17}}'
+    )
+
+    ConfigurationBuilder._apply_java_home_override(
+      command, "SOLR", "SOLR_SERVER"
+    )
+
+    self.assertEqual("/java/component", command["ambariLevelParams"]["java_home"])
+    self.assertEqual("17", command["ambariLevelParams"]["java_version"])
+    self.assertEqual(
+      "/java/ambari", command["ambariLevelParams"]["ambari_java_home"]
+    )
+    self.assertIsNone(command["ambariLevelParams"]["jdk_name"])
+    isfile_mock.assert_called_once_with("/java/component/bin/java")
+
+  @patch("ambari_agent.ConfigurationBuilder.os.path.isfile", return_value=True)
+  def test_service_java_home_override_is_used_as_fallback(self, isfile_mock):
+    command = self._command_with_overrides(
+      '{"solr": {"home": "/java/service", "version": "11"}}'
+    )
+
+    ConfigurationBuilder._apply_java_home_override(
+      command, "SOLR", "SOLR_SERVER"
+    )
+
+    self.assertEqual("/java/service", command["ambariLevelParams"]["java_home"])
+    self.assertEqual("11", command["ambariLevelParams"]["java_version"])
+    isfile_mock.assert_called_once_with("/java/service/bin/java")
+
+  def test_invalid_java_home_override_keeps_stack_default(self):
+    command = self._command_with_overrides(
+      '{"SOLR": {"home": "/java/service"}}'
+    )
+
+    ConfigurationBuilder._apply_java_home_override(
+      command, "SOLR", "SOLR_SERVER"
+    )
+
+    self.assertEqual("/java/stack", command["ambariLevelParams"]["java_home"])
+    self.assertEqual("11", command["ambariLevelParams"]["java_version"])
+
+  def test_invalid_java_home_override_version_type_keeps_stack_default(self):
+    command = self._command_with_overrides(
+      '{"SOLR": {"home": "/java/service", "version": true}}'
+    )
+
+    ConfigurationBuilder._apply_java_home_override(
+      command, "SOLR", "SOLR_SERVER"
+    )
+
+    self.assertEqual("/java/stack", command["ambariLevelParams"]["java_home"])
+    self.assertEqual("11", command["ambariLevelParams"]["java_version"])
+
+  @patch("ambari_agent.ConfigurationBuilder.os.path.isfile", return_value=False)
+  def test_missing_java_home_override_keeps_stack_default(self, isfile_mock):
+    command = self._command_with_overrides(
+      '{"SOLR": {"home": "/java/missing", "version": 17}}'
+    )
+
+    ConfigurationBuilder._apply_java_home_override(
+      command, "SOLR", "SOLR_SERVER"
+    )
+
+    self.assertEqual("/java/stack", command["ambariLevelParams"]["java_home"])
+    self.assertEqual("11", command["ambariLevelParams"]["java_version"])
+    isfile_mock.assert_called_once_with("/java/missing/bin/java")
+
+  @staticmethod
+  def _command_with_overrides(overrides):
+    return {
+      "ambariLevelParams": {
+        "ambari_java_home": "/java/ambari",
+        "ambari_java_version": "17",
+        "java_home": "/java/stack",
+        "java_version": "11",
+        "jdk_name": "stack-jdk.tar.gz",
+        "jce_name": "stack-jce.zip",
+      },
+      "configurations": {
+        "cluster-env": {"java_home_overrides": overrides},
+      },
+    }

--- a/ambari-server/conf/unix/ambari.properties
+++ b/ambari-server/conf/unix/ambari.properties
@@ -23,18 +23,10 @@ resources.dir = $ROOT/var/lib/ambari-server/resources
 shared.resources.dir = $ROOT/usr/lib/ambari-server/lib/ambari_commons/resources
 custom.action.definitions = $ROOT/var/lib/ambari-server/resources/custom_action_definitions
 
-java.releases=jdk1.8
+java.releases=
 java.releases.ppc64le=
-
-jdk1.8.desc=Oracle JDK 1.8 + Java Cryptography Extension (JCE) Policy Files 8
-jdk1.8.url=http://public-repo-1.hortonworks.com/ARTIFACTS/jdk-8u112-linux-x64.tar.gz
-jdk1.8.dest-file=jdk-8u112-linux-x64.tar.gz
-jdk1.8.jcpol-url=http://public-repo-1.hortonworks.com/ARTIFACTS/jce_policy-8.zip
-jdk1.8.jcpol-file=jce_policy-8.zip
-jdk1.8.home=$ROOT/usr/jdk64/
-jdk1.8.re=(jdk.*)/jre
-jdk.download.supported=true
-jce.download.supported=true
+jdk.download.supported=false
+jce.download.supported=false
 
 metadata.path=$ROOT/var/lib/ambari-server/resources/stacks
 common.services.path=$ROOT/var/lib/ambari-server/resources/common-services

--- a/ambari-server/src/main/java/org/apache/ambari/server/configuration/Configuration.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/configuration/Configuration.java
@@ -813,12 +813,18 @@ public class Configuration {
   /**
    * The name of the Ambari JDK installation binary.
    */
+  @Markdown(
+      description = "The name of the Ambari JDK installation binary.",
+      examples = { "jdk-17-linux-x64.tar.gz" })
   public static final ConfigurationProperty<String> AMBARI_JDK_NAME = new ConfigurationProperty<>(
       "ambari.jdk.name", null);
 
   /**
    * The name of the Ambari JCE policy ZIP file.
    */
+  @Markdown(
+      description = "The name of the Ambari JCE policy ZIP file.",
+      examples = { "jce-policy.zip" })
   public static final ConfigurationProperty<String> AMBARI_JCE_NAME = new ConfigurationProperty<>(
       "ambari.jce.name", null);
 

--- a/ambari-server/src/main/java/org/apache/ambari/server/configuration/Configuration.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/configuration/Configuration.java
@@ -181,7 +181,7 @@ public class Configuration {
   /**
    * The minimum JDK version supported by Ambari.
    */
-  public static final float JDK_MIN_VERSION = 1.7f;
+  public static final int JDK_MIN_VERSION = 17;
 
   /**
    * The prefix for any configuration property which will be appended to
@@ -784,28 +784,49 @@ public class Configuration {
       "gpl.license.accepted", false);
 
   /**
-   * The location of the JDK on the Ambari Agent hosts.
+   * The legacy location of the JDK used by stack services.
    */
   @Markdown(
-      description = "The location of the JDK on the Ambari Agent hosts. If stack.java.home exists, that is only used by Ambari Server (or you can find that as ambari_java_home in the commandParams on the agent side)",
-      examples = { "/usr/jdk64/jdk1.8.0_112" })
+      description = "Legacy fallback for the JDK used by stack services. Use stack.java.home for new installations.",
+      examples = { "/usr/lib/jvm/java-11" })
   public static final ConfigurationProperty<String> JAVA_HOME = new ConfigurationProperty<>(
       "java.home", null);
 
   /**
-   * The location of the JDK on the Ambari Agent hosts.
+   * The location of the JDK used by Ambari Server and Agent Java helpers.
    */
   @Markdown(
-          description = "The location of the JDK on the Ambari Agent hosts. This is only used by Ambari Server",
-          examples = { "/usr/jdk64/jdk1.8.0_112" })
+          description = "The JDK used by Ambari Server and by Ambari-owned Java helpers on every Agent host.",
+          examples = { "/usr/lib/jvm/java-17" })
   public static final ConfigurationProperty<String> AMBARI_JAVA_HOME = new ConfigurationProperty<>(
           "ambari.java.home", null);
+
+  /**
+   * Java feature version used by Ambari Server and Agent Java helpers.
+   */
+  @Markdown(
+      description = "Java feature version used by Ambari Server and Ambari-owned Java helpers.",
+      examples = { "17" })
+  public static final ConfigurationProperty<String> AMBARI_JAVA_VERSION = new ConfigurationProperty<>(
+      "ambari.java.version", String.valueOf(Runtime.version().feature()));
+
+  /**
+   * The name of the Ambari JDK installation binary.
+   */
+  public static final ConfigurationProperty<String> AMBARI_JDK_NAME = new ConfigurationProperty<>(
+      "ambari.jdk.name", null);
+
+  /**
+   * The name of the Ambari JCE policy ZIP file.
+   */
+  public static final ConfigurationProperty<String> AMBARI_JCE_NAME = new ConfigurationProperty<>(
+      "ambari.jce.name", null);
 
   /**
    * The name of the JDK installation binary.
    */
   @Markdown(
-      description = "The name of the JDK installation binary. If stack.jdk.name exists, that is only used by Ambari Server (or you can find that as ambari_jdk_name in the commandParams on the agent side)",
+      description = "Legacy fallback for the stack JDK installation binary name.",
       examples = { "jdk-8u112-linux-x64.tar.gz" })
   public static final ConfigurationProperty<String> JDK_NAME = new ConfigurationProperty<>(
       "jdk.name", null);
@@ -814,17 +835,17 @@ public class Configuration {
    * The name of the JCE policy ZIP file.
    */
   @Markdown(
-      description = "The name of the JCE policy ZIP file. If stack.jce.name exists, that is only used by Ambari Server (or you can find that as ambari_jce_name in the commandParams on the agent side)",
+      description = "Legacy fallback for the stack JCE policy ZIP file name.",
       examples = {"UnlimitedJCEPolicyJDK8.zip"})
   public static final ConfigurationProperty<String> JCE_NAME = new ConfigurationProperty<>(
       "jce.name", null);
 
   /**
-   * The location of the JDK on the Ambari Agent hosts.
+   * The default location of the JDK used by stack services.
    */
   @Markdown(
-    description = "The location of the JDK on the Ambari Agent hosts for stack services.",
-    examples = { "/usr/jdk64/jdk1.7.0_45" })
+    description = "The default JDK used by stack services. BIGTOP cluster-env overrides may replace it for a service or component.",
+    examples = { "/usr/lib/jvm/java-11" })
   public static final ConfigurationProperty<String> STACK_JAVA_HOME = new ConfigurationProperty<>(
     "stack.java.home", null);
 
@@ -850,8 +871,8 @@ public class Configuration {
    * Java version of the stack
    */
   @Markdown(
-    description = "JDK version of the stack, use in case of it differs from Ambari JDK version.",
-    examples = {"1.7"})
+    description = "Java feature version of the default stack JDK.",
+    examples = {"11"})
   public static final ConfigurationProperty<String> STACK_JAVA_VERSION = new ConfigurationProperty<>(
     "stack.java.version", null);
 
@@ -2890,7 +2911,8 @@ public class Configuration {
     defaultAgentConfigsMap.put(CHECK_REMOTE_MOUNTS.getKey(), getProperty(CHECK_REMOTE_MOUNTS));
     defaultAgentConfigsMap.put(CHECK_MOUNTS_TIMEOUT.getKey(), getProperty(CHECK_MOUNTS_TIMEOUT));
     defaultAgentConfigsMap.put(ENABLE_AUTO_AGENT_CACHE_UPDATE.getKey(), getProperty(ENABLE_AUTO_AGENT_CACHE_UPDATE));
-    defaultAgentConfigsMap.put(JAVA_HOME.getKey(), getProperty(JAVA_HOME));
+    defaultAgentConfigsMap.put(JAVA_HOME.getKey(), StringUtils.defaultIfEmpty(
+        getProperty(AMBARI_JAVA_HOME), getProperty(JAVA_HOME)));
 
     configsMap = new HashMap<>();
     configsMap.putAll(defaultAgentConfigsMap);
@@ -3379,23 +3401,10 @@ public class Configuration {
   }
 
   /**
-   * @return conventional Java version number, e.g. 7.
-   * Integer is used here to simplify comparisons during usage.
-   * If java version is not supported, returns -1
+   * @return the Java feature version used by the running Ambari Server.
    */
   public int getJavaVersion() {
-    String versionStr = System.getProperty("java.version");
-    if (versionStr.startsWith("1.6")) {
-      return 6;
-    } else if (versionStr.startsWith("1.7")) {
-      return 7;
-    } else if (versionStr.startsWith("1.8")) {
-      return 8;
-    } else if (versionStr.startsWith("17")) {
-      return 17;
-    } else { // Some unsupported java version
-      return -1;
-    }
+    return Runtime.version().feature();
   }
 
   public File getBootStrapDir() {
@@ -4126,6 +4135,18 @@ public class Configuration {
 
   public String getAmbariJavaHome() {
     return getProperty(AMBARI_JAVA_HOME);
+  }
+
+  public String getAmbariJavaVersion() {
+    return String.valueOf(getJavaVersion());
+  }
+
+  public String getAmbariJDKName() {
+    return getProperty(AMBARI_JDK_NAME);
+  }
+
+  public String getAmbariJCEName() {
+    return getProperty(AMBARI_JCE_NAME);
   }
 
   public String getJDKName() {

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/AmbariManagementController.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/AmbariManagementController.java
@@ -714,12 +714,12 @@ public interface AmbariManagementController {
   String getJdkResourceUrl();
 
   /**
-   * Getter for the java home, stored in ambari.properties
+   * Gets the effective default Java home for stack services.
    */
   String getJavaHome();
 
   /**
-   * Getter for the java home, stored in ambari.properties
+   * Gets the Java home used by Ambari Server and Agent Java helpers.
    */
   String getAmbariJavaHome();
 
@@ -1036,4 +1036,3 @@ public interface AmbariManagementController {
    */
   MpackResponse getMpack(Long mpackId);
 }
-

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/AmbariManagementControllerImpl.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/AmbariManagementControllerImpl.java
@@ -25,6 +25,7 @@ import static org.apache.ambari.server.agent.ExecutionCommand.KeyNames.AMBARI_DB
 import static org.apache.ambari.server.agent.ExecutionCommand.KeyNames.AMBARI_DB_RCA_URL;
 import static org.apache.ambari.server.agent.ExecutionCommand.KeyNames.AMBARI_DB_RCA_USERNAME;
 import static org.apache.ambari.server.agent.ExecutionCommand.KeyNames.AMBARI_JAVA_HOME;
+import static org.apache.ambari.server.agent.ExecutionCommand.KeyNames.AMBARI_JAVA_VERSION;
 import static org.apache.ambari.server.agent.ExecutionCommand.KeyNames.CLIENTS_TO_UPDATE_CONFIGS;
 import static org.apache.ambari.server.agent.ExecutionCommand.KeyNames.CLUSTER_NAME;
 import static org.apache.ambari.server.agent.ExecutionCommand.KeyNames.COMMAND_RETRY_ENABLED;
@@ -450,10 +451,22 @@ public class AmbariManagementControllerImpl implements AmbariManagementControlle
         masterPort = configs.getClientApiPort();
       }
       jdkResourceUrl = getAmbariServerURI(JDK_RESOURCE_LOCATION);
-      javaHome = configs.getJavaHome();
+      String stackJavaHome = configs.getStackJavaHome();
+      String legacyJavaHome = configs.getJavaHome();
       ambariJavaHome = configs.getAmbariJavaHome();
-      jdkName = configs.getJDKName();
-      jceName = configs.getJCEName();
+      if (StringUtils.isNotEmpty(stackJavaHome)) {
+        javaHome = stackJavaHome;
+        jdkName = configs.getStackJDKName();
+        jceName = configs.getStackJCEName();
+      } else if (StringUtils.isNotEmpty(legacyJavaHome)) {
+        javaHome = legacyJavaHome;
+        jdkName = configs.getJDKName();
+        jceName = configs.getJCEName();
+      } else {
+        javaHome = ambariJavaHome;
+        jdkName = configs.getAmbariJDKName();
+        jceName = configs.getAmbariJCEName();
+      }
       ojdbcUrl = getAmbariServerURI(JDK_RESOURCE_LOCATION + "/" + configs.getOjdbcJarName());
       mysqljdbcUrl = getAmbariServerURI(JDK_RESOURCE_LOCATION + "/" + configs.getMySQLJarName());
 
@@ -6038,7 +6051,9 @@ public class AmbariManagementControllerImpl implements AmbariManagementControlle
     clusterLevelParams.put(JDK_LOCATION, getJdkResourceUrl());
     clusterLevelParams.put(JAVA_HOME, getJavaHome());
     clusterLevelParams.put(AMBARI_JAVA_HOME, getAmbariJavaHome());
-    clusterLevelParams.put(JAVA_VERSION, String.valueOf(configs.getJavaVersion()));
+    clusterLevelParams.put(AMBARI_JAVA_VERSION, configs.getAmbariJavaVersion());
+    clusterLevelParams.put(JAVA_VERSION, StringUtils.defaultIfEmpty(
+        configs.getStackJavaVersion(), String.valueOf(configs.getJavaVersion())));
     clusterLevelParams.put(JDK_NAME, getJDKName());
     clusterLevelParams.put(JCE_NAME, getJCEName());
     clusterLevelParams.put(DB_NAME, getServerDB());

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/RootServiceResponseFactory.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/RootServiceResponseFactory.java
@@ -160,6 +160,7 @@ public class RootServiceResponseFactory extends
         response = configs.getAmbariProperties();
         response.put(JDK_LOCATION, managementController.getJdkResourceUrl());
         response.put("java.version", System.getProperty("java.specification.version"));
+        response.put("ambari.java.version", String.valueOf(Runtime.version().feature()));
         propertiesToHideInResponse = configs.getPropertiesToBlackList();
         for(String key : propertiesToHideInResponse) {
       	  response.remove(key);

--- a/ambari-server/src/main/java/org/apache/ambari/server/upgrade/SchemaUpgradeHelper.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/upgrade/SchemaUpgradeHelper.java
@@ -399,11 +399,9 @@ public class SchemaUpgradeHelper {
    */
   public static void main(String[] args) throws Exception {
     try {
-      // check java version to be higher then 1.6
-      String[] splittedJavaVersion = System.getProperty("java.version").split("\\.");
-      float javaVersion = Float.parseFloat(splittedJavaVersion[0] + "." + splittedJavaVersion[1]);
+      int javaVersion = Runtime.version().feature();
       if (javaVersion < Configuration.JDK_MIN_VERSION) {
-        LOG.error(String.format("Oracle JDK version is lower than %.1f It can cause problems during upgrade process. Please," +
+        LOG.error(String.format("JDK version is lower than %d. It can cause problems during upgrade. Please" +
                 " use 'ambari-server setup' command to upgrade JDK!", Configuration.JDK_MIN_VERSION));
         System.exit(1);
       }

--- a/ambari-server/src/main/java/org/apache/ambari/server/utils/StageUtils.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/utils/StageUtils.java
@@ -579,44 +579,43 @@ public class StageUtils {
    * Add ambari specific JDK details to command parameters.
    */
   public static void useAmbariJdkInCommandParams(Map<String, String> commandParams, Configuration configuration) {
-    if (StringUtils.isNotEmpty(configuration.getJavaHome()) && !configuration.getJavaHome().equals(configuration.getStackJavaHome())) {
+    if (StringUtils.isNotEmpty(configuration.getAmbariJavaHome())) {
       commandParams.put(AMBARI_JAVA_HOME, configuration.getAmbariJavaHome());
-      commandParams.put(AMBARI_JAVA_VERSION, String.valueOf(configuration.getJavaVersion()));
-      if (StringUtils.isNotEmpty(configuration.getJDKName())) { // if not custom jdk
-        commandParams.put(AMBARI_JDK_NAME, configuration.getJDKName());
+      commandParams.put(AMBARI_JAVA_VERSION, configuration.getAmbariJavaVersion());
+      if (StringUtils.isNotEmpty(configuration.getAmbariJDKName())) {
+        commandParams.put(AMBARI_JDK_NAME, configuration.getAmbariJDKName());
       }
-      if (StringUtils.isNotEmpty(configuration.getJCEName())) { // if not custom jdk
-        commandParams.put(AMBARI_JCE_NAME, configuration.getJCEName());
+      if (StringUtils.isNotEmpty(configuration.getAmbariJCEName())) {
+        commandParams.put(AMBARI_JCE_NAME, configuration.getAmbariJCEName());
       }
     }
   }
 
   /**
-   * Fill hots level parameters with Jdk details, override them with the stack JDK data, in case of stack JAVA_HOME exists
+   * Fill host-level parameters with the effective stack JDK details.
    */
   public static void useStackJdkIfExists(Map<String, String> hostLevelParams, Configuration configuration) {
-    // set defaults first
-    hostLevelParams.put(JAVA_HOME, configuration.getJavaHome());
-    hostLevelParams.put(JDK_NAME, configuration.getJDKName());
-    hostLevelParams.put(JCE_NAME, configuration.getJCEName());
-    hostLevelParams.put(JAVA_VERSION, String.valueOf(configuration.getJavaVersion()));
-    if (StringUtils.isNotEmpty(configuration.getStackJavaHome())
-      && !configuration.getStackJavaHome().equals(configuration.getJavaHome())) {
+    if (StringUtils.isNotEmpty(configuration.getStackJavaHome())) {
       hostLevelParams.put(JAVA_HOME, configuration.getStackJavaHome());
-      if (StringUtils.isNotEmpty(configuration.getStackJavaVersion())) {
-        hostLevelParams.put(JAVA_VERSION, configuration.getStackJavaVersion());
-      }
-      if (StringUtils.isNotEmpty(configuration.getStackJDKName())) {
-        hostLevelParams.put(JDK_NAME, configuration.getStackJDKName());
-      } else {
-        hostLevelParams.put(JDK_NAME, null); // custom jdk for stack
-      }
-      if (StringUtils.isNotEmpty(configuration.getStackJCEName())) {
-        hostLevelParams.put(JCE_NAME, configuration.getStackJCEName());
-      } else {
-        hostLevelParams.put(JCE_NAME, null); // custom jdk for stack
-      }
+      hostLevelParams.put(JAVA_VERSION, StringUtils.defaultIfEmpty(
+          configuration.getStackJavaVersion(), String.valueOf(configuration.getJavaVersion())));
+      hostLevelParams.put(JDK_NAME, configuration.getStackJDKName());
+      hostLevelParams.put(JCE_NAME, configuration.getStackJCEName());
+      return;
     }
+
+    if (StringUtils.isNotEmpty(configuration.getJavaHome())) {
+      hostLevelParams.put(JAVA_HOME, configuration.getJavaHome());
+      hostLevelParams.put(JDK_NAME, configuration.getJDKName());
+      hostLevelParams.put(JCE_NAME, configuration.getJCEName());
+      hostLevelParams.put(JAVA_VERSION, String.valueOf(configuration.getJavaVersion()));
+      return;
+    }
+
+    hostLevelParams.put(JAVA_HOME, configuration.getAmbariJavaHome());
+    hostLevelParams.put(JDK_NAME, configuration.getAmbariJDKName());
+    hostLevelParams.put(JCE_NAME, configuration.getAmbariJCEName());
+    hostLevelParams.put(JAVA_VERSION, configuration.getAmbariJavaVersion());
   }
 
   /**

--- a/ambari-server/src/main/python/ambari-server.py
+++ b/ambari-server/src/main/python/ambari-server.py
@@ -759,18 +759,18 @@ def init_setup_parser_options(parser):
     "-j",
     "--java-home",
     default=None,
-    help="Use specified java_home.  Must be valid on all hosts",
+    help="Deprecated alias for --ambari-java-home",
   )
   other_group.add_option(
     "--ambari-java-home",
     dest="ambari_java_home",
-    help="Use specified java_home for ambari.  Must be valid on Ambari server hosts",
+    help="Use the specified JDK for Ambari Server and Agent helpers. Must be valid on all Ambari hosts",
   )
   other_group.add_option(
     "--stack-java-home",
     dest="stack_java_home",
     default=None,
-    help="Use specified java_home for stack services.  Must be valid on all hosts",
+    help="Use the specified default JDK for stack services. Must be valid on all component hosts",
   )
   other_group.add_option(
     "--skip-view-extraction",
@@ -875,6 +875,16 @@ def init_start_parser_options(parser):
 @OsFamilyFuncImpl(OsFamilyImpl.DEFAULT)
 def init_empty_parser_options(parser):
   pass
+
+
+@OsFamilyFuncImpl(OsFamilyImpl.DEFAULT)
+def init_upgrade_parser_options(parser):
+  parser.add_option(
+    "--ambari-java-home",
+    dest="ambari_java_home",
+    default=None,
+    help="Use the specified JDK 17+ for the Ambari upgrade",
+  )
 
 
 @OsFamilyFuncImpl(OsFamilyImpl.DEFAULT)
@@ -1751,7 +1761,7 @@ def init_action_parser(action, parser):
     RESTART_ACTION: init_start_parser_options,
     RESET_ACTION: init_reset_parser_options,
     STATUS_ACTION: init_empty_parser_options,
-    UPGRADE_ACTION: init_empty_parser_options,
+    UPGRADE_ACTION: init_upgrade_parser_options,
     LDAP_SETUP_ACTION: init_ldap_setup_parser_options,
     LDAP_SYNC_ACTION: init_ldap_sync_parser_options,
     SET_CURRENT_ACTION: init_set_current_parser_options,

--- a/ambari-server/src/main/python/ambari_server/serverConfiguration.py
+++ b/ambari-server/src/main/python/ambari_server/serverConfiguration.py
@@ -109,6 +109,7 @@ AMBARI_JAVA_HOME_PROPERTY = "ambari.java.home"
 AMBARI_JDK_NAME_PROPERTY = "ambari.jdk.name"
 AMBARI_JCE_NAME_PROPERTY = "ambari.jce.name"
 AMBARI_JAVA_VERSION = "ambari.java.version"
+MIN_AMBARI_JAVA_VERSION = 17
 
 
 # TODO property used incorrectly in local case, it was meant to be dbms name, not postgres database name,
@@ -252,7 +253,7 @@ REQUIRED_PROPERTIES = [
   SECURITY_KEYS_DIR,
   JDBC_DATABASE_NAME_PROPERTY,
   NR_USER_PROPERTY,
-  JAVA_HOME_PROPERTY,
+  AMBARI_JAVA_HOME_PROPERTY,
   JDBC_PASSWORD_PROPERTY,
   SHARED_RESOURCES_DIR,
   JDBC_USER_NAME_PROPERTY,
@@ -270,7 +271,7 @@ REQUIRED_PROPERTIES = [
 SETUP_DONE_PROPERTIES = [
   OS_FAMILY_PROPERTY,
   OS_TYPE_PROPERTY,
-  JDK_NAME_PROPERTY,
+  AMBARI_JAVA_HOME_PROPERTY,
   JDBC_DATABASE_PROPERTY,
   NR_USER_PROPERTY,
   PERSISTENCE_TYPE_PROPERTY,
@@ -1745,6 +1746,11 @@ def get_JAVA_HOME(java_home_type=JavaHomeType.AMBARI):
   if (not 0 == len(java_home)) and (os.path.exists(java_home)):
     return java_home
 
+  if java_home_type == JavaHomeType.AMBARI:
+    java_home = os.environ.get(JAVA_HOME)
+    if validate_jdk(java_home):
+      return java_home
+
   return None
 
 
@@ -1760,14 +1766,57 @@ def validate_jdk(jdk_path):
   return False
 
 
+def get_java_version(jdk_path):
+  """Return the Java feature version for a JDK home, or None when unknown."""
+  if not validate_jdk(jdk_path):
+    return None
+
+  java_exe_path = os.path.join(jdk_path, configDefaults.JAVA_EXE_SUBPATH)
+  try:
+    retcode, stdout, stderr = run_os_command([java_exe_path, "-version"])
+  except OSError:
+    return None
+  if retcode != 0:
+    return None
+
+  version_output = "\n".join(value for value in (stdout, stderr) if value)
+  match = re.search(r'version\s+"([^"]+)"', version_output, re.IGNORECASE)
+  if not match:
+    return None
+
+  version_parts = match.group(1).split(".")
+  try:
+    feature_part = version_parts[1] if version_parts[0] == "1" else version_parts[0]
+    feature_match = re.match(r"\d+", feature_part)
+    return int(feature_match.group(0)) if feature_match else None
+  except IndexError:
+    return None
+
+
 #
 # Finds the available JDKs.
 #
-def find_jdk(java_home_type=JavaHomeType.AMBARI):
+def find_jdk(java_home_type=JavaHomeType.AMBARI, min_version=None):
+  if java_home_type == JavaHomeType.AMBARI and min_version is None:
+    min_version = MIN_AMBARI_JAVA_VERSION
+
+  def is_usable_jdk(jdk_path):
+    if not validate_jdk(jdk_path):
+      return False
+    return min_version is None or (get_java_version(jdk_path) or -1) >= min_version
+
   jdkPath = get_JAVA_HOME(java_home_type)
-  if jdkPath:
-    if validate_jdk(jdkPath):
-      return jdkPath
+  if jdkPath and is_usable_jdk(jdkPath):
+    return jdkPath
+
+  if java_home_type == JavaHomeType.AMBARI:
+    java_executable = shutil.which("java.exe" if OS_FAMILY == OSConst.WINSRV_FAMILY else "java")
+    if java_executable:
+      jdkPath = os.path.dirname(os.path.dirname(os.path.realpath(java_executable)))
+      if is_usable_jdk(jdkPath):
+        print(f"INFO: Selected JDK from PATH: {jdkPath}")
+        return jdkPath
+
   print(f"INFO: Looking for available JDKs at {configDefaults.JDK_INSTALL_DIR}")
   jdks = glob.glob(
     os.path.join(configDefaults.JDK_INSTALL_DIR, configDefaults.JDK_SEARCH_PATTERN)
@@ -1779,7 +1828,7 @@ def find_jdk(java_home_type=JavaHomeType.AMBARI):
     return
   for jdkPath in jdks:
     print(f"INFO: Trying to use JDK {jdkPath}")
-    if validate_jdk(jdkPath):
+    if is_usable_jdk(jdkPath):
       print(f"INFO: Selected JDK {jdkPath}")
       return jdkPath
     else:
@@ -1788,7 +1837,10 @@ def find_jdk(java_home_type=JavaHomeType.AMBARI):
 
 
 def get_java_exe_path(java_home_type=JavaHomeType.AMBARI):
-  jdkPath = find_jdk(java_home_type)
+  min_version = (
+    MIN_AMBARI_JAVA_VERSION if java_home_type == JavaHomeType.AMBARI else None
+  )
+  jdkPath = find_jdk(java_home_type, min_version)
   if jdkPath:
     java_exe = os.path.join(jdkPath, configDefaults.JAVA_EXE_SUBPATH)
     return java_exe

--- a/ambari-server/src/main/python/ambari_server/serverSetup.py
+++ b/ambari-server/src/main/python/ambari_server/serverSetup.py
@@ -55,7 +55,8 @@ from ambari_server.serverConfiguration import (
   get_is_secure,
   get_is_persisted,
   get_java_exe_path,
-  get_JAVA_HOME,
+  get_java_version,
+  find_jdk,
   get_missing_properties,
   get_resources_location,
   get_value_from_properties,
@@ -65,11 +66,8 @@ from ambari_server.serverConfiguration import (
   write_property,
   write_gpl_license_accepted,
   JAVA_HOME,
-  JAVA_HOME_PROPERTY,
-  JCE_NAME_PROPERTY,
   JDBC_RCA_URL_PROPERTY,
   JDBC_URL_PROPERTY,
-  JDK_NAME_PROPERTY,
   JDK_RELEASES,
   NR_USER_PROPERTY,
   OS_FAMILY,
@@ -88,6 +86,10 @@ from ambari_server.serverConfiguration import (
   STACK_JAVA_VERSION,
   GPL_LICENSE_ACCEPTED_PROPERTY,
   AMBARI_JAVA_HOME_PROPERTY,
+  AMBARI_JDK_NAME_PROPERTY,
+  AMBARI_JCE_NAME_PROPERTY,
+  AMBARI_JAVA_VERSION,
+  MIN_AMBARI_JAVA_VERSION,
 )
 
 from ambari_server.serverUtils import is_server_runing
@@ -134,9 +136,6 @@ UNTAR_JDK_ARCHIVE = "tar --no-same-owner -xvf {0}"
 
 JDK_PROMPT = "[{0}] {1}\n"
 JDK_VALID_CHOICES = "^[{0}{1:d}]$"
-
-JDK_VERSION_CHECK_CMD = """{0} -version 2>&1 | grep -i version | sed 's/.*version ".*\.\(.*\)\..*"/\\1/; 1q' 2>&1"""
-
 
 def get_supported_jdbc_drivers():
   factory = DBMSConfigFactory()
@@ -517,85 +516,112 @@ class JDKSetup(object):
       "please make sure JCE Unlimited Strength Jurisdiction Policy Files are valid on all hosts."
     )
 
-    if args.ambari_java_home:
-      print("start setting AMBARI_JAVA_HOME for Ambari...")
-      if not validate_jdk(args.ambari_java_home):
-        err = (
-          "Path to Ambari java home "
-          + args.ambari_java_home
-          + " or java binary file does not exist"
-        )
-        raise FatalException(1, err)
+    ambari_java_home = getattr(args, "ambari_java_home", None)
+    if not isinstance(ambari_java_home, str):
+      ambari_java_home = None
+    legacy_java_home = getattr(args, "java_home", None)
+    if not isinstance(legacy_java_home, str):
+      legacy_java_home = None
+    stack_java_home = getattr(args, "stack_java_home", None)
+    if not isinstance(stack_java_home, str):
+      stack_java_home = None
 
+    if legacy_java_home:
       print_warning_msg(
-        "AMBARI_JAVA_HOME " + args.ambari_java_home + " must be valid on ALL hosts"
+        "-j/--java-home is deprecated; use --ambari-java-home instead."
+      )
+      if stack_java_home and legacy_java_home == stack_java_home:
+        print_warning_msg(
+          "Ignoring --java-home because it duplicates --stack-java-home."
+        )
+      elif ambari_java_home and ambari_java_home != legacy_java_home:
+        raise FatalException(
+          1, "--java-home and --ambari-java-home must refer to the same JDK"
+        )
+      else:
+        ambari_java_home = legacy_java_home
+
+    ambari_java_version = None
+    if ambari_java_home:
+      if not validate_jdk(ambari_java_home):
+        raise FatalException(
+          1,
+          "Path to Ambari java home "
+          + ambari_java_home
+          + " or java binary file does not exist",
+        )
+
+      ambari_java_version = get_java_version(ambari_java_home)
+      if ambari_java_version is None or ambari_java_version < MIN_AMBARI_JAVA_VERSION:
+        raise FatalException(
+          1,
+          f"Ambari Server and Agent helpers require JDK {MIN_AMBARI_JAVA_VERSION} or later",
+        )
+
+    stack_java_version = None
+    if stack_java_home:
+      if not validate_jdk(stack_java_home):
+        raise FatalException(
+          1,
+          "Path to stack Java home "
+          + stack_java_home
+          + " or java binary file does not exist",
+        )
+      stack_java_version = get_java_version(stack_java_home)
+      if stack_java_version is None:
+        raise FatalException(
+          1, f"Unable to determine the Stack JDK version at {stack_java_home}"
+        )
+
+    if ambari_java_home:
+      print("Setting Ambari Java home...")
+      print_warning_msg(
+        "AMBARI_JAVA_HOME "
+        + ambari_java_home
+        + " must be valid on all Ambari Server and Agent hosts"
+      )
+      properties.process_pair(AMBARI_JAVA_HOME_PROPERTY, ambari_java_home)
+      for property_name in (AMBARI_JDK_NAME_PROPERTY, AMBARI_JCE_NAME_PROPERTY):
+        properties.removeOldProp(property_name)
+        properties.removeProp(property_name)
+      properties.process_pair(AMBARI_JAVA_VERSION, str(ambari_java_version))
+
+      self._ensure_java_home_env_var_is_set(ambari_java_home)
+      self.jdk_index = self.custom_jdk_number
+      print("Setting Ambari Java home finished")
+
+    if stack_java_home:
+      print("Setting Java home for stack services...")
+      print_warning_msg(
+        "Stack Java home "
+        + stack_java_home
+        + " must be valid on all component hosts"
       )
       print_warning_msg(jcePolicyWarn)
+      properties.process_pair(STACK_JAVA_HOME_PROPERTY, stack_java_home)
+      for property_name in (STACK_JDK_NAME_PROPERTY, STACK_JCE_NAME_PROPERTY):
+        properties.removeOldProp(property_name)
+        properties.removeProp(property_name)
+      properties.process_pair(STACK_JAVA_VERSION, str(stack_java_version))
 
-      properties.process_pair(AMBARI_JAVA_HOME_PROPERTY, args.ambari_java_home)
-      properties.removeOldProp(JDK_NAME_PROPERTY)
-      properties.removeOldProp(JCE_NAME_PROPERTY)
-
-      if not ambariOnly:
-        properties.process_pair(STACK_JAVA_HOME_PROPERTY, args.ambari_java_home)
-        properties.removeOldProp(STACK_JDK_NAME_PROPERTY)
-        properties.removeOldProp(STACK_JCE_NAME_PROPERTY)
-
-      self._ensure_java_home_env_var_is_set(args.ambari_java_home)
-      self.jdk_index = self.custom_jdk_number
-      print('Setting AMBARI_JAVA_HOME for Ambari finished')
-
-
-    if args.java_home:
-      # java_home was specified among the command-line arguments. Use it as custom JDK location.
-      if not validate_jdk(args.java_home):
-        err = (
-          "Path to java home " + args.java_home + " or java binary file does not exists"
-        )
-        raise FatalException(1, err)
-
-      print_warning_msg("JAVA_HOME " + args.java_home + " must be valid on ALL hosts")
-      print_warning_msg(jcePolicyWarn)
-      IS_CUSTOM_JDK = True
-
-      properties.process_pair(JAVA_HOME_PROPERTY, args.java_home)
-      properties.removeOldProp(JDK_NAME_PROPERTY)
-      properties.removeOldProp(JCE_NAME_PROPERTY)
-
-      if not ambariOnly:
-        properties.process_pair(STACK_JAVA_HOME_PROPERTY, args.java_home)
-        properties.removeOldProp(STACK_JDK_NAME_PROPERTY)
-        properties.removeOldProp(STACK_JCE_NAME_PROPERTY)
-
-      self._ensure_java_home_env_var_is_set(args.java_home)
-      self.jdk_index = self.custom_jdk_number
-
-      if (
-        args.stack_java_home
-      ):  # reset stack specific jdk properties if stack_java_home exists
-        print("Setting JAVA_HOME for stack services...")
-        print_warning_msg(
-          "JAVA_HOME " + args.stack_java_home + " (Stack) must be valid on ALL hosts"
-        )
-        print_warning_msg(jcePolicyWarn)
-        properties.process_pair(STACK_JAVA_HOME_PROPERTY, args.stack_java_home)
-        properties.removeOldProp(STACK_JDK_NAME_PROPERTY)
-        properties.removeOldProp(STACK_JCE_NAME_PROPERTY)
-
+    if ambari_java_home:
       return
 
-    java_home_var = get_JAVA_HOME()
+    java_home_var = find_jdk(min_version=MIN_AMBARI_JAVA_VERSION)
     if OS_FAMILY == OSConst.WINSRV_FAMILY:
       progress_func = None
     else:
       progress_func = download_progress
 
     if java_home_var:
-      message = "Do you want to change Oracle JDK [y/n] (n)? "
-      if ambariOnly:
-        message = "Do you want to change Oracle JDK for Ambari Server [y/n] (n)? "
-      change_jdk = get_YN_input(message, False)
+      ambari_java_version = get_java_version(java_home_var)
+      change_jdk = False
+      if not stack_java_home:
+        message = "Do you want to change the Ambari JDK [y/n] (n)? "
+        change_jdk = get_YN_input(message, False)
       if not change_jdk:
+        properties.process_pair(AMBARI_JAVA_HOME_PROPERTY, java_home_var)
+        properties.process_pair(AMBARI_JAVA_VERSION, str(ambari_java_version))
         self._ensure_java_home_env_var_is_set(java_home_var)
         self.jdk_index = self.custom_jdk_number
         return
@@ -614,42 +640,43 @@ class JDKSetup(object):
 
     if self.jdk_index == self.custom_jdk_number:
       print_warning_msg(
-        "JDK must be installed on all hosts and JAVA_HOME must be valid on all hosts."
+        "JDK 17 must be installed at the same path on all Ambari Server and Agent hosts."
       )
-      print_warning_msg(jcePolicyWarn)
 
       if get_silent():
-        print_error_msg("Path to JAVA_HOME should be specified via -j option.")
+        print_error_msg(
+          "Path to Ambari Java home should be specified via --ambari-java-home."
+        )
         sys.exit(1)
 
-      args.java_home = get_validated_string_input(
-        "Path to JAVA_HOME: ", None, None, None, False, False
+      custom_java_home = get_validated_string_input(
+        "Path to Ambari Java home: ", None, None, None, False, False
       )
-      if not os.path.exists(args.java_home) or not os.path.isfile(
-        os.path.join(args.java_home, "bin", self.JAVA_BIN)
+      if not os.path.exists(custom_java_home) or not os.path.isfile(
+        os.path.join(custom_java_home, "bin", self.JAVA_BIN)
       ):
         err = "Java home path or java binary file is unavailable. Please put correct path to java home."
         raise FatalException(1, err)
       print("Validating JDK on Ambari Server...done.")
 
-      properties.process_pair(JAVA_HOME_PROPERTY, args.java_home)
-      properties.removeOldProp(JDK_NAME_PROPERTY)
-      properties.removeOldProp(JCE_NAME_PROPERTY)
+      ambari_java_version = get_java_version(custom_java_home)
+      if ambari_java_version is None or ambari_java_version < MIN_AMBARI_JAVA_VERSION:
+        raise FatalException(
+          1,
+          f"Ambari Server and Agent helpers require JDK {MIN_AMBARI_JAVA_VERSION} or later",
+        )
 
-      if not ambariOnly:
-        properties.process_pair(STACK_JAVA_HOME_PROPERTY, args.java_home)
-        properties.removeOldProp(STACK_JDK_NAME_PROPERTY)
-        properties.removeOldProp(STACK_JCE_NAME_PROPERTY)
+      properties.process_pair(AMBARI_JAVA_HOME_PROPERTY, custom_java_home)
+      properties.process_pair(AMBARI_JAVA_VERSION, str(ambari_java_version))
+      properties.removeOldProp(AMBARI_JDK_NAME_PROPERTY)
+      properties.removeOldProp(AMBARI_JCE_NAME_PROPERTY)
 
       # Make sure any previously existing JDK and JCE name properties are removed. These will
       # confuse things in a Custom JDK scenario
-      properties.removeProp(JDK_NAME_PROPERTY)
-      properties.removeProp(JCE_NAME_PROPERTY)
-      if not ambariOnly:
-        properties.removeOldProp(STACK_JDK_NAME_PROPERTY)
-        properties.removeOldProp(STACK_JCE_NAME_PROPERTY)
+      properties.removeProp(AMBARI_JDK_NAME_PROPERTY)
+      properties.removeProp(AMBARI_JCE_NAME_PROPERTY)
 
-      self._ensure_java_home_env_var_is_set(args.java_home)
+      self._ensure_java_home_env_var_is_set(custom_java_home)
       return
 
     jdk_cfg = self.jdks[self.jdk_index]
@@ -735,11 +762,8 @@ class JDKSetup(object):
         )
         raise FatalException(1, err)
 
-    properties.process_pair(JDK_NAME_PROPERTY, jdk_cfg.dest_file)
-    properties.process_pair(JAVA_HOME_PROPERTY, java_home_dir)
-    if not ambariOnly:
-      properties.process_pair(STACK_JDK_NAME_PROPERTY, jdk_cfg.dest_file)
-      properties.process_pair(STACK_JAVA_HOME_PROPERTY, java_home_dir)
+    properties.process_pair(AMBARI_JDK_NAME_PROPERTY, jdk_cfg.dest_file)
+    properties.process_pair(AMBARI_JAVA_HOME_PROPERTY, java_home_dir)
 
     self._ensure_java_home_env_var_is_set(java_home_dir)
 
@@ -770,7 +794,7 @@ class JDKSetup(object):
 
     print("Installing JCE policy...")
     try:
-      jdk_path = properties.get_property(JAVA_HOME_PROPERTY)
+      jdk_path = properties.get_property(AMBARI_JAVA_HOME_PROPERTY)
       JDKSetup.unpack_jce_policy(jdk_path, resources_dir, jdk_cfg.dest_jcpol_file)
       self.adjust_jce_permissions(jdk_path)
     except FatalException as e:
@@ -872,9 +896,7 @@ class JDKSetup(object):
     else:
       print("JCE Policy archive already exists, using " + dest_file)
 
-    properties.process_pair(JCE_NAME_PROPERTY, dest_jcpol_file)
-    if not ambariOnly:
-      properties.process_pair(STACK_JCE_NAME_PROPERTY, dest_jcpol_file)
+    properties.process_pair(AMBARI_JCE_NAME_PROPERTY, dest_jcpol_file)
 
   # Base implementation, overriden in the subclasses
   def _install_jdk(self, java_inst_file, java_home_dir):
@@ -971,18 +993,7 @@ class JDKSetupWindows(JDKSetup):
 class JDKSetupLinux(JDKSetup):
   def __init__(self):
     super(JDKSetupLinux, self).__init__()
-    self.JDK_DEFAULT_CONFIGS = [
-      JDKRelease(
-        "jdk1.8",
-        "Oracle JDK 1.8 + Java Cryptography Extension (JCE) Policy Files 8",
-        "http://public-repo-1.hortonworks.com/ARTIFACTS/jdk-8u112-linux-x64.tar.gz",
-        "jdk-8u112-linux-x64.tar.gz",
-        "http://public-repo-1.hortonworks.com/ARTIFACTS/jce_policy-8.zip",
-        "jce_policy-8.zip",
-        AmbariPath.get("/usr/jdk64/jdk1.8.0_112"),
-        "(jdk.*)/jre",
-      )
-    ]
+    self.JDK_DEFAULT_CONFIGS = []
 
     self.jdks = self.JDK_DEFAULT_CONFIGS
     self.custom_jdk_number = len(self.jdks)
@@ -1072,19 +1083,19 @@ def download_and_install_jdk(options):
   jdkSetup = JDKSetup()
   jdkSetup.download_and_install_jdk(options, properties)
 
-  if jdkSetup.jdk_index != jdkSetup.custom_jdk_number:
-    jdkSetup.download_and_unpack_jce_policy(properties)
+  ambari_java_version_valid = check_ambari_java_version_is_valid(
+    properties.get_property(AMBARI_JAVA_HOME_PROPERTY),
+    jdkSetup.JAVA_BIN,
+    MIN_AMBARI_JAVA_VERSION,
+    properties,
+  )
+  if not ambari_java_version_valid:
+    raise FatalException(
+      1,
+      f"Ambari Server and Agent helpers require JDK {MIN_AMBARI_JAVA_VERSION} or later",
+    )
 
   update_properties(properties)
-
-  # ambari_java_version_valid = check_ambari_java_version_is_valid(get_JAVA_HOME(), jdkSetup.JAVA_BIN, 8, properties)
-  ambari_java_version_valid = True
-  if not ambari_java_version_valid:
-    jdkSetup = JDKSetup()  # recreate object
-    jdkSetup.download_and_install_jdk(options, properties, True)
-    if jdkSetup.jdk_index != jdkSetup.custom_jdk_number:
-      jdkSetup.download_and_unpack_jce_policy(properties, True)
-    update_properties(properties)
 
   return 0
 
@@ -1504,13 +1515,13 @@ def setup_jce_policy(args):
       err = f"Fail while trying to copy {args[1]} to {resources_dir}. {e}"
       raise FatalException(1, err)
 
-  jdk_path = properties.get_property(JAVA_HOME_PROPERTY)
+  jdk_path = properties.get_property(AMBARI_JAVA_HOME_PROPERTY)
   if not jdk_path or not os.path.exists(jdk_path):
     err = "JDK not installed, you need to run 'ambari-server setup' before attempting to install the JCE policy."
     raise FatalException(1, err)
 
   zip_name = zip_path[1]
-  properties.process_pair(JCE_NAME_PROPERTY, zip_name)
+  properties.process_pair(AMBARI_JCE_NAME_PROPERTY, zip_name)
 
   print("Installing JCE policy...")
   try:
@@ -1529,46 +1540,20 @@ def setup_jce_policy(args):
 
 def check_ambari_java_version_is_valid(java_home, java_bin, min_version, properties):
   """
-  Check that ambari uses the proper (minimum) JDK with a shell command.
+  Check that Ambari uses the required minimum JDK.
   Returns true, if Ambari meets with the minimal JDK version requirement.
   """
   result = True
   print("Check JDK version for Ambari Server...")
-  try:
-    command = JDK_VERSION_CHECK_CMD.format(os.path.join(java_home, "bin", java_bin))
-    print(f"Running java version check command: {command}")
-    process = subprocess.Popen(
-      command,
-      stdout=subprocess.PIPE,
-      stdin=subprocess.PIPE,
-      stderr=subprocess.PIPE,
-      shell=True,
-      universal_newlines=True,
-    )
-    (out, err) = process.communicate()
-    if process.returncode != 0:
-      err = f"Checking JDK version command returned with exit code {process.returncode}"
-      raise FatalException(process.returncode, err)
-    else:
-      actual_jdk_version = int(out)
-      print(f"JDK version found: {actual_jdk_version}")
-      if actual_jdk_version < min_version:
-        print(
-          f"Minimum JDK version is {min_version} for Ambari. Setup JDK again only for Ambari Server."
-        )
-        properties.process_pair(STACK_JAVA_VERSION, out)
-        result = False
-      else:
-        print(
-          f"Minimum JDK version is {min_version} for Ambari. Skipping to setup different JDK for Ambari Server."
-        )
+  actual_jdk_version = get_java_version(java_home)
+  if actual_jdk_version is None:
+    raise FatalException(1, f"Unable to determine JDK version at {java_home}")
 
-  except FatalException as e:
-    err = f"Running java version check command failed: {e}. Exiting."
-    raise FatalException(e.code, err)
-  except Exception as e:
-    err = f"Running java version check command failed: {e}. Exiting."
-    raise FatalException(1, err)
+  print(f"JDK version found: {actual_jdk_version}")
+  properties.process_pair(AMBARI_JAVA_VERSION, str(actual_jdk_version))
+  if actual_jdk_version < min_version:
+    print(f"Ambari requires JDK {min_version} or later.")
+    result = False
 
   return result
 

--- a/ambari-server/src/main/python/ambari_server/serverUpgrade.py
+++ b/ambari-server/src/main/python/ambari_server/serverUpgrade.py
@@ -57,6 +57,8 @@ from ambari_server.serverConfiguration import (
   get_ambari_properties,
   get_ambari_version,
   get_java_exe_path,
+  find_jdk,
+  get_java_version,
   get_stack_location,
   parse_properties_file,
   read_ambari_user,
@@ -79,6 +81,18 @@ from ambari_server.serverConfiguration import (
   get_default_views_dir,
   write_gpl_license_accepted,
   set_property,
+  JAVA_HOME_PROPERTY,
+  JDK_NAME_PROPERTY,
+  JCE_NAME_PROPERTY,
+  STACK_JAVA_HOME_PROPERTY,
+  STACK_JDK_NAME_PROPERTY,
+  STACK_JCE_NAME_PROPERTY,
+  STACK_JAVA_VERSION,
+  AMBARI_JAVA_HOME_PROPERTY,
+  AMBARI_JDK_NAME_PROPERTY,
+  AMBARI_JCE_NAME_PROPERTY,
+  AMBARI_JAVA_VERSION,
+  MIN_AMBARI_JAVA_VERSION,
 )
 from ambari_server.setupSecurity import (
   adjust_directory_permissions,
@@ -125,7 +139,7 @@ SCHEMA_UPGRADE_HELPER_CMD = (
 SCHEMA_UPGRADE_HELPER_CMD_DEBUG = (
   "{0} "
   "-server -XX:NewRatio=2 "
-  "-XX:+UseConcMarkSweepGC " + " -Xdebug -Xrunjdwp:transport=dt_socket,address=5005,"
+  "-XX:+UseG1GC " + " -Xdebug -Xrunjdwp:transport=dt_socket,address=5005,"
   "server=y,suspend={2} "
   "-cp {1} "
   + "org.apache.ambari.server.upgrade.SchemaUpgradeHelper"
@@ -327,6 +341,56 @@ def move_user_custom_actions():
     raise FatalException(1, err)
 
 
+def migrate_java_home_properties(properties, requested_ambari_java_home=None):
+  legacy_java_home = properties.get_property(JAVA_HOME_PROPERTY)
+  stack_java_home = properties.get_property(STACK_JAVA_HOME_PROPERTY)
+  if not stack_java_home and legacy_java_home:
+    stack_java_home = legacy_java_home
+    properties.process_pair(STACK_JAVA_HOME_PROPERTY, stack_java_home)
+    legacy_jdk_name = properties.get_property(JDK_NAME_PROPERTY)
+    legacy_jce_name = properties.get_property(JCE_NAME_PROPERTY)
+    if legacy_jdk_name and not properties.get_property(STACK_JDK_NAME_PROPERTY):
+      properties.process_pair(STACK_JDK_NAME_PROPERTY, legacy_jdk_name)
+    if legacy_jce_name and not properties.get_property(STACK_JCE_NAME_PROPERTY):
+      properties.process_pair(STACK_JCE_NAME_PROPERTY, legacy_jce_name)
+
+  if stack_java_home and not properties.get_property(STACK_JAVA_VERSION):
+    stack_java_version = get_java_version(stack_java_home)
+    if stack_java_version is not None:
+      properties.process_pair(STACK_JAVA_VERSION, str(stack_java_version))
+    else:
+      print_warning_msg(
+        "Unable to detect the Stack JDK version on the Ambari Server. "
+        "Set stack.java.version before installing or upgrading stack services."
+      )
+
+  if not isinstance(requested_ambari_java_home, str):
+    requested_ambari_java_home = None
+  configured_ambari_java_home = properties.get_property(AMBARI_JAVA_HOME_PROPERTY)
+  ambari_java_home = requested_ambari_java_home or configured_ambari_java_home
+  ambari_java_version = get_java_version(ambari_java_home)
+  if not requested_ambari_java_home and (
+    ambari_java_version is None
+    or ambari_java_version < MIN_AMBARI_JAVA_VERSION
+  ):
+    ambari_java_home = find_jdk(min_version=MIN_AMBARI_JAVA_VERSION)
+    ambari_java_version = get_java_version(ambari_java_home)
+  if ambari_java_version is None or ambari_java_version < MIN_AMBARI_JAVA_VERSION:
+    raise FatalException(
+      1,
+      "Ambari upgrade requires JDK 17 or later. Set JAVA_HOME or pass "
+      "--ambari-java-home, without changing the stack Java home.",
+    )
+
+  properties.process_pair(AMBARI_JAVA_HOME_PROPERTY, ambari_java_home)
+  properties.process_pair(AMBARI_JAVA_VERSION, str(ambari_java_version))
+  if ambari_java_home != configured_ambari_java_home:
+    for property_name in (AMBARI_JDK_NAME_PROPERTY, AMBARI_JCE_NAME_PROPERTY):
+      properties.removeOldProp(property_name)
+      properties.removeProp(property_name)
+  update_properties(properties)
+
+
 def upgrade(args):
   print_info_msg("Upgrade Ambari Server", True)
   if not is_root():
@@ -339,6 +403,11 @@ def upgrade(args):
   if not retcode == 0:
     err = AMBARI_PROPERTIES_FILE + " file can't be updated. Exiting"
     raise FatalException(retcode, err)
+
+  properties = get_ambari_properties()
+  if properties == -1:
+    raise FatalException(-1, "Error getting Ambari properties")
+  migrate_java_home_properties(properties, getattr(args, "ambari_java_home", None))
 
   print_info_msg(f"Updating Ambari Server properties in {AMBARI_ENV_FILE} ...", True)
   retcode = update_ambari_env()

--- a/ambari-server/src/main/python/ambari_server/setupSecurity.py
+++ b/ambari-server/src/main/python/ambari_server/setupSecurity.py
@@ -699,7 +699,7 @@ def sensitive_data_encryption(options, direction, masterKey=None):
     return 1
   serverClassPath = ServerClassPath(get_ambari_properties(), options)
   command = SECURITY_SENSITIVE_DATA_ENCRYPTON_CMD.format(
-    get_java_exe_path(),
+    os.path.join(jdk_path, configDefaults.JAVA_EXE_SUBPATH),
     serverClassPath.get_full_ambari_classpath_escaped_for_shell(),
     direction,
   )

--- a/ambari-server/src/main/python/ambari_server/setupSecurity.py
+++ b/ambari-server/src/main/python/ambari_server/setupSecurity.py
@@ -98,9 +98,9 @@ from ambari_server.serverConfiguration import (
   SSL_TRUSTSTORE_PASSWORD_PROPERTY,
   SSL_TRUSTSTORE_PATH_PROPERTY,
   SSL_TRUSTSTORE_TYPE_PROPERTY,
-  JDK_NAME_PROPERTY,
-  JCE_NAME_PROPERTY,
-  JAVA_HOME_PROPERTY,
+  AMBARI_JDK_NAME_PROPERTY,
+  AMBARI_JCE_NAME_PROPERTY,
+  AMBARI_JAVA_HOME_PROPERTY,
   get_resources_location,
   SECURITY_MASTER_KEY_LOCATION,
   SETUP_OR_UPGRADE_MSG,
@@ -295,9 +295,9 @@ def adjust_directory_permissions(ambari_user):
 
   # Update JDK and JCE permissions
   resources_dir = get_resources_location(properties)
-  jdk_file_name = properties.get_property(JDK_NAME_PROPERTY)
-  jce_file_name = properties.get_property(JCE_NAME_PROPERTY)
-  java_home = properties.get_property(JAVA_HOME_PROPERTY)
+  jdk_file_name = properties.get_property(AMBARI_JDK_NAME_PROPERTY)
+  jce_file_name = properties.get_property(AMBARI_JCE_NAME_PROPERTY)
+  java_home = properties.get_property(AMBARI_JAVA_HOME_PROPERTY)
   if jdk_file_name:
     jdk_file_path = os.path.abspath(os.path.join(resources_dir, jdk_file_name))
     if os.path.exists(jdk_file_path):

--- a/ambari-server/src/main/python/ambari_server_main.py
+++ b/ambari-server/src/main/python/ambari_server_main.py
@@ -43,7 +43,6 @@ from ambari_server.serverConfiguration import (
   configDefaults,
   find_jdk,
   get_ambari_properties,
-  get_java_exe_path,
   read_ambari_user,
   get_is_active_instance,
   update_properties,
@@ -433,7 +432,7 @@ def server_process_main(options, scmStatus=None):
   if scmStatus is not None:
     scmStatus.reportStartPending()
 
-  java_exe = get_java_exe_path()
+  java_exe = os.path.join(jdk_path, configDefaults.JAVA_EXE_SUBPATH)
 
   serverClassPath = ServerClassPath(properties, options)
 

--- a/ambari-server/src/main/resources/common-services/AMBARI_METRICS/3.0.0/package/scripts/params.py
+++ b/ambari-server/src/main/resources/common-services/AMBARI_METRICS/3.0.0/package/scripts/params.py
@@ -295,14 +295,9 @@ security_enabled = (
 metric_prop_file_name = "hadoop-metrics2-hbase.properties"
 
 java_home = config["ambariLevelParams"]["java_home"]
-ambari_java_home = default("/ambariLevelParams/ambari_java_home", None)
 # not supporting 32 bit jdk.
-java64_home = ambari_java_home if ambari_java_home is not None else java_home
-ambari_java_version = default("/ambariLevelParams/ambari_java_version", None)
-if ambari_java_version:
-  java_version = expect("/ambariLevelParams/ambari_java_version", int)
-else:
-  java_version = expect("/ambariLevelParams/java_version", int)
+java64_home = java_home
+java_version = expect("/ambariLevelParams/java_version", int)
 
 metrics_collector_heapsize = default(
   "/configurations/ams-env/metrics_collector_heapsize", "512"

--- a/ambari-server/src/main/resources/custom_actions/scripts/check_host.py
+++ b/ambari-server/src/main/resources/custom_actions/scripts/check_host.py
@@ -340,28 +340,100 @@ class CheckHost(Script):
 
   def execute_java_home_available_check(self, config):
     Logger.info("Java home check started.")
-    java_home = config["commandParams"]["java_home"]
+    java_home = config["commandParams"].get("java_home")
+    expected_java_version = config["commandParams"].get("java_version")
 
-    Logger.info("Java home to check: " + java_home)
+    Logger.info("Java home to check: " + str(java_home))
+    if not java_home:
+      return {
+        "exit_code": 1,
+        "message": "Ambari Java home is not configured.",
+        "java_home": java_home,
+        "expected_java_version": expected_java_version,
+      }
     java_bin = "java"
     if OSCheck.is_windows_family():
       java_bin = "java.exe"
 
-    if not os.path.isfile(os.path.join(java_home, "bin", java_bin)):
+    java_executable = os.path.join(java_home, "bin", java_bin)
+    if not os.path.isfile(java_executable):
       Logger.warning("Java home doesn't exist!")
       java_home_check_structured_output = {
         "exit_code": 1,
         "message": "Java home doesn't exist!",
+        "java_home": java_home,
+        "expected_java_version": expected_java_version,
       }
     else:
-      Logger.info("Java home exists!")
+      exit_code, version_output = shell.call(
+        [java_executable, "-version"], shell=False
+      )
+      version_match = re.search(
+        r'version\s+"([^"]+)"', version_output or "", re.IGNORECASE
+      )
+      actual_java_version = version_match.group(1) if version_match else None
+      actual_java_feature = self._java_feature_version(actual_java_version)
+      expected_java_feature = self._java_feature_version(expected_java_version)
+      runtime_line = next(
+        (
+          line.strip()
+          for line in (version_output or "").splitlines()
+          if "Runtime Environment" in line
+        ),
+        None,
+      )
+      vendor = (
+        runtime_line.split(" Runtime Environment", 1)[0]
+        if runtime_line and " Runtime Environment" in runtime_line
+        else None
+      )
+
       java_home_check_structured_output = {
         "exit_code": 0,
-        "message": "Java home exists!",
+        "message": "Java home is valid.",
+        "java_home": java_home,
+        "java_version": actual_java_version,
+        "java_vendor": vendor,
+        "java_runtime": runtime_line,
+        "expected_java_version": expected_java_version,
       }
+      if exit_code != 0 or actual_java_feature is None:
+        java_home_check_structured_output.update(
+          {
+            "exit_code": 1,
+            "message": f"Unable to run Java from {java_home}.",
+          }
+        )
+      elif (
+        expected_java_feature is not None
+        and actual_java_feature != expected_java_feature
+      ):
+        java_home_check_structured_output.update(
+          {
+            "exit_code": 1,
+            "message": (
+              f"Java at {java_home} has feature version {actual_java_feature}; "
+              f"Ambari requires feature version {expected_java_feature}."
+            ),
+          }
+        )
+      else:
+        Logger.info("Java home exists and its version is valid.")
 
     Logger.info("Java home check completed.")
     return java_home_check_structured_output
+
+  @staticmethod
+  def _java_feature_version(version):
+    if version is None:
+      return None
+    parts = str(version).split(".")
+    try:
+      feature_part = parts[1] if parts[0] == "1" else parts[0]
+      feature_match = re.match(r"\d+", feature_part)
+      return int(feature_match.group(0)) if feature_match else None
+    except IndexError:
+      return None
 
   def execute_db_connection_check(self, config, tmp_dir):
     Logger.info("DB connection check started.")

--- a/ambari-server/src/main/resources/stacks/BIGTOP/3.2.0/configuration/cluster-env.xml
+++ b/ambari-server/src/main/resources/stacks/BIGTOP/3.2.0/configuration/cluster-env.xml
@@ -249,6 +249,16 @@ gpgcheck=0</value>
     <on-ambari-upgrade add="true"/>
   </property>
   <property>
+    <name>java_home_overrides</name>
+    <display-name>Service and component Java home overrides</display-name>
+    <value>{}</value>
+    <description>JSON map of service or component names to a pre-installed Java home and feature version. Component entries take precedence. Example: {"SOLR":{"home":"/usr/lib/jvm/java-17","version":17}}</description>
+    <value-attributes>
+      <empty-value-valid>true</empty-value-valid>
+    </value-attributes>
+    <on-ambari-upgrade add="true"/>
+  </property>
+  <property>
     <name>alerts_repeat_tolerance</name>
     <value>1</value>
     <description>The number of consecutive alerts required to transition an alert from the SOFT to the HARD state.</description>

--- a/ambari-server/src/main/resources/stacks/BIGTOP/3.2.0/services/HBASE/configuration/hbase-env.xml
+++ b/ambari-server/src/main/resources/stacks/BIGTOP/3.2.0/services/HBASE/configuration/hbase-env.xml
@@ -194,7 +194,11 @@ export HBASE_CLASSPATH=${HBASE_CLASSPATH}
 # Below are what we set by default. May only work with SUN JVM.
 # For more on why as well as other possible settings,
 # see http://wiki.apache.org/hadoop/PerformanceTuning
+{% if java_version &gt;= 9 %}
+export SERVER_GC_OPTS="-Xlog:gc*:file={{log_dir}}/gc.log:time,uptime,level,tags:filecount=10,filesize=100M"
+{% else %}
 export SERVER_GC_OPTS="-verbose:gc -XX:-PrintGCCause -XX:+PrintAdaptiveSizePolicy -XX:+PrintGCDetails -XX:+PrintGCDateStamps -Xloggc:{{log_dir}}/gc.log-`date +'%Y%m%d%H%M'`"
+{% endif %}
 # Uncomment below to enable java garbage collection logging.
 # export HBASE_OPTS="$HBASE_OPTS -verbose:gc -XX:+PrintGCDetails -XX:+PrintGCDateStamps -Xloggc:$HBASE_HOME/logs/gc-hbase.log"
 

--- a/ambari-server/src/main/resources/stacks/BIGTOP/3.2.0/services/SOLR/package/scripts/params.py
+++ b/ambari-server/src/main/resources/stacks/BIGTOP/3.2.0/services/SOLR/package/scripts/params.py
@@ -85,6 +85,7 @@ solr_user_nproc_limit = default(
 
 # shared configs
 java_home = config["ambariLevelParams"]["java_home"]
+java_version = expect("/ambariLevelParams/java_version", int)
 ambari_java_home = config['ambariLevelParams']['ambari_java_home']
 ambari_java_exec = format("{ambari_java_home}/bin/java")
 

--- a/ambari-server/src/main/resources/stacks/BIGTOP/3.2.0/services/SOLR/properties/solr-env.sh.j2
+++ b/ambari-server/src/main/resources/stacks/BIGTOP/3.2.0/services/SOLR/properties/solr-env.sh.j2
@@ -24,9 +24,13 @@ SOLR_JAVA_MEM="-Xms{{solr_min_mem}}m -Xmx{{solr_max_mem}}m"
 
 SOLR_JAVA_STACK_SIZE="-Xss{{solr_java_stack_size}}m"
 
+{% if java_version >= 9 -%}
+GC_LOG_OPTS="-Xlog:gc*:file={{solr_log_dir}}/solr_gc.log:time,uptime,level,tags:filecount=15,filesize=200M"
+GC_TUNE="-XX:+UseG1GC -XX:MaxGCPauseMillis=250 -XX:+ParallelRefProcEnabled"
+{% else -%}
 GC_LOG_OPTS="{{solr_gc_log_opts}} -Xloggc:{{solr_log_dir}}/solr_gc.log"
-
 GC_TUNE="{{solr_gc_tune}}"
+{% endif %}
 
 # Set the ZooKeeper connection string if using an external ZooKeeper ensemble
 # e.g. host1:2181,host2:2181/chroot

--- a/ambari-server/src/test/java/org/apache/ambari/server/configuration/ConfigurationTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/configuration/ConfigurationTest.java
@@ -82,6 +82,35 @@ public class ConfigurationTest {
     temp.delete();
   }
 
+  @Test
+  public void testAmbariJavaProperties() {
+    Configuration configuration = new Configuration();
+    configuration.setProperty("ambari.java.home", "/java17");
+    configuration.setProperty("ambari.java.version", "17");
+
+    assertEquals(Runtime.version().feature(), configuration.getJavaVersion());
+    assertEquals("/java17", configuration.getAmbariJavaHome());
+    assertEquals(
+        String.valueOf(Runtime.version().feature()), configuration.getAmbariJavaVersion());
+  }
+
+  @Test
+  public void testAgentJavaHomeUsesAmbariJdkWithLegacyFallback() {
+    Properties ambariProperties = new Properties();
+    ambariProperties.setProperty("java.home", "/stack-java");
+    ambariProperties.setProperty("ambari.java.home", "/ambari-java");
+
+    Configuration configuration = new Configuration(ambariProperties);
+
+    assertEquals("/ambari-java",
+        configuration.getAgentConfigsMap().get("agentConfig").get("java.home"));
+
+    ambariProperties.remove("ambari.java.home");
+    configuration = new Configuration(ambariProperties);
+    assertEquals("/stack-java",
+        configuration.getAgentConfigsMap().get("agentConfig").get("java.home"));
+  }
+
   /**
    * ambari.properties doesn't contain "security.agent.hostname.validate" option
    */

--- a/ambari-server/src/test/java/org/apache/ambari/server/controller/RootServiceResponseFactoryTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/controller/RootServiceResponseFactoryTest.java
@@ -160,10 +160,11 @@ public class RootServiceResponseFactoryTest {
 
   private void verifyResponseForAmbariServer(RootServiceComponentResponse response) {
     assertEquals(ambariMetaInfo.getServerVersion(), response.getComponentVersion());
-    // all properties from config + "jdk_location" + "java.version"
-    int expectedPropertyCount = config.getAmbariProperties().size() + 2;
+    // all properties from config + "jdk_location" + Stack and Ambari Java versions
+    int expectedPropertyCount = config.getAmbariProperties().size() + 3;
     assertEquals(response.getProperties().toString(), expectedPropertyCount, response.getProperties().size());
     assertTrue(response.getProperties().containsKey("jdk_location"));
     assertTrue(response.getProperties().containsKey("java.version"));
+    assertTrue(response.getProperties().containsKey("ambari.java.version"));
   }
 }

--- a/ambari-server/src/test/java/org/apache/ambari/server/utils/StageUtilsTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/utils/StageUtilsTest.java
@@ -611,8 +611,8 @@ public class StageUtilsTest extends EasyMockSupport {
     Map<String, String> commandParams = new HashMap<>();
     Configuration configuration = new Configuration();
     configuration.setProperty("java.home", "myJavaHome");
-    configuration.setProperty("jdk.name", "myJdkName");
-    configuration.setProperty("jce.name", "myJceName");
+    configuration.setProperty("ambari.jdk.name", "myJdkName");
+    configuration.setProperty("ambari.jce.name", "myJceName");
     configuration.setProperty("ambari.java.home", "ambari_java_home");
     // WHEN
     StageUtils.useAmbariJdkInCommandParams(commandParams, configuration);
@@ -678,6 +678,38 @@ public class StageUtilsTest extends EasyMockSupport {
     assertEquals("myJdkName", hostLevelParams.get("jdk_name"));
     assertEquals("myJceName", hostLevelParams.get("jce_name"));
     assertEquals(4, hostLevelParams.size());
+  }
+
+  @Test
+  public void testUseAmbariJdkAsStackDefaultWhenStackAndLegacyJdksAreMissing() {
+    Map<String, String> hostLevelParams = new HashMap<>();
+    Configuration configuration = new Configuration();
+    configuration.setProperty("ambari.java.home", "ambariJavaHome");
+    configuration.setProperty("ambari.jdk.name", "ambariJdkName");
+    configuration.setProperty("ambari.jce.name", "ambariJceName");
+
+    StageUtils.useStackJdkIfExists(hostLevelParams, configuration);
+
+    assertEquals("ambariJavaHome", hostLevelParams.get("java_home"));
+    assertEquals("ambariJdkName", hostLevelParams.get("jdk_name"));
+    assertEquals("ambariJceName", hostLevelParams.get("jce_name"));
+    assertEquals(String.valueOf(Runtime.version().feature()), hostLevelParams.get("java_version"));
+    assertEquals(4, hostLevelParams.size());
+  }
+
+  @Test
+  public void testUseStackJdkDoesNotReplaceAmbariJdk() {
+    Map<String, String> commandParams = new HashMap<>();
+    Configuration configuration = new Configuration();
+    configuration.setProperty("ambari.java.home", "ambariJavaHome");
+    configuration.setProperty("ambari.java.version", "17");
+    configuration.setProperty("stack.java.home", "stackJavaHome");
+    configuration.setProperty("stack.java.version", "11");
+
+    StageUtils.useAmbariJdkInCommandParams(commandParams, configuration);
+
+    assertEquals("ambariJavaHome", commandParams.get("ambari_java_home"));
+    assertEquals("17", commandParams.get("ambari_java_version"));
   }
 
   private void checkServiceHostIndexes(Map<String, Set<String>> info, String componentName, String mappedComponentName,

--- a/ambari-server/src/test/python/TestAmbariServer.py
+++ b/ambari-server/src/test/python/TestAmbariServer.py
@@ -5302,6 +5302,7 @@ class TestAmbariServer(TestCase):
     p.process_pair(SERVER_VERSION_FILE_PATH, "some_value")
     p.process_pair(OS_TYPE_PROPERTY, "some_value")
     p.process_pair(JAVA_HOME_PROPERTY, "some_value")
+    p.process_pair(AMBARI_JAVA_HOME_PROPERTY, "some_value")
     p.process_pair(JDK_NAME_PROPERTY, "some_value")
     p.process_pair(JCE_NAME_PROPERTY, "some_value")
     p.process_pair(COMMON_SERVICES_PATH_PROPERTY, "some_value")
@@ -5645,7 +5646,7 @@ class TestAmbariServer(TestCase):
 
     # Checking situation when required properties not set up
     args = reset_mocks()
-    p.removeProp(JAVA_HOME_PROPERTY)
+    p.removeProp(AMBARI_JAVA_HOME_PROPERTY)
     get_ambari_properties_mock.return_value = p
     try:
       _ambari_server_.start(args)

--- a/ambari-server/src/test/python/TestAmbariServer.py
+++ b/ambari-server/src/test/python/TestAmbariServer.py
@@ -167,6 +167,7 @@ with patch.object(
                     JDBC_DATABASE_NAME_PROPERTY,
                     OS_TYPE_PROPERTY,
                     validate_jdk,
+                    get_java_version,
                     JDBC_POSTGRES_SCHEMA_PROPERTY,
                     RESOURCES_DIR_PROPERTY,
                     JDBC_RCA_PASSWORD_ALIAS,
@@ -191,6 +192,10 @@ with patch.object(
                     JAVA_HOME_PROPERTY,
                     JDK_NAME_PROPERTY,
                     JCE_NAME_PROPERTY,
+                    AMBARI_JAVA_HOME_PROPERTY,
+                    AMBARI_JDK_NAME_PROPERTY,
+                    AMBARI_JCE_NAME_PROPERTY,
+                    AMBARI_JAVA_VERSION,
                     STACK_LOCATION_KEY,
                     SERVER_VERSION_FILE_PATH,
                     COMMON_SERVICES_PATH_PROPERTY,
@@ -202,6 +207,9 @@ with patch.object(
                     STACKADVISOR_SCRIPT,
                     BOOTSTRAP_DIR_PROPERTY,
                     MPACKS_STAGING_PATH_PROPERTY,
+                    STACK_JAVA_HOME_PROPERTY,
+                    STACK_JDK_NAME_PROPERTY,
+                    STACK_JCE_NAME_PROPERTY,
                     STACK_JAVA_VERSION,
                   )
                   from ambari_server.serverUtils import (
@@ -230,6 +238,7 @@ with patch.object(
                     run_schema_upgrade,
                     move_user_custom_actions,
                     find_and_copy_custom_services,
+                    migrate_java_home_properties,
                   )
                   from ambari_server.setupHttps import (
                     is_valid_https_port,
@@ -1537,9 +1546,9 @@ class TestAmbariServer(TestCase):
   ):
     # Testing boostrap dir wipe
     properties_mock = Properties()
-    properties_mock.process_pair(JDK_NAME_PROPERTY, "dummy_jdk")
-    properties_mock.process_pair(JCE_NAME_PROPERTY, "dummy_jce")
-    properties_mock.process_pair(JAVA_HOME_PROPERTY, "dummy_java_home")
+    properties_mock.process_pair(AMBARI_JDK_NAME_PROPERTY, "dummy_jdk")
+    properties_mock.process_pair(AMBARI_JCE_NAME_PROPERTY, "dummy_jce")
+    properties_mock.process_pair(AMBARI_JAVA_HOME_PROPERTY, "dummy_java_home")
     get_ambari_properties_mock.return_value = properties_mock
 
     get_value_from_properties_mock.return_value = "dummy_bootstrap_dir"
@@ -3254,8 +3263,9 @@ class TestAmbariServer(TestCase):
   @patch("ambari_server.serverSetup.update_properties")
   @patch("ambari_server.serverSetup.get_validated_string_input")
   @patch("ambari_server.serverSetup.print_info_msg")
+  @patch("ambari_server.serverSetup.get_java_version")
   @patch("ambari_server.serverSetup.validate_jdk")
-  @patch("ambari_server.serverSetup.get_JAVA_HOME")
+  @patch("ambari_server.serverSetup.find_jdk")
   @patch("ambari_server.serverSetup.get_resources_location")
   @patch("ambari_server.serverSetup.get_ambari_properties")
   @patch("ambari_server.serverSetup.check_ambari_java_version_is_valid")
@@ -3268,8 +3278,9 @@ class TestAmbariServer(TestCase):
     check_ambari_java_version_is_valid_mock,
     get_ambari_properties_mock,
     get_resources_location_mock,
-    get_JAVA_HOME_mock,
+    find_jdk_mock,
     validate_jdk_mock,
+    get_java_version_mock,
     print_info_msg_mock,
     get_validated_string_input_mock,
     update_properties_mock,
@@ -3331,6 +3342,8 @@ class TestAmbariServer(TestCase):
 
     args = MagicMock()
     args.java_home = "somewhere"
+    args.ambari_java_home = None
+    args.stack_java_home = None
     args.silent = False
 
     p, jdk1_url, res_location, pem_side_effect1 = _init_test_jdk_mocks()
@@ -3338,10 +3351,11 @@ class TestAmbariServer(TestCase):
     validate_jdk_mock.return_value = False
     path_existsMock.return_value = False
     get_resources_location_mock.return_value = res_location
-    get_JAVA_HOME_mock.return_value = False
+    find_jdk_mock.return_value = False
     read_ambari_user_mock.return_value = "ambari"
     get_ambari_properties_mock.return_value = p
     check_ambari_java_version_is_valid_mock.return_value = True
+    get_java_version_mock.return_value = 17
     # Test case: ambari.properties not found
     try:
       download_and_install_jdk(args)
@@ -3355,7 +3369,7 @@ class TestAmbariServer(TestCase):
     args.java_home = None
     args.jdk_location = None
     args.ambari_java_home = None
-    get_JAVA_HOME_mock.return_value = "some_jdk"
+    find_jdk_mock.return_value = "some_jdk"
     validate_jdk_mock.return_value = True
     get_YN_input_mock.return_value = False
     path_existsMock.return_value = False
@@ -3367,7 +3381,7 @@ class TestAmbariServer(TestCase):
     args.java_home = "somewhere"
     validate_jdk_mock.return_value = True
     path_existsMock.return_value = False
-    get_JAVA_HOME_mock.return_value = None
+    find_jdk_mock.return_value = None
     rcode = download_and_install_jdk(args)
     self.assertEqual(0, rcode)
     self.assertTrue(update_properties_mock.called)
@@ -3426,7 +3440,7 @@ class TestAmbariServer(TestCase):
 
     # Test case: jdk is already installed, ensure that JCE check is skipped if -j option is not supplied.
     args.jdk_location = None
-    get_JAVA_HOME_mock.return_value = "some_jdk"
+    find_jdk_mock.return_value = "some_jdk"
     validate_jdk_mock.return_value = True
     get_YN_input_mock.return_value = False
     path_existsMock.reset_mock()
@@ -3445,7 +3459,7 @@ class TestAmbariServer(TestCase):
     validate_jdk_mock.return_value = True
     path_existsMock.reset_mock()
     path_existsMock.side_effect = pem_side_effect1
-    get_JAVA_HOME_mock.return_value = "some_jdk"
+    find_jdk_mock.return_value = "some_jdk"
     path_isfileMock.return_value = True
     download_and_install_jdk(args)
     self.assertTrue(update_properties_mock.call_count == 1)
@@ -3456,7 +3470,7 @@ class TestAmbariServer(TestCase):
     # args.java_home = "somewhere"
     # path_existsMock.side_effect = None
     # path_existsMock.return_value = True
-    # get_JAVA_HOME_mock.return_value = "some_jdk"
+    # find_jdk_mock.return_value = "some_jdk"
     # try:
     #  download_and_install_jdk(args)
     #  self.fail("Should throw exception")
@@ -3472,7 +3486,7 @@ class TestAmbariServer(TestCase):
     path_existsMock.reset_mock()
     path_existsMock.side_effect = [True, True, True, True]
     get_validated_string_input_mock.return_value = "2"
-    get_JAVA_HOME_mock.return_value = None
+    find_jdk_mock.return_value = None
     rcode = download_and_install_jdk(args)
     self.assertEqual(0, rcode)
     self.assertTrue(update_properties_mock.called)
@@ -3483,7 +3497,7 @@ class TestAmbariServer(TestCase):
     path_existsMock.reset_mock()
     path_existsMock.side_effect = pem_side_effect1
     get_validated_string_input_mock.return_value = "2"
-    get_JAVA_HOME_mock.return_value = None
+    find_jdk_mock.return_value = None
     try:
       download_and_install_jdk(args)
       self.fail("Should throw exception")
@@ -3499,7 +3513,7 @@ class TestAmbariServer(TestCase):
     path_existsMock.reset_mock()
     path_existsMock.side_effect = pem_side_effect1
     get_validated_string_input_mock.return_value = "2"
-    get_JAVA_HOME_mock.return_value = None
+    find_jdk_mock.return_value = None
     flag = False
     try:
       download_and_install_jdk(args)
@@ -3520,7 +3534,8 @@ class TestAmbariServer(TestCase):
       self.fail("Should throw exception")
     except FatalException as fe:
       self.assertTrue(
-        "Path to java home somewhere or java binary file does not exists" in fe.reason
+        "Path to Ambari java home somewhere or java binary file does not exist"
+        in fe.reason
       )
       pass
     pass
@@ -3647,42 +3662,28 @@ class TestAmbariServer(TestCase):
     pass
 
   @not_for_platform(PLATFORM_WINDOWS)
-  @patch.object(subprocess, "Popen")
-  def test_check_ambari_java_version_is_valid(self, popenMock):
-    # case 1:  jdk7 is picked for stacks
+  @patch("ambari_server.serverSetup.get_java_version")
+  def test_check_ambari_java_version_is_valid(self, get_java_version_mock):
+    # case 1: JDK 7 is too old for Ambari
     properties = Properties()
-    p = MagicMock()
-    p.communicate.return_value = ("7", None)
-    p.returncode = 0
-    popenMock.return_value = p
+    get_java_version_mock.return_value = 7
     result = check_ambari_java_version_is_valid(
       "/usr/jdk64/jdk_1.7.0/", "java", 8, properties
     )
-    self.assertEqual(properties.get_property(STACK_JAVA_VERSION), "7")
+    self.assertEqual(properties.get_property(AMBARI_JAVA_VERSION), "7")
     self.assertFalse(result)
 
-    # case 2: jdk8 is picked for stacks
+    # case 2: JDK 8 satisfies the requested minimum
     properties = Properties()
-    p.communicate.return_value = ("8", None)
-    p.returncode = 0
+    get_java_version_mock.return_value = 8
     result = check_ambari_java_version_is_valid(
       "/usr/jdk64/jdk_1.8.0/", "java", 8, properties
     )
-    self.assertFalse(properties.get_property(STACK_JAVA_VERSION))
+    self.assertEqual(properties.get_property(AMBARI_JAVA_VERSION), "8")
     self.assertTrue(result)
 
-    # case 3: return code is not 0
-    p.returncode = 1
-    try:
-      check_ambari_java_version_is_valid("/usr/jdk64/jdk_1.8.0/", "java", 8, properties)
-      self.fail("Should throw exception")
-    except FatalException:
-      # expected
-      pass
-
-    # case 4: unparseable response - type error
-    p.communicate.return_value = ("something else", None)
-    p.returncode = 0
+    # case 3: version cannot be determined
+    get_java_version_mock.return_value = None
     try:
       check_ambari_java_version_is_valid("/usr/jdk64/jdk_1.8.0/", "java", 8, properties)
       self.fail("Should throw exception")
@@ -3690,6 +3691,57 @@ class TestAmbariServer(TestCase):
       # expected
       self.assertEqual(e.code, 1)
       pass
+
+  @patch("ambari_server.serverSetup.validate_jdk", return_value=True)
+  @patch("ambari_server.serverSetup.get_java_version", side_effect=[17, 11])
+  def test_jdk_setup_keeps_ambari_and_stack_java_independent(
+    self, get_java_version_mock, validate_jdk_mock
+  ):
+    properties = Properties()
+    properties.process_pair(AMBARI_JDK_NAME_PROPERTY, "old-ambari-jdk.tar.gz")
+    properties.process_pair(AMBARI_JCE_NAME_PROPERTY, "old-ambari-jce.zip")
+    properties.process_pair(STACK_JDK_NAME_PROPERTY, "old-stack-jdk.tar.gz")
+    properties.process_pair(STACK_JCE_NAME_PROPERTY, "old-stack-jce.zip")
+    args = MagicMock(
+      java_home="/java11",
+      ambari_java_home="/java17",
+      stack_java_home="/java11",
+    )
+    jdk_setup = JDKSetup()
+    jdk_setup._ensure_java_home_env_var_is_set = MagicMock()
+
+    jdk_setup.download_and_install_jdk(args, properties)
+
+    self.assertEqual("/java17", properties.get_property(AMBARI_JAVA_HOME_PROPERTY))
+    self.assertEqual("17", properties.get_property(AMBARI_JAVA_VERSION))
+    self.assertEqual("/java11", properties.get_property(STACK_JAVA_HOME_PROPERTY))
+    self.assertEqual("11", properties.get_property(STACK_JAVA_VERSION))
+    self.assertFalse(properties.get_property(AMBARI_JDK_NAME_PROPERTY))
+    self.assertFalse(properties.get_property(AMBARI_JCE_NAME_PROPERTY))
+    self.assertFalse(properties.get_property(STACK_JDK_NAME_PROPERTY))
+    self.assertFalse(properties.get_property(STACK_JCE_NAME_PROPERTY))
+    jdk_setup._ensure_java_home_env_var_is_set.assert_called_once_with("/java17")
+
+  @patch("ambari_server.serverSetup.validate_jdk", return_value=True)
+  @patch("ambari_server.serverSetup.get_java_version", side_effect=[17, None])
+  def test_jdk_setup_validates_all_java_homes_before_updating_properties(
+    self, get_java_version_mock, validate_jdk_mock
+  ):
+    properties = Properties()
+    args = MagicMock(
+      java_home=None,
+      ambari_java_home="/java17",
+      stack_java_home="/broken-stack-java",
+    )
+    jdk_setup = JDKSetup()
+    jdk_setup._ensure_java_home_env_var_is_set = MagicMock()
+
+    with self.assertRaises(FatalException):
+      jdk_setup.download_and_install_jdk(args, properties)
+
+    self.assertFalse(properties.get_property(AMBARI_JAVA_HOME_PROPERTY))
+    self.assertFalse(properties.get_property(STACK_JAVA_HOME_PROPERTY))
+    self.assertFalse(jdk_setup._ensure_java_home_env_var_is_set.called)
 
   @not_for_platform(PLATFORM_WINDOWS)
   @patch.object(OSCheck, "os_distribution", new=MagicMock(return_value=os_distro_value))
@@ -4060,9 +4112,13 @@ class TestAmbariServer(TestCase):
     pass
 
   @patch("glob.glob")
+  @patch("shutil.which", new=MagicMock(return_value=None))
   @patch("ambari_server.serverConfiguration.get_JAVA_HOME")
   @patch("ambari_server.serverConfiguration.validate_jdk")
-  def test_find_jdk(self, validate_jdk_mock, get_JAVA_HOME_mock, globMock):
+  @patch("ambari_server.serverConfiguration.get_java_version", return_value=17)
+  def test_find_jdk(
+    self, get_java_version_mock, validate_jdk_mock, get_JAVA_HOME_mock, globMock
+  ):
     get_JAVA_HOME_mock.return_value = "somewhere"
     validate_jdk_mock.return_value = True
     result = find_jdk()
@@ -4082,6 +4138,73 @@ class TestAmbariServer(TestCase):
     result = find_jdk()
     self.assertEqual(result, "one")
     pass
+
+  @patch("ambari_server.serverConfiguration.get_java_version")
+  @patch("ambari_server.serverConfiguration.get_JAVA_HOME")
+  @patch("shutil.which", new=MagicMock(return_value="/opt/java17/bin/java"))
+  @patch(
+    "ambari_server.serverConfiguration.validate_jdk",
+    new=MagicMock(return_value=True),
+  )
+  def test_find_jdk_skips_versions_below_minimum(
+    self, get_JAVA_HOME_mock, get_java_version_mock
+  ):
+    get_JAVA_HOME_mock.return_value = "/opt/java11"
+    get_java_version_mock.side_effect = [11, 17]
+
+    self.assertEqual("/opt/java17", find_jdk(min_version=17))
+
+  @patch("ambari_server.serverConfiguration.run_os_command")
+  @patch(
+    "ambari_server.serverConfiguration.validate_jdk",
+    new=MagicMock(return_value=True),
+  )
+  def test_get_java_version(self, run_os_command_mock):
+    run_os_command_mock.return_value = (
+      0,
+      "",
+      'openjdk version "17.0.12" 2024-07-16',
+    )
+    self.assertEqual(17, get_java_version("/java17"))
+
+    run_os_command_mock.return_value = (0, "", 'java version "1.8.0_402"')
+    self.assertEqual(8, get_java_version("/java8"))
+
+    run_os_command_mock.return_value = (1, "", "failed")
+    self.assertIsNone(get_java_version("/invalid"))
+
+  @patch("ambari_server.serverUpgrade.update_properties")
+  @patch("ambari_server.serverUpgrade.get_java_version")
+  def test_migrate_java_home_properties(
+    self, get_java_version_mock, update_properties_mock
+  ):
+    properties = Properties()
+    properties.process_pair(JAVA_HOME_PROPERTY, "/java11")
+    properties.process_pair(JDK_NAME_PROPERTY, "stack-jdk.tar.gz")
+    properties.process_pair(JCE_NAME_PROPERTY, "stack-jce.zip")
+    properties.process_pair(AMBARI_JDK_NAME_PROPERTY, "old-jdk.tar.gz")
+    properties.process_pair(AMBARI_JCE_NAME_PROPERTY, "old-jce.zip")
+    get_java_version_mock.side_effect = [11, 17]
+
+    migrate_java_home_properties(properties, "/java17")
+
+    self.assertEqual(
+      "/java11", properties.get_property(STACK_JAVA_HOME_PROPERTY)
+    )
+    self.assertEqual("11", properties.get_property(STACK_JAVA_VERSION))
+    self.assertEqual(
+      "stack-jdk.tar.gz", properties.get_property(STACK_JDK_NAME_PROPERTY)
+    )
+    self.assertEqual(
+      "stack-jce.zip", properties.get_property(STACK_JCE_NAME_PROPERTY)
+    )
+    self.assertEqual(
+      "/java17", properties.get_property(AMBARI_JAVA_HOME_PROPERTY)
+    )
+    self.assertEqual("17", properties.get_property(AMBARI_JAVA_VERSION))
+    self.assertFalse(properties.get_property(AMBARI_JDK_NAME_PROPERTY))
+    self.assertFalse(properties.get_property(AMBARI_JCE_NAME_PROPERTY))
+    self.assertTrue(update_properties_mock.called)
 
   @patch("os.path.exists")
   @patch("zipfile.ZipFile")
@@ -4160,7 +4283,7 @@ class TestAmbariServer(TestCase):
   ):
     exists_mock.return_value = True
     properties = Properties()
-    properties.process_pair(JAVA_HOME_PROPERTY, "/java_home")
+    properties.process_pair(AMBARI_JAVA_HOME_PROPERTY, "/java_home")
     unpack_jce_policy_mock.return_value = 0
     get_ambari_properties_mock.return_value = properties
     conf_file = "etc/ambari-server/conf/ambari.properties"
@@ -5949,8 +6072,10 @@ class TestAmbariServer(TestCase):
   @patch("ambari_server.setupMpacks.get_replay_log_file")
   @patch("ambari_server.serverUpgrade.logger")
   @patch.object(PGConfig, "_change_db_files_owner", return_value=0)
+  @patch("ambari_server.serverUpgrade.migrate_java_home_properties")
   def test_upgrade_from_161(
     self,
+    migrate_java_home_properties_mock,
     change_db_files_owner_mock,
     logger_mock,
     get_replay_log_file_mock,
@@ -6262,8 +6387,10 @@ class TestAmbariServer(TestCase):
   @patch("ambari_server.serverUpgrade.move_user_custom_actions")
   @patch("ambari_server.serverUpgrade.update_krb_jaas_login_properties")
   @patch("ambari_server.serverUpgrade.update_ambari_env")
+  @patch("ambari_server.serverUpgrade.migrate_java_home_properties")
   def test_upgrade(
     self,
+    migrate_java_home_properties_mock,
     update_ambari_env_mock,
     update_krb_jaas_login_properties_mock,
     move_user_custom_actions,
@@ -6487,8 +6614,10 @@ class TestAmbariServer(TestCase):
   @patch("ambari_server.serverUpgrade.get_ambari_properties")
   @patch("ambari_server.serverUpgrade.move_user_custom_actions")
   @patch("ambari_server.serverUpgrade.update_krb_jaas_login_properties")
+  @patch("ambari_server.serverUpgrade.migrate_java_home_properties")
   def test_upgrade(
     self,
+    migrate_java_home_properties_mock,
     update_krb_jaas_login_properties_mock,
     move_user_custom_actions,
     get_ambari_properties_mock,

--- a/ambari-server/src/test/python/TestAmbariServer.py
+++ b/ambari-server/src/test/python/TestAmbariServer.py
@@ -3495,15 +3495,12 @@ class TestAmbariServer(TestCase):
     update_properties_mock.reset_mock()
     validate_jdk_mock.return_value = False
     path_existsMock.reset_mock()
-    path_existsMock.side_effect = pem_side_effect1
+    path_existsMock.side_effect = None
+    path_existsMock.return_value = False
     get_validated_string_input_mock.return_value = "2"
     find_jdk_mock.return_value = None
-    try:
+    with self.assertRaises(FatalException):
       download_and_install_jdk(args)
-      self.fail("Should throw exception")
-    except FatalException as fe:
-      # Expected
-      pass
 
     # Test when custom java home exists but java binary file doesn't exist
     args.java_home = None
@@ -3511,18 +3508,12 @@ class TestAmbariServer(TestCase):
     path_isfileMock.return_value = False
     update_properties_mock.reset_mock()
     path_existsMock.reset_mock()
-    path_existsMock.side_effect = pem_side_effect1
+    path_existsMock.side_effect = None
+    path_existsMock.return_value = True
     get_validated_string_input_mock.return_value = "2"
     find_jdk_mock.return_value = None
-    flag = False
-    try:
+    with self.assertRaises(FatalException):
       download_and_install_jdk(args)
-      self.fail("Should throw exception")
-    except FatalException as fe:
-      # Expected
-      flag = True
-      pass
-    self.assertTrue(flag)
 
     # Test case: Setup ambari-server with java home passed. Path to java home doesn't exist
     args.java_home = "somewhere"

--- a/ambari-server/src/test/python/TestSensitiveDataEncryption.py
+++ b/ambari-server/src/test/python/TestSensitiveDataEncryption.py
@@ -123,10 +123,6 @@ class TestSensitiveDataEncryption(TestCase):
 
   @patch("os.path.isdir", new=MagicMock(return_value=True))
   @patch("os.access", new=MagicMock(return_value=True))
-  @patch(
-    "ambari_server.setupSecurity.get_java_exe_path",
-    new=MagicMock(return_value="/java17/bin/java"),
-  )
   @patch.object(
     ServerClassPath,
     "get_full_ambari_classpath_escaped_for_shell",
@@ -143,7 +139,7 @@ class TestSensitiveDataEncryption(TestCase):
     find_jdk_mock,
     find_properties_file_mock,
   ):
-    find_jdk_mock.return_value = "/"
+    find_jdk_mock.return_value = "/java17"
     find_properties_file_mock.return_value = "/tmp/ambari.properties"
     environ = os.environ.copy()
 
@@ -175,10 +171,6 @@ class TestSensitiveDataEncryption(TestCase):
 
   @patch("os.path.isdir", new=MagicMock(return_value=True))
   @patch("os.access", new=MagicMock(return_value=True))
-  @patch(
-    "ambari_server.setupSecurity.get_java_exe_path",
-    new=MagicMock(return_value="/java17/bin/java"),
-  )
   @patch.object(
     ServerClassPath,
     "get_full_ambari_classpath_escaped_for_shell",
@@ -195,7 +187,7 @@ class TestSensitiveDataEncryption(TestCase):
     find_jdk_mock,
     find_properties_file_mock,
   ):
-    find_jdk_mock.return_value = "/"
+    find_jdk_mock.return_value = "/java17"
     find_properties_file_mock.return_value = "/tmp/ambari.properties"
     environ = os.environ.copy()
     master = "master"

--- a/ambari-server/src/test/python/TestSensitiveDataEncryption.py
+++ b/ambari-server/src/test/python/TestSensitiveDataEncryption.py
@@ -123,6 +123,10 @@ class TestSensitiveDataEncryption(TestCase):
 
   @patch("os.path.isdir", new=MagicMock(return_value=True))
   @patch("os.access", new=MagicMock(return_value=True))
+  @patch(
+    "ambari_server.setupSecurity.get_java_exe_path",
+    new=MagicMock(return_value="/java17/bin/java"),
+  )
   @patch.object(
     ServerClassPath,
     "get_full_ambari_classpath_escaped_for_shell",
@@ -149,7 +153,7 @@ class TestSensitiveDataEncryption(TestCase):
     options = self._create_empty_options_mock()
     sensitive_data_encryption(options, "encription")
     run_os_command_mock.assert_called_with(
-      "None -cp test:path12 org.apache.ambari.server.security.encryption.SensitiveDataEncryption encription > /var/log/ambari-server/ambari-server.out 2>&1",
+      "/java17/bin/java -cp test:path12 org.apache.ambari.server.security.encryption.SensitiveDataEncryption encription > /var/log/ambari-server/ambari-server.out 2>&1",
       environ,
     )
     pass
@@ -171,6 +175,10 @@ class TestSensitiveDataEncryption(TestCase):
 
   @patch("os.path.isdir", new=MagicMock(return_value=True))
   @patch("os.access", new=MagicMock(return_value=True))
+  @patch(
+    "ambari_server.setupSecurity.get_java_exe_path",
+    new=MagicMock(return_value="/java17/bin/java"),
+  )
   @patch.object(
     ServerClassPath,
     "get_full_ambari_classpath_escaped_for_shell",
@@ -199,7 +207,7 @@ class TestSensitiveDataEncryption(TestCase):
     options = self._create_empty_options_mock()
     sensitive_data_encryption(options, "decryption", master)
     run_os_command_mock.assert_called_with(
-      "None -cp test:path12 org.apache.ambari.server.security.encryption.SensitiveDataEncryption decryption > /var/log/ambari-server/ambari-server.out 2>&1",
+      "/java17/bin/java -cp test:path12 org.apache.ambari.server.security.encryption.SensitiveDataEncryption decryption > /var/log/ambari-server/ambari-server.out 2>&1",
       environ,
     )
     pass

--- a/ambari-server/src/test/python/custom_actions/TestCheckHost.py
+++ b/ambari-server/src/test/python/custom_actions/TestCheckHost.py
@@ -51,12 +51,18 @@ class TestCheckHost(TestCase):
   current_dir = os.path.dirname(os.path.realpath(__file__))
 
   @patch.object(OSCheck, "os_distribution", new=MagicMock(return_value=os_distro_value))
+  @patch("check_host.shell.call")
   @patch("os.path.isfile")
   @patch.object(Script, "get_config")
   @patch.object(Script, "get_tmp_dir")
   @patch("resource_management.libraries.script.Script.put_structured_out")
   def testJavaHomeAvailableCheck(
-    self, structured_out_mock, get_tmp_dir_mock, mock_config, os_isfile_mock
+    self,
+    structured_out_mock,
+    get_tmp_dir_mock,
+    mock_config,
+    os_isfile_mock,
+    shell_call_mock,
   ):
     # test, java home exists
     os_isfile_mock.return_value = True
@@ -65,15 +71,32 @@ class TestCheckHost(TestCase):
       "commandParams": {
         "check_execute_list": "java_home_check",
         "java_home": "test_java_home",
+        "java_version": "17",
       }
     }
+    shell_call_mock.return_value = (
+      0,
+      'openjdk version "17.0.12" 2024-07-16\n'
+      "OpenJDK Runtime Environment Temurin-17.0.12+7\n"
+      "OpenJDK 64-Bit Server VM Temurin-17.0.12+7\n",
+    )
 
     checkHost = CheckHost()
     checkHost.actionexecute(None)
 
     self.assertEqual(
       structured_out_mock.call_args[0][0],
-      {"java_home_check": {"message": "Java home exists!", "exit_code": 0}},
+      {
+        "java_home_check": {
+          "exit_code": 0,
+          "message": "Java home is valid.",
+          "java_home": "test_java_home",
+          "java_version": "17.0.12",
+          "java_vendor": "OpenJDK",
+          "java_runtime": "OpenJDK Runtime Environment Temurin-17.0.12+7",
+          "expected_java_version": "17",
+        }
+      },
     )
     # test, java home doesn't exist
     os_isfile_mock.reset_mock()
@@ -83,8 +106,31 @@ class TestCheckHost(TestCase):
 
     self.assertEqual(
       structured_out_mock.call_args[0][0],
-      {"java_home_check": {"message": "Java home doesn't exist!", "exit_code": 1}},
+      {
+        "java_home_check": {
+          "message": "Java home doesn't exist!",
+          "exit_code": 1,
+          "java_home": "test_java_home",
+          "expected_java_version": "17",
+        }
+      },
     )
+
+  @patch("check_host.shell.call")
+  @patch("os.path.isfile", new=MagicMock(return_value=True))
+  def testJavaHomeAvailableCheckRejectsWrongVersion(self, shell_call_mock):
+    shell_call_mock.return_value = (
+      0,
+      'java version "1.8.0_402"\nJava(TM) SE Runtime Environment (build 1.8.0_402)\n',
+    )
+
+    result = CheckHost().execute_java_home_available_check(
+      {"commandParams": {"java_home": "/java", "java_version": "17"}}
+    )
+
+    self.assertEqual(1, result["exit_code"])
+    self.assertEqual("1.8.0_402", result["java_version"])
+    self.assertIn("feature version 8", result["message"])
 
   @patch.object(OSCheck, "os_distribution", new=MagicMock(return_value=os_distro_value))
   @patch("tempfile.mkdtemp", new=MagicMock(return_value="/tmp/jdk_tmp_dir"))

--- a/ambari-web/classic/app/config.js
+++ b/ambari-web/classic/app/config.js
@@ -31,7 +31,7 @@ App.apiPrefix = '/api/v1';
 App.defaultStackVersion = 'HDP-2.3';
 App.defaultWindowsStackVersion = 'HDPWIN-2.1';
 
-App.defaultJavaHome = '/usr/jdk/jdk1.6.0_31';
+App.defaultJavaHome = '';
 App.timeout = 300000; // default AJAX timeout
 App.maxRetries = 3; // max number of retries for certain AJAX calls
 App.sessionKeepAliveInterval  = 60000;

--- a/ambari-web/classic/app/controllers/global/cluster_controller.js
+++ b/ambari-web/classic/app/controllers/global/cluster_controller.js
@@ -434,8 +434,8 @@ App.ClusterController = Em.Controller.extend(App.ReloadPopupMixin, {
   loadAmbariPropertiesSuccess: function (data) {
     var mainController = App.router.get('mainController');
     this.set('ambariProperties', data.RootServiceComponents.properties);
-    // Absence of 'jdk.name' and 'jce.name' properties says that ambari configured with custom jdk.
-    this.set('isCustomJDK', App.isEmptyObject(App.permit(data.RootServiceComponents.properties, ['jdk.name', 'jce.name'])));
+    // Absence of Ambari JDK/JCE archives means that Ambari uses a pre-installed JDK.
+    this.set('isCustomJDK', App.isEmptyObject(App.permit(data.RootServiceComponents.properties, ['ambari.jdk.name', 'ambari.jce.name'])));
     this.setServerClock(data);
     mainController.setAmbariServerVersion.call(mainController, data);
     mainController.monitorInactivity();

--- a/ambari-web/classic/app/controllers/installer.js
+++ b/ambari-web/classic/app/controllers/installer.js
@@ -1144,21 +1144,25 @@ App.InstallerController = App.WizardController.extend(App.Persist, {
 
 
   /**
-   * Compare jdk versions used for ambari and selected stack.
-   * Validation check will fire only for non-custom jdk configuration.
+   * Compare the configured default Stack JDK with the selected stack.
    *
    * @param {Function} successCallback
    * @param {Function} failCallback
    */
   validateJDKVersion: function (successCallback, failCallback) {
     var selectedStack = App.Stack.find().findProperty('isSelected', true),
-        currentJDKVersion = App.router.get('clusterController.ambariProperties')['java.version'],
+        currentJDKVersion = App.router.get('clusterController.ambariProperties')['stack.java.version'],
         // use min as max, or max as min version, in case when some of them missed
         minJDKVersion = selectedStack.get('minJdkVersion') || selectedStack.get('maxJdkVersion'),
         maxJDKVersion = selectedStack.get('maxJdkVersion') || selectedStack.get('minJdkVersion'),
         t = Em.I18n.t,
         fCallback = failCallback || function() {},
         sCallback = successCallback || function() {};
+
+    var jdkFeatureVersion = function (version) {
+      var parts = String(version).split('.');
+      return parseInt(parts[0] === '1' ? parts[1] : parts[0], 10);
+    };
 
     // Skip jdk check if min and max required version not set in stack definition.
     if (!minJDKVersion && !maxJDKVersion) {
@@ -1167,15 +1171,11 @@ App.InstallerController = App.WizardController.extend(App.Persist, {
     }
 
     if (currentJDKVersion) {
-      if (stringUtils.compareVersions(currentJDKVersion, minJDKVersion) < 0 ||
-          stringUtils.compareVersions(maxJDKVersion, currentJDKVersion) < 0) {
-        // checks and process only minor part for now
-        var versionDistance = parseInt(maxJDKVersion.split('.')[1], 10) - parseInt(minJDKVersion.split('.')[1], 10);
-        var versionsList = [minJDKVersion];
-        for (var i = 1; i < versionDistance + 1; i++) {
-          versionsList.push("" + minJDKVersion.split('.')[0] + '.' + (+minJDKVersion.split('.')[1] + i));
-        }
-        var versionsString = stringUtils.getFormattedStringFromArray(versionsList, t('or'));
+      var currentJDKFeature = jdkFeatureVersion(currentJDKVersion),
+          minJDKFeature = jdkFeatureVersion(minJDKVersion),
+          maxJDKFeature = jdkFeatureVersion(maxJDKVersion);
+      if (currentJDKFeature < minJDKFeature || currentJDKFeature > maxJDKFeature) {
+        var versionsString = minJDKVersion === maxJDKVersion ? minJDKVersion : minJDKVersion + ' through ' + maxJDKVersion;
         var popupBody = t('popup.jdkValidation.body').format(selectedStack.get('stackName') + ' ' + selectedStack.get('stackVersion'), versionsString, currentJDKVersion);
         App.showConfirmationPopup(sCallback, popupBody, fCallback, t('popup.jdkValidation.header'), t('common.proceedAnyway'), 'danger');
         return;

--- a/ambari-web/classic/app/controllers/main/service/reassign/step4_controller.js
+++ b/ambari-web/classic/app/controllers/main/service/reassign/step4_controller.js
@@ -653,8 +653,8 @@ App.ReassignMasterWizardStep4Controller = App.HighAvailabilityProgressPageContro
 
     params['db_name'] = this.get('content.databaseType');
     params['jdk_location'] = ambariProperties['jdk_location'];
-    params['jdk_name'] = ambariProperties['jdk.name'];
-    params['java_home'] = ambariProperties['java.home'];
+    params['jdk_name'] = ambariProperties['ambari.jdk.name'];
+    params['java_home'] = ambariProperties['ambari.java.home'];
 
     params['threshold'] = 60;
     params['ambari_server_host'] = location.hostname;

--- a/ambari-web/classic/app/controllers/wizard/step2_controller.js
+++ b/ambari-web/classic/app/controllers/wizard/step2_controller.js
@@ -515,7 +515,7 @@ App.WizardStep2Controller = Em.Controller.extend({
   }.observes('content.installOptions.useSsh'),
 
   /**
-   * Load java.home value frin server
+   * Load ambari.java.home from the server.
    * @method setAmbariJavaHome
    */
   setAmbariJavaHome: function () {
@@ -528,16 +528,16 @@ App.WizardStep2Controller = Em.Controller.extend({
   },
 
   /**
-   * Set received java.home value
+   * Set the received Ambari Java home.
    * @method onGetAmbariJavaHomeSuccess
    * @param {Object} data
    */
   onGetAmbariJavaHomeSuccess: function (data) {
-    this.set('content.installOptions.javaHome', data.RootServiceComponents.properties['java.home']);
+    this.set('content.installOptions.javaHome', data.RootServiceComponents.properties['ambari.java.home']);
   },
 
   /**
-   * Set default java.home value
+   * Set the default Ambari Java home.
    * @method onGetAmbariJavaHomeError
    */
   onGetAmbariJavaHomeError: function () {

--- a/ambari-web/classic/app/controllers/wizard/step3_controller.js
+++ b/ambari-web/classic/app/controllers/wizard/step3_controller.js
@@ -697,8 +697,7 @@ App.WizardStep3Controller = Em.Controller.extend(App.ReloadPopupMixin, App.Check
   },
 
   /**
-   * Get JDK name from server to determine if user had setup a customized JDK path when doing 'ambari-server setup'.
-   * The Ambari properties are different from default ambari-server setup, property 'jdk.name' will be missing if a customized jdk path is applied.
+   * Get the Ambari JDK path and version used by Agent Java helpers.
    * @return {$.ajax}
    * @method getJDKName
    */
@@ -707,26 +706,29 @@ App.WizardStep3Controller = Em.Controller.extend(App.ReloadPopupMixin, App.Check
       name: 'ambari.service',
       sender: this,
       data: {
-        fields : '?fields=RootServiceComponents/properties/jdk.name,RootServiceComponents/properties/java.home,RootServiceComponents/properties/jdk_location'
+        fields : '?fields=RootServiceComponents/properties/ambari.java.home,RootServiceComponents/properties/ambari.java.version,RootServiceComponents/properties/java.version,RootServiceComponents/properties/jdk_location'
       },
       success: 'getJDKNameSuccessCallback'
     });
   },
 
   /**
-    * Success callback for JDK name, property 'jdk.name' will be missing if a customized jdk path is applied
+   * Success callback for Ambari JDK properties.
     * @param {object} data
     * @method getJDKNameSuccessCallback
     */
   getJDKNameSuccessCallback: function (data) {
-    this.set('needJDKCheckOnHosts', !data.RootServiceComponents.properties["jdk.name"]);
-    this.set('jdkLocation', Em.get(data, "RootServiceComponents.properties.jdk_location"));
-    this.set('javaHome', data.RootServiceComponents.properties["java.home"]);
+    var properties = data.RootServiceComponents.properties;
+    this.set('needJDKCheckOnHosts', !!properties["ambari.java.home"]);
+    this.set('jdkLocation', properties.jdk_location);
+    this.set('javaHome', properties["ambari.java.home"]);
+    this.set('javaVersion', properties["ambari.java.version"] || properties["java.version"] || "17");
   },
 
   doCheckJDK: function () {
     const hostsNames = this.get('bootHosts').filterProperty('bootStatus', 'REGISTERED').getEach('name').join(','),
       javaHome = this.get('javaHome'),
+      javaVersion = this.get('javaVersion'),
       jdkLocation = this.get('jdkLocation');
     App.ajax.send({
       name: 'wizard.step3.jdk_check',
@@ -734,6 +736,7 @@ App.WizardStep3Controller = Em.Controller.extend(App.ReloadPopupMixin, App.Check
       data: {
         host_names: hostsNames,
         java_home: javaHome,
+        java_version: javaVersion,
         jdk_location: jdkLocation
       },
       success: 'doCheckJDKsuccessCallback',
@@ -804,7 +807,7 @@ App.WizardStep3Controller = Em.Controller.extend(App.ReloadPopupMixin, App.Check
         // need to do JDK check on each host
        self.doCheckJDK();
       } else {
-        // no customized JDK path, so no need to check jdk
+        // Ambari JDK is not configured, so there is no path to validate.
         self.set('jdkCategoryWarnings', []);
         self.set('isJDKWarningsLoaded', true);
       }

--- a/ambari-web/classic/app/messages.js
+++ b/ambari-web/classic/app/messages.js
@@ -534,7 +534,7 @@ Em.I18n.translations = {
   'popup.dependent.configs.dependencies.for.groups': 'You are changing not default group, please select config group to which you want to save dependent configs from other services',
 
   'popup.jdkValidation.header': 'Unsupported JDK',
-  'popup.jdkValidation.body': 'The {0} Stack requires JDK {1} but Ambari is configured for JDK {2}. This could result in error or problems with running your cluster.',
+  'popup.jdkValidation.body': 'The {0} Stack requires JDK {1} but the default Stack Java is configured for JDK {2}. This could result in errors when running your cluster.',
   'popup.logTail.header': 'File Name',
   'popup.logTail.openInLogSearch': 'Open In Log Search',
 

--- a/ambari-web/classic/app/utils/ajax/ajax.js
+++ b/ambari-web/classic/app/utils/ajax/ajax.js
@@ -2218,6 +2218,7 @@ var urls = {
             "parameters": {
               "threshold": "60",
               "java_home": data.java_home,
+              "java_version": data.java_version,
               "jdk_location": data.jdk_location,
               "check_execute_list": "java_home_check"
             }

--- a/ambari-web/classic/app/views/common/configs/widgets/test_db_connection_widget_view.js
+++ b/ambari-web/classic/app/views/common/configs/widgets/test_db_connection_widget_view.js
@@ -167,15 +167,15 @@ App.TestDbConnectionWidgetView = App.ConfigWidgetView.extend({
       ambari_server_host: location.hostname,
       check_execute_list: "db_connection_check"
     };
-    var properties = App.permit(properties, ['jdk.name', 'jdk_location', 'java.home']);
+    var properties = App.permit(properties, ['ambari.jdk.name', 'jdk_location', 'ambari.java.home']);
     var renameKey = function (oldKey, newKey) {
       if (properties[oldKey]) {
         defaults[newKey] = properties[oldKey];
         delete properties[oldKey];
       }
     };
-    renameKey('java.home', 'java_home');
-    renameKey('jdk.name', 'jdk_name');
+    renameKey('ambari.java.home', 'java_home');
+    renameKey('ambari.jdk.name', 'jdk_name');
     $.extend(properties, defaults);
     App.db.set('tmp', 'ambariProperties', properties);
     this.set('ambariProperties', properties);

--- a/ambari-web/classic/app/views/common/controls_view.js
+++ b/ambari-web/classic/app/views/common/controls_view.js
@@ -1280,15 +1280,15 @@ App.CheckDBConnectionView = Ember.View.extend({
       ambari_server_host: location.hostname,
       check_execute_list : "db_connection_check"
     };
-    var properties = App.permit(properties, ['jdk.name','jdk_location','java.home']);
+    var properties = App.permit(properties, ['ambari.jdk.name','jdk_location','ambari.java.home']);
     var renameKey = function(oldKey, newKey) {
       if (properties[oldKey]) {
         defaults[newKey] = properties[oldKey];
         delete properties[oldKey];
       }
     };
-    renameKey('java.home', 'java_home');
-    renameKey('jdk.name', 'jdk_name');
+    renameKey('ambari.java.home', 'java_home');
+    renameKey('ambari.jdk.name', 'jdk_name');
     $.extend(properties, defaults);
     App.db.set('tmp', 'ambariProperties', properties);
     this.set('ambariProperties', properties);

--- a/ambari-web/classic/test/controllers/installer_test.js
+++ b/ambari-web/classic/test/controllers/installer_test.js
@@ -1090,7 +1090,7 @@ describe('App.InstallerController', function () {
       {
         isCustomJDK: false,
         ambariProperties: {
-          'java.version': '1.8'
+          'stack.java.version': '1.8'
         },
         successCallbackCalled: false,
         popupCalled: true,
@@ -1104,7 +1104,7 @@ describe('App.InstallerController', function () {
       {
         isCustomJDK: false,
         ambariProperties: {
-          'java.version': '1.8'
+          'stack.java.version': '1.8'
         },
         successCallbackCalled: true,
         popupCalled: false,
@@ -1118,7 +1118,7 @@ describe('App.InstallerController', function () {
       {
         isCustomJDK: false,
         ambariProperties: {
-          'java.version': '1.5'
+          'stack.java.version': '1.5'
         },
         successCallbackCalled: false,
         popupCalled: true,
@@ -1132,7 +1132,7 @@ describe('App.InstallerController', function () {
       {
         isCustomJDK: false,
         ambariProperties: {
-          'java.version': '1.5'
+          'stack.java.version': '1.5'
         },
         successCallbackCalled: true,
         popupCalled: false,
@@ -1146,7 +1146,7 @@ describe('App.InstallerController', function () {
       {
         isCustomJDK: false,
         ambariProperties: {
-          'java.version': '1.5'
+          'stack.java.version': '1.5'
         },
         successCallbackCalled: true,
         popupCalled: false,
@@ -1160,7 +1160,7 @@ describe('App.InstallerController', function () {
       {
         isCustomJDK: false,
         ambariProperties: {
-          'java.version': '1.6'
+          'stack.java.version': '1.6'
         },
         successCallbackCalled: false,
         popupCalled: true,
@@ -1174,7 +1174,7 @@ describe('App.InstallerController', function () {
       {
         isCustomJDK: false,
         ambariProperties: {
-          'java.version': '1.5'
+          'stack.java.version': '1.5'
         },
         successCallbackCalled: true,
         popupCalled: false,
@@ -1188,7 +1188,7 @@ describe('App.InstallerController', function () {
       {
         isCustomJDK: false,
         ambariProperties: {
-          'java.version': '1.5'
+          'stack.java.version': '1.5'
         },
         successCallbackCalled: false,
         popupCalled: true,
@@ -1202,7 +1202,7 @@ describe('App.InstallerController', function () {
       {
         isCustomJDK: false,
         ambariProperties: {
-          'java.version': '1.8'
+          'stack.java.version': '1.8'
         },
         successCallbackCalled: true,
         popupCalled: false,
@@ -1214,7 +1214,7 @@ describe('App.InstallerController', function () {
       {
         isCustomJDK: true,
         ambariProperties: {
-          'java.version': '1.8'
+          'stack.java.version': '1.8'
         },
         successCallbackCalled: true,
         popupCalled: false,
@@ -1224,6 +1224,34 @@ describe('App.InstallerController', function () {
           isSelected: true
         })],
         m: 'JDK 1.8, custom jdk location used, procceed installation without warning'
+      },
+      {
+        isCustomJDK: false,
+        ambariProperties: {
+          'java.version': '17'
+        },
+        successCallbackCalled: true,
+        popupCalled: false,
+        stacks: [Em.Object.create({
+          minJdkVersion: '11',
+          maxJdkVersion: '11',
+          isSelected: true
+        })],
+        m: 'server JDK is ignored when the Stack JDK is not configured'
+      },
+      {
+        isCustomJDK: false,
+        ambariProperties: {
+          'stack.java.version': '8'
+        },
+        successCallbackCalled: true,
+        popupCalled: false,
+        stacks: [Em.Object.create({
+          minJdkVersion: '1.8',
+          maxJdkVersion: '1.8',
+          isSelected: true
+        })],
+        m: 'feature version 8 is compatible with legacy version 1.8'
       }
     ];
 

--- a/ambari-web/classic/test/controllers/main/service/reassign/step4_controller_test.js
+++ b/ambari-web/classic/test/controllers/main/service/reassign/step4_controller_test.js
@@ -1045,8 +1045,8 @@ describe('App.ReassignMasterWizardStep4Controller', function () {
     beforeEach(function () {
       sinon.stub(App.router, 'get').returns({
         'jdk_location': 'jdk_location',
-        'jdk.name': 'jdk.name',
-        'java.home': 'java.home'
+        'ambari.jdk.name': 'jdk.name',
+        'ambari.java.home': 'java.home'
       });
       sinon.stub(controller, 'getConnectionProperty').returns('prop1');
       controller.set('content.reassignHosts', Em.Object.create({target: 'host1'}));

--- a/ambari-web/classic/test/controllers/wizard/step2_test.js
+++ b/ambari-web/classic/test/controllers/wizard/step2_test.js
@@ -599,16 +599,16 @@ describe('App.WizardStep2Controller', function () {
   });
 
   describe('#onGetAmbariJavaHomeSuccess', function() {
-    it('should set java.home value receiced from server', function() {
+    it('should set ambari.java.home value received from server', function() {
       var controller = App.WizardStep2Controller.create({content: {installOptions: {}}});
-      var test = {RootServiceComponents: {properties: {'java.home': '/root'}}};
+      var test = {RootServiceComponents: {properties: {'ambari.java.home': '/root'}}};
       controller.onGetAmbariJavaHomeSuccess(test);
       expect(controller.content.installOptions.javaHome).to.equal('/root');
     });
   });
 
   describe('#onGetAmbariJavaHomeError', function() {
-    it('should set default java.home value', function() {
+    it('should set default Ambari Java home value', function() {
       var controller = App.WizardStep2Controller.create({content: {installOptions: {}}});
       controller.onGetAmbariJavaHomeError();
       expect(controller.content.installOptions.javaHome).to.equal(App.get('defaultJavaHome'));

--- a/ambari-web/classic/test/controllers/wizard/step3_test.js
+++ b/ambari-web/classic/test/controllers/wizard/step3_test.js
@@ -2528,17 +2528,18 @@ describe('App.WizardStep3Controller', function () {
         data = {
           RootServiceComponents: {
             properties: {
-              'jdk.name': expected.name,
-              'java.home': expected.home,
+              'ambari.java.home': expected.home,
+              'ambari.java.version': '17',
               'jdk_location': expected.location
             }
           }
         };
 
       c.getJDKNameSuccessCallback(data);
-      expect(c.get('needJDKCheckOnHosts')).to.equal(false);
+      expect(c.get('needJDKCheckOnHosts')).to.equal(true);
       expect(c.get('jdkLocation')).to.equal(expected.location);
       expect(c.get('javaHome')).to.equal(expected.home);
+      expect(c.get('javaVersion')).to.equal('17');
     });
 
   });
@@ -2552,15 +2553,19 @@ describe('App.WizardStep3Controller', function () {
           Em.Object.create({name: 'n2', bootStatus: 'REGISTERED'})
         ],
         javaHome = '/java',
+        javaVersion = '17',
         jdkLocation = '/jdk';
       c.reopen({
         bootHosts: bootHosts,
         javaHome: javaHome,
+        javaVersion: javaVersion,
         jdkLocation: jdkLocation
       });
       c.doCheckJDK();
       var args = testHelpers.findAjaxRequest('name', 'wizard.step3.jdk_check');
       expect(args).exists;
+      expect(args[0].data.java_home).to.equal(javaHome);
+      expect(args[0].data.java_version).to.equal(javaVersion);
     });
 
   });

--- a/ambari-web/latest/src/hooks/useHostChecks.test.tsx
+++ b/ambari-web/latest/src/hooks/useHostChecks.test.tsx
@@ -52,12 +52,9 @@ import { useHostChecks } from "./useHostChecks";
 
 const contextValue = {
   ambariProperties: {
-    RootServiceComponents: {
-      properties: {
-        "java.home": "/opt/custom-java",
-        jdk_location: "/resources",
-      },
-    },
+    "ambari.java.home": "/opt/ambari-java",
+    "ambari.java.version": "17",
+    jdk_location: "/resources",
   },
   clusterName: "cluster1",
 } as ContextType<typeof AppContext>;
@@ -122,7 +119,8 @@ describe("useHostChecks custom JDK validation", () => {
         context: "Check hosts",
         parameters: {
           check_execute_list: "java_home_check",
-          java_home: "/opt/custom-java",
+          java_home: "/opt/ambari-java",
+          java_version: "17",
           jdk_location: "/resources",
           threshold: "60",
         },

--- a/ambari-web/latest/src/hooks/useHostChecks.tsx
+++ b/ambari-web/latest/src/hooks/useHostChecks.tsx
@@ -171,11 +171,7 @@ export const useHostChecks = (
       : newHosts;
     const hostsString = hosts.join(",");
     if (hostsString.length === 0) return null;
-    const jdkLocation = get(
-      ambariProperties,
-      "RootServiceComponents.properties.jdk_location",
-      ""
-    );
+    const jdkLocation = ambariProperties?.jdk_location || "";
     const RequestInfo = {
       action: "check_host",
       context: "Check host",
@@ -1053,8 +1049,8 @@ export const useHostChecks = (
 
   const launchJdkCheck = async () => {
     const hostNames = map(bootHosts.current, "name").join(",");
-    const properties = get(ambariProperties, "RootServiceComponents.properties", {});
-    if (!hostNames || properties["jdk.name"]) {
+    const javaHome = ambariProperties?.["ambari.java.home"];
+    if (!hostNames || !javaHome) {
       finishHostCheck();
       return;
     }
@@ -1064,8 +1060,11 @@ export const useHostChecks = (
         context: "Check hosts",
         parameters: {
           check_execute_list: "java_home_check",
-          java_home: properties["java.home"],
-          jdk_location: properties.jdk_location,
+          java_home: javaHome,
+          java_version: ambariProperties?.["ambari.java.version"]
+            || ambariProperties?.["java.version"]
+            || "17",
+          jdk_location: ambariProperties?.jdk_location,
           threshold: "60",
         },
       },
@@ -1087,11 +1086,7 @@ export const useHostChecks = (
         0,
       )) === 1,
     ).map((task: any) => get(task, "Tasks.host_name", ""));
-    const javaHome = get(
-      ambariProperties,
-      "RootServiceComponents.properties.java.home",
-      "",
-    );
+    const javaHome = ambariProperties?.["ambari.java.home"] || "";
     setWarningData((current: any) => ({
       ...current,
       jdkCategoryWarnings: invalidHosts.length ? [{
@@ -1154,11 +1149,7 @@ export const useHostChecks = (
     bootHosts.current = bootHostsList;
     if (!isEmpty(ambariProperties)) {
       const hostName = map(bootHosts.current, "name").join(",");
-      const jdkLocation = get(
-        ambariProperties,
-        "RootServiceComponents.properties.jdk_location",
-        ""
-      );
+      const jdkLocation = ambariProperties?.jdk_location || "";
       const requestInfo = {
         action: "check_host",
         context: "Check host",

--- a/ambari-web/latest/src/screens/BackgroundOperations/BackgroundOperations.test.tsx
+++ b/ambari-web/latest/src/screens/BackgroundOperations/BackgroundOperations.test.tsx
@@ -228,7 +228,7 @@ describe("Background Operations permissions and abort recovery", () => {
     renderOperations();
 
     await waitFor(() => expect(mocks.fetchBackgroundOperationsSnapshot).toHaveBeenCalledWith(20));
-    fireEvent.click(screen.getByText("Show More..."));
+    fireEvent.click(await screen.findByText("Show More..."));
     await waitFor(() => expect(mocks.fetchBackgroundOperationsSnapshot).toHaveBeenCalledWith(30));
   });
 

--- a/ambari-web/latest/src/screens/ClusterWizard/Step1.tsx
+++ b/ambari-web/latest/src/screens/ClusterWizard/Step1.tsx
@@ -897,8 +897,9 @@ export default function Step1({ wizardName = "clusterCreation" }) {
   };
 
   const continueAfterJdkValidation = () => {
+    const stackJavaVersion = ambariProperties?.["stack.java.version"];
     const compatible = isJdkCompatible(
-      ambariProperties?.["java.version"],
+      stackJavaVersion,
       selectedStack?.min_jdk,
       selectedStack?.max_jdk,
     );
@@ -952,7 +953,7 @@ export default function Step1({ wizardName = "clusterCreation" }) {
           selectedStack?.stack_version || ""
         } version requires JDK ${selectedStack?.min_jdk || selectedStack?.max_jdk} through ${
           selectedStack?.max_jdk || selectedStack?.min_jdk
-        }, but Ambari Server uses ${ambariProperties?.["java.version"]}.`}
+        }, but the configured Stack Java uses ${ambariProperties?.["stack.java.version"]}.`}
         isOpen={showJdkWarning}
         successCallback={() => {
           setShowJdkWarning(false);

--- a/ambari-web/latest/src/screens/ClusterWizard/versionSelection.test.ts
+++ b/ambari-web/latest/src/screens/ClusterWizard/versionSelection.test.ts
@@ -26,9 +26,11 @@ describe("cluster version selection", () => {
     expect(compareVersions("17", "17.0")).toBe(0);
   });
 
-  it("applies inclusive JDK ranges and skips custom JDKs", () => {
-    expect(isJdkCompatible("17.0.8", "11", "17")).toBe(false);
+  it("compares JDK feature versions and skips unconfigured JDKs", () => {
+    expect(isJdkCompatible("17.0.8", "11", "17")).toBe(true);
     expect(isJdkCompatible("17", "11", "17")).toBe(true);
+    expect(isJdkCompatible("8", "1.8", "1.8")).toBe(true);
+    expect(isJdkCompatible("21", "11", "17")).toBe(false);
     expect(isJdkCompatible(undefined, "11", "17")).toBe(true);
     expect(isJdkCompatible("17", undefined, undefined)).toBe(true);
   });

--- a/ambari-web/latest/src/screens/ClusterWizard/versionSelection.ts
+++ b/ambari-web/latest/src/screens/ClusterWizard/versionSelection.ts
@@ -33,6 +33,11 @@ export function compareVersions(left: string, right: string): number {
   return 0;
 }
 
+function jdkFeatureVersion(value: string): number | undefined {
+  const parts = versionParts(value);
+  return parts[0] === 1 ? parts[1] : parts[0];
+}
+
 export function isJdkCompatible(
   currentVersion: string | undefined,
   minimumVersion: string | undefined,
@@ -43,6 +48,11 @@ export function isJdkCompatible(
   }
   const minimum = minimumVersion || maximumVersion || "";
   const maximum = maximumVersion || minimumVersion || "";
-  return compareVersions(currentVersion, minimum) >= 0
-    && compareVersions(currentVersion, maximum) <= 0;
+  const currentFeature = jdkFeatureVersion(currentVersion);
+  const minimumFeature = jdkFeatureVersion(minimum);
+  const maximumFeature = jdkFeatureVersion(maximum);
+  if (currentFeature === undefined || minimumFeature === undefined || maximumFeature === undefined) {
+    return true;
+  }
+  return currentFeature >= minimumFeature && currentFeature <= maximumFeature;
 }

--- a/ambari-web/latest/src/screens/CommonConfigs/TestConnection.test.tsx
+++ b/ambari-web/latest/src/screens/CommonConfigs/TestConnection.test.tsx
@@ -404,9 +404,9 @@ describe("database test connection recovery", () => {
           "hive-site/javax.jdo.option.ConnectionPassword",
       },
       ambariProperties: {
-        "java.home": "/opt/java",
+        "ambari.java.home": "/opt/java",
         jdk_location: "/var/lib/ambari-server/resources",
-        "jdk.name": "jdk.tar.gz",
+        "ambari.jdk.name": "jdk.tar.gz",
       },
     });
     const button = await screen.findByRole("button", {

--- a/ambari-web/latest/src/screens/CommonConfigs/testConnectionUtils.test.ts
+++ b/ambari-web/latest/src/screens/CommonConfigs/testConnectionUtils.test.ts
@@ -121,9 +121,9 @@ describe("Theme Test Connection contract", () => {
       databaseConnectionParameters(
         resolved.values,
         {
-          "java.home": "/java",
+          "ambari.java.home": "/java",
           jdk_location: "/jdk",
-          "jdk.name": "jdk.tar.gz",
+          "ambari.jdk.name": "jdk.tar.gz",
         },
         "ambari01",
       ),

--- a/ambari-web/latest/src/screens/CommonConfigs/testConnectionUtils.ts
+++ b/ambari-web/latest/src/screens/CommonConfigs/testConnectionUtils.ts
@@ -124,9 +124,9 @@ export const databaseConnectionParameters = (
   db_connection_url: String(values["jdbc.driver.url"] ?? ""),
   db_name: normalizeDatabaseType(values["db.type"]),
   ambari_server_host: ambariServerHost,
-  java_home: String(ambariProperties["java.home"] ?? ""),
+  java_home: String(ambariProperties["ambari.java.home"] ?? ""),
   jdk_location: String(ambariProperties.jdk_location ?? ""),
-  jdk_name: String(ambariProperties["jdk.name"] ?? ""),
+  jdk_name: String(ambariProperties["ambari.jdk.name"] ?? ""),
   check_execute_list: "db_connection_check",
   threshold: "60",
 });

--- a/ambari-web/latest/src/screens/Services/reassign/Step4.tsx
+++ b/ambari-web/latest/src/screens/Services/reassign/Step4.tsx
@@ -1560,8 +1560,8 @@ function Step4() {
 
     params["db_name"] = dbType;
     params["jdk_location"] = ambariProperties?.["jdk_location"] || "";
-    params["jdk_name"] = ambariProperties?.["jdk.name"] || "";
-    params["java_home"] = ambariProperties?.["java.home"] || "";
+    params["jdk_name"] = ambariProperties?.["ambari.jdk.name"] || "";
+    params["java_home"] = ambariProperties?.["ambari.java.home"] || "";
     params["threshold"] = 60;
     params["ambari_server_host"] = window.location.hostname;
     params["check_execute_list"] = "db_connection_check";

--- a/contrib/utils/preinstall-check/src/main/python/preinstall_checker.py
+++ b/contrib/utils/preinstall-check/src/main/python/preinstall_checker.py
@@ -663,9 +663,10 @@ def run_java_home_checks(options, agents, server_url):
   label_check = 'Java Home location'
   step(label_check)
   url = '{0}/api/v1/requests'.format(server_url)
-  java_home = get_ambari_server_property('java.home')
+  java_home = get_ambari_server_property('ambari.java.home')
+  java_version = get_ambari_server_property('ambari.java.version') or get_ambari_server_property('java.version')
   logger.info('Ambari server java home: {0}'.format(java_home))
-  data = '{{"RequestInfo":{{"context":"Check hosts","action":"check_host","parameters":{{"threshold":"60","java_home":"{0}","jdk_location":"{1}/resources","check_execute_list":"java_home_check"}}}},"Requests/resource_filters":[{{"hosts":"{2}"}}]}}'.format(java_home, server_url, ','.join(agents))
+  data = '{{"RequestInfo":{{"context":"Check hosts","action":"check_host","parameters":{{"threshold":"60","java_home":"{0}","java_version":"{1}","jdk_location":"{2}/resources","check_execute_list":"java_home_check"}}}},"Requests/resource_filters":[{{"hosts":"{3}"}}]}}'.format(java_home, java_version, server_url, ','.join(agents))
   logger.debug('Java home check data {0}'.format(data))
   task_results_by_hosts, results_to_print = run_check(options, url, label_check, data)
   java_home_check_parser(task_results_by_hosts, results_to_print)


### PR DESCRIPTION
Issue: [AMBARI-26641](https://issues.apache.org/jira/browse/AMBARI-26641)

## What changes were proposed in this pull request?

Separate Java selection into three layers:

1. `ambari.java.home` and `ambari.java.version` for Ambari Server and Ambari-owned Agent Java helpers.
2. `stack.java.home` and `stack.java.version` for the default stack service JDK, with compatibility fallback through the legacy `java.home` setting.
3. BIGTOP `cluster-env/java_home_overrides` for pre-installed service or component JDKs, with component entries taking precedence and invalid entries falling back to the stack JDK.

The patch also migrates existing setup and upgrade properties, validates actual Java feature versions during setup and host checks, keeps database and credential helpers on the Ambari JDK, updates JDK-compatible BIGTOP GC settings, exposes the effective Java metadata, and updates the classic and React installation workflows. Windows behavior is intentionally outside this change.

## How was this patch tested?

Static checks passed for `git diff --check`, the two modified XML files with `xmllint --noout`, modified Python files with `py_compile` (excluding the existing Python 2 preinstall checker), modified classic JavaScript files with `node --check`, the React TypeScript production build, and focused React lint. No Ember tests were run.

Focused Agent Python tests, 6 passed:

```shell
docker exec \
  -e PYTHONDONTWRITEBYTECODE=1 \
  -e PYTHONPATH=/workspace/ambari-common/src/main/python:/workspace/ambari-agent/src/main/python:/workspace/ambari-agent/src/main/python/ambari_agent:/workspace/ambari-common/src/main/python/ambari_jinja2:/workspace/ambari-common/src/main/python/ambari_commons:/workspace/ambari-common/src/test/python:/workspace/ambari-agent/src/test/python:/workspace/ambari-agent/src/test/python/ambari_agent:/workspace/ambari-agent/src/main/python/resource_management:/workspace/ambari-agent/src/test/python/resource_management:/workspace/ambari-server/src/test/python:/workspace/ambari-server/src/main/resources/common-services/HDFS/2.1.0.2.0/package/files \
  ambari-jdk17-focused-tests bash -lc \
  'cd /workspace/ambari-agent/src/test/python/ambari_agent && ambari-builder-python -m unittest TestConfigurationBuilder.TestConfigurationBuilder'
```

Focused Server setup, upgrade, Java discovery, and host-check Python tests, 10 passed:

```shell
docker exec \
  -e PYTHONDONTWRITEBYTECODE=1 \
  -e PYTHONPATH=/workspace/ambari-common/src/main/python:/workspace/ambari-agent/src/main/python:/workspace/ambari-agent/src/main/python/ambari_agent:/workspace/ambari-common/src/main/python/ambari_jinja2:/workspace/ambari-common/src/main/python/ambari_commons:/workspace/ambari-common/src/test/python:/workspace/ambari-server/src/main/python:/workspace/ambari-server/src/main/python/ambari-server-state:/workspace/ambari-server/src/main/resources/custom_actions:/workspace/ambari-server/src/main/resources/custom_actions/scripts:/workspace/ambari-server/src/main/resources/scripts:/workspace/ambari-server/src/test/python:/workspace/ambari-server/src/test/python/custom_actions \
  ambari-jdk17-focused-tests bash -lc \
  'cd /workspace/ambari-server/src/test/python && ambari-builder-python -m unittest TestAmbariServer.TestAmbariServer.test_download_jdk TestAmbariServer.TestAmbariServer.test_check_ambari_java_version_is_valid TestAmbariServer.TestAmbariServer.test_jdk_setup_keeps_ambari_and_stack_java_independent TestAmbariServer.TestAmbariServer.test_jdk_setup_validates_all_java_homes_before_updating_properties TestAmbariServer.TestAmbariServer.test_find_jdk TestAmbariServer.TestAmbariServer.test_find_jdk_skips_versions_below_minimum TestAmbariServer.TestAmbariServer.test_get_java_version TestAmbariServer.TestAmbariServer.test_migrate_java_home_properties custom_actions.TestCheckHost.TestCheckHost.testJavaHomeAvailableCheck custom_actions.TestCheckHost.TestCheckHost.testJavaHomeAvailableCheckRejectsWrongVersion'
```

Focused Java tests under JDK 17, 93 passed:

```shell
mvn -pl ambari-server \
  -Dtest=ConfigurationTest,StageUtilsTest,RootServiceResponseFactoryTest \
  -DfailIfNoTests=false \
  compiler:compile compiler:testCompile surefire:test
```

Focused React tests, 4 files and 21 tests passed:

```shell
npx vitest run \
  src/hooks/useHostChecks.test.tsx \
  src/screens/ClusterWizard/versionSelection.test.ts \
  src/screens/CommonConfigs/TestConnection.test.tsx \
  src/screens/CommonConfigs/testConnectionUtils.test.ts
```

An Ambari-only Rocky 8 aarch64 RPM build completed successfully from the implementation commit. Its verified manifest contains only `ambari-agent` and `ambari-server`; no Hadoop ecosystem package was rebuilt. A three-node BIGTOP 3.3.0 cluster was then deployed from the digest-pinned preloaded runtime image with ZooKeeper, HDFS, YARN, Hive, and HBase. All 13 deploy phases completed successfully.

Live validation confirmed:

- Ambari Server runs JDK 17 and reports `ambari.java.home/version=17` while `stack.java.home/version=8`.
- Agent metadata carries both JDK layers, and Agent JCEKS `CredentialShell` helpers actually executed with the Ambari JDK 17 path.
- ZooKeeper, HDFS, YARN, Hive, and HBase initially ran on the stack JDK 8.
- A `ZOOKEEPER=JDK 8` service override plus `ZOOKEEPER_SERVER=JDK 17` component override moved one restarted ZooKeeper process to JDK 17 while NameNode and DataNode on the same host remained on JDK 8.
- The structured `java_home_check` action passed on all three hosts and reported the expected JDK 17 feature version, vendor, runtime, and executable home.

The first local topology included Metrics but deploy generated `VICTORIAMETRICS_SERVER`, which is not present in current Ambari trunk. Metrics was removed from this JDK-focused deployment; the final supported-stack deployment passed.

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.
