### PR TITLE
AMBARI-26648: Service Configs Bug: all properties render read-only, and JVM/command-line values incorrectly split into multi-line display

### DIFF
--- a/ambari-web/latest/src/Utils/configHistory.ts
+++ b/ambari-web/latest/src/Utils/configHistory.ts
@@ -113,7 +113,11 @@ export function resolveConfigHistorySelection(
   currentDefaultVersion: string,
   navigationState?: ConfigHistoryNavigationState | null,
 ) {
-  const selectedVersion = navigationState?.serviceConfigVersion || currentDefaultVersion;
+  // Normalize to string: navigationState may carry a raw numeric version
+  // (e.g. from router state constructed elsewhere), and comparing that
+  // against the string-typed currentDefaultVersion with === would otherwise
+  // never match, making every property look read-only.
+  const selectedVersion = String(navigationState?.serviceConfigVersion || currentDefaultVersion);
   const configGroup = navigationState?.configGroup || "Default";
   const versionsToLoad = selectedVersion === currentDefaultVersion && configGroup === "Default"
     ? null

--- a/ambari-web/latest/src/Utils/jvmFormatUtils.test.ts
+++ b/ambari-web/latest/src/Utils/jvmFormatUtils.test.ts
@@ -24,24 +24,33 @@ import {
 } from "./jvmFormatUtils";
 
 describe("JVM parameter formatting", () => {
-  it("formats JVM options without splitting quoted whitespace", () => {
-    const value = '-Xmx1g -Dname="value with spaces" -XX:+UseG1GC';
-    const displayed = [
-      "-Xmx1g",
-      '-Dname="value with spaces"',
-      "-XX:+UseG1GC",
-    ].join("\n");
+  it("does not treat single-line JVM/command-line argument strings as multiline", () => {
+    // e.g. mapreduce.admin.map.child.java.opts — must stay single-line, or the
+    // injected display newlines get persisted and corrupt the config.
+    const value =
+      "-server -XX:NewRatio=8 -Djava.net.preferIPv4Stack=true -Dhdp.version=${hdp.version}";
 
-    expect(shouldUseMultilineFormatting(value, "string")).toBe(true);
-    expect(formatParamsForDisplay(value, "string")).toBe(displayed);
-    expect(formatParamsForSave(displayed)).toBe(value);
+    expect(shouldUseMultilineFormatting(value)).toBe(false);
+    expect(formatParamsForDisplay(value)).toBe(value);
+    expect(formatParamsForSave(value)).toBe(value);
   });
 
-  it("does not rewrite ordinary or explicitly multiline content", () => {
+  it("honors an explicit multiLine displayType regardless of content", () => {
+    expect(shouldUseMultilineFormatting("-Xmx1g -Xms1g", "multiLine")).toBe(true);
+  });
+
+  it("does not treat content as multiline when displayType says otherwise", () => {
     expect(shouldUseMultilineFormatting("first\nsecond", "string")).toBe(false);
-    expect(shouldUseMultilineFormatting("-Xmx1g -Xms1g", "multiLine")).toBe(
-      false,
-    );
-    expect(shouldUseMultilineFormatting("plain words", "string")).toBe(false);
+  });
+
+  it("falls back to content-based detection when no displayType is given", () => {
+    expect(shouldUseMultilineFormatting("first\nsecond")).toBe(true);
+    expect(shouldUseMultilineFormatting("first\\nsecond")).toBe(true);
+    expect(shouldUseMultilineFormatting("plain words")).toBe(false);
+  });
+
+  it("converts escaped newlines for display and leaves real newlines for save", () => {
+    expect(formatParamsForDisplay("first\\nsecond")).toBe("first\nsecond");
+    expect(formatParamsForSave("first\nsecond")).toBe("first\nsecond");
   });
 });

--- a/ambari-web/latest/src/Utils/jvmFormatUtils.ts
+++ b/ambari-web/latest/src/Utils/jvmFormatUtils.ts
@@ -16,66 +16,62 @@
  * limitations under the License.
  */
 
-const splitQuotedParameters = (value: string): string[] => {
-  const parameters: string[] = [];
-  let current = "";
-  let quote = "";
-  let escaped = false;
-
-  for (const character of value) {
-    if (escaped) {
-      current += character;
-      escaped = false;
-      continue;
-    }
-    if (character === "\\") {
-      current += character;
-      escaped = true;
-      continue;
-    }
-    if (quote) {
-      current += character;
-      if (character === quote) quote = "";
-      continue;
-    }
-    if (character === '"' || character === "'") {
-      current += character;
-      quote = character;
-      continue;
-    }
-    if (/\s/.test(character)) {
-      if (current) parameters.push(current);
-      current = "";
-      continue;
-    }
-    current += character;
-  }
-  if (current) parameters.push(current);
-  return parameters;
+// Checks if a string contains only a single line. Also treats an escaped
+// newline sequence from the backend as a newline.
+const isSingleLine = (value: string): boolean => {
+  const stringValue = String(value).trim();
+  return stringValue.indexOf("\n") === -1 && stringValue.indexOf("\\n") === -1;
 };
 
-const startsLikeJvmOption = (value: string) =>
-  /^(?:-X|-D|-XX:|-server$|-client$|--add-(?:opens|exports)=)/.test(value);
-
-export const formatParamsForDisplay = (
-  value: string,
-  _displayType?: string,
-): string => splitQuotedParameters(String(value ?? "")).join("\n");
-
-export const formatParamsForSave = (value: string): string =>
-  splitQuotedParameters(String(value ?? "")).join(" ");
-
+// Ember's logic: an explicit displayType from the backend takes priority;
+// otherwise fall back to content-based detection. Values that merely look
+// like command-line/JVM arguments (e.g. mapreduce.admin.map.child.java.opts:
+// "-server -XX:NewRatio=8 -Djava.net.preferIPv4Stack=true -Dhdp.version=${hdp.version}")
+// must NOT be treated as multiline just because they contain multiple "-X"-style
+// tokens — only genuine (real or escaped) newlines should.
 export const shouldUseMultilineFormatting = (
   value: string,
   displayType?: string,
 ): boolean => {
-  if (
-    ["content", "directories", "directory", "multiLine"].includes(
-      String(displayType),
-    )
-  ) {
+  if (!value || typeof value !== "string") {
     return false;
   }
-  const parameters = splitQuotedParameters(String(value ?? ""));
-  return parameters.length > 1 && parameters.every(startsLikeJvmOption);
+  if (displayType) {
+    return displayType === "multiLine";
+  }
+  return !isSingleLine(value);
+};
+
+export const formatParamsForDisplay = (
+  value: string,
+  displayType?: string,
+): string => {
+  if (!value || typeof value !== "string") {
+    return value;
+  }
+  if (!shouldUseMultilineFormatting(value, displayType)) {
+    return value;
+  }
+  // Already has real newlines; let the textarea render it naturally.
+  if (value.includes("\n")) {
+    return value;
+  }
+  // Convert escaped newline sequences to actual newlines for display.
+  if (value.includes("\\n")) {
+    return value.replace(/\\n/g, "\n");
+  }
+  return value;
+};
+
+// Leaves real newlines as real newlines — JSON.stringify() will escape them
+// when the save payload is serialized. Escaping here too would double-escape
+// (\n -> \\n -> \\\\n).
+export const formatParamsForSave = (value: string): string => {
+  if (!value || typeof value !== "string") {
+    return value;
+  }
+  if (value.includes("\\n")) {
+    return value;
+  }
+  return value;
 };

--- a/ambari-web/latest/src/screens/ServiceConfigs/index.tsx
+++ b/ambari-web/latest/src/screens/ServiceConfigs/index.tsx
@@ -233,7 +233,8 @@ export default function ServiceConfigs({
   async function onVersionChange(versionNumber: any) {
     const requestId = ++versionRequestId.current;
     try {
-      setSelectedVersion(versionNumber);
+      // Normalize to string so it compares correctly against defaultVersionNumber.
+      setSelectedVersion(String(versionNumber));
       let apiVersionNumber = versionNumber;
       if (configGroup !== "Default") {
         apiVersionNumber = defaultVersionNumber + "," + versionNumber;


### PR DESCRIPTION
AMBARI-26648: Service Configs Bug: all properties render read-only, and JVM/command-line values incorrectly split into multi-line display

## What changes were proposed in this pull request?

(Please fill in changes proposed in this fix)

## How was this patch tested?
Tested on local cluster
<img width="1888" height="861" alt="image" src="https://github.com/user-attachments/assets/61e4a295-2fd3-4707-82c7-78b044d38a21" />


(Please explain how this patch was tested. Ex: unit tests, manual tests)
(If this patch involves UI changes, please attach a screen-shot; otherwise, remove this)

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.