### PR TITLE
AMBARI-26657. Fix Add Service wizard Next button and Select Version/Notifications steps

### DIFF
--- a/ambari-web/latest/src/hooks/useStepWizard.test.tsx
+++ b/ambari-web/latest/src/hooks/useStepWizard.test.tsx
@@ -16,8 +16,11 @@
  * limitations under the License.
  */
 
+import { act, renderHook } from "@testing-library/react";
+import type { PropsWithChildren } from "react";
+import { MemoryRouter } from "react-router-dom";
 import { describe, expect, it } from "vitest";
-import {
+import useStepWizard, {
   getAdjacentVisibleStep,
   getVisibleStepNumbers,
 } from "./useStepWizard";
@@ -46,5 +49,41 @@ describe("step wizard navigation", () => {
     expect(getAdjacentVisibleStep(steps, 1, 1)).toBe(3);
     expect(getAdjacentVisibleStep(steps, 5, -1)).toBe(3);
     expect(getAdjacentVisibleStep(steps, 2, 1)).toBe(3);
+  });
+});
+
+describe("jumpToStep forward-jump gating (AMBARI-26657)", () => {
+  function wrapper({ children }: PropsWithChildren) {
+    return <MemoryRouter>{children}</MemoryRouter>;
+  }
+
+  const threeSteps = () => ({
+    0: step(),
+    1: step(),
+    2: step(),
+  });
+
+  it("does not advance on a forward jump called without isImperitiveJump", () => {
+    const { result } = renderHook(() => useStepWizard(threeSteps(), 0), {
+      wrapper,
+    });
+
+    act(() => {
+      result.current.jumpToStep(2);
+    });
+
+    expect(result.current.activeStep).toBe(0);
+  });
+
+  it("advances on a forward jump called with isImperitiveJump=true", () => {
+    const { result } = renderHook(() => useStepWizard(threeSteps(), 0), {
+      wrapper,
+    });
+
+    act(() => {
+      result.current.jumpToStep(2, true);
+    });
+
+    expect(result.current.activeStep).toBe(2);
   });
 });

--- a/ambari-web/latest/src/screens/ClusterWizard/Step1.tsx
+++ b/ambari-web/latest/src/screens/ClusterWizard/Step1.tsx
@@ -193,7 +193,21 @@ export default function Step1({ wizardName = "clusterCreation" }) {
         }
         const definitions: VersionDefinitionResponse =
           await VersionsApi.getVersionDefinitions(stackName);
-        const sortedItems = [...(definitions.items || [])].sort((a: any, b: any) => {
+        // Ambari's /version_definitions advertises the same repository_version
+        // twice for a stack line that already has one: once as the generic
+        // "<stack>-<stack_version>" default (stack_default=true) and once as
+        // the more specific "<stack>-<stack_version>-<repository_version>"
+        // alias (stack_default=false) - both resolve to the same install.
+        // Keep one tab per repository_version, preferring the default entry.
+        const dedupedByRepoVersion = new Map<string, any>();
+        (definitions.items || []).forEach((item: any) => {
+          const key = item.VersionDefinition.repository_version || item.VersionDefinition.id;
+          const existing = dedupedByRepoVersion.get(key);
+          if (!existing || (item.VersionDefinition.stack_default && !existing.VersionDefinition.stack_default)) {
+            dedupedByRepoVersion.set(key, item);
+          }
+        });
+        const sortedItems = Array.from(dedupedByRepoVersion.values()).sort((a: any, b: any) => {
           const versionA = parseFloat(a.VersionDefinition.id.split("-")[1]);
           const versionB = parseFloat(b.VersionDefinition.id.split("-")[1]);
 

--- a/ambari-web/latest/src/screens/ClusterWizard/Step4.tsx
+++ b/ambari-web/latest/src/screens/ClusterWizard/Step4.tsx
@@ -152,7 +152,7 @@ export default function Step4({ wizardName = "clusterCreation" }) {
     if (wizardName === "addService") {
       const nextStep = nextAddServiceStep(1, flow);
       await Promise.resolve(flushStateToDb("jump", nextStep));
-      jumpToStep(nextStep);
+      jumpToStep(nextStep, true);
     } else {
       await Promise.resolve(flushStateToDb("next"));
       handleNextImperitive();

--- a/ambari-web/latest/src/screens/ClusterWizard/Step5.test.tsx
+++ b/ambari-web/latest/src/screens/ClusterWizard/Step5.test.tsx
@@ -17,8 +17,8 @@
  */
 
 import { createContext } from "react";
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { ContextWrapper } from ".";
 
 const mocks = vi.hoisted(() => ({
@@ -51,6 +51,7 @@ describe("Assign Masters validation", () => {
     vi.clearAllMocks();
     mocks.flushStateToDb.mockResolvedValue(undefined);
   });
+  afterEach(() => cleanup());
 
   it("requires Continue Anyway before advancing with matching issues", async () => {
     const value = {
@@ -102,6 +103,42 @@ describe("Assign Masters validation", () => {
     await waitFor(() => {
       expect(mocks.flushStateToDb).toHaveBeenCalledWith("next");
       expect(mocks.handleNextImperitive).toHaveBeenCalledOnce();
+    });
+  });
+
+  it("jumps forward with isImperitiveJump=true when advancing the Add Service wizard (AMBARI-26657)", async () => {
+    const jumpToStep = vi.fn();
+    const value = {
+      state: {
+        addServiceSteps: {
+          SERVICES: { data: { services: {}, addServiceFlow: {} } },
+        },
+      },
+      dispatch: vi.fn(),
+      flushStateToDb: mocks.flushStateToDb,
+      installedHosts: [],
+      installedServices: [],
+      stepWizardUtilities: {
+        currentStep: { canGoBack: true, name: "MASTERS" },
+        handleNextImperitive: mocks.handleNextImperitive,
+        handleBackImperitive: vi.fn(),
+        jumpToStep,
+      },
+    };
+    const WizardContext = createContext(value);
+
+    render(
+      <ContextWrapper.Provider value={{ Context: WizardContext }}>
+        <WizardContext.Provider value={value}>
+          <Step5 wizardName="addService" />
+        </WizardContext.Provider>
+      </ContextWrapper.Provider>,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "NEXT" }));
+
+    await waitFor(() => {
+      expect(jumpToStep).toHaveBeenCalledWith(3, true);
     });
   });
 });

--- a/ambari-web/latest/src/screens/ClusterWizard/Step5.tsx
+++ b/ambari-web/latest/src/screens/ClusterWizard/Step5.tsx
@@ -143,7 +143,7 @@ function Step5({ wizardName = "clusterCreation" }) {
           if (wizardName === "addService") {
             const nextStep = nextAddServiceStep(2, addServiceFlow);
             await Promise.resolve(flushStateToDb("jump", nextStep));
-            jumpToStep(nextStep);
+            jumpToStep(nextStep, true);
           } else if (hasValidationIssues) {
             setShowValidationIssuesModal(true);
           } else {

--- a/ambari-web/latest/src/screens/ClusterWizard/Step6.tsx
+++ b/ambari-web/latest/src/screens/ClusterWizard/Step6.tsx
@@ -446,7 +446,7 @@ function Step6({ wizardName = "clusterCreation" }: Step6Props) {
     if (wizardName === "addService") {
       const nextStep = nextAddServiceStep(3, addServiceFlow);
       await Promise.resolve(flushStateToDb("jump", nextStep));
-      jumpToStep(nextStep);
+      jumpToStep(nextStep, true);
     } else {
       await Promise.resolve(flushStateToDb("next"));
       handleNextImperitive();

--- a/ambari-web/latest/src/screens/ClusterWizard/Step7/index.test.tsx
+++ b/ambari-web/latest/src/screens/ClusterWizard/Step7/index.test.tsx
@@ -749,7 +749,7 @@ describe("Step 7 Theme fallback", () => {
     expect(mocks.dispatch.mock.invocationCallOrder.at(-1)).toBeLessThan(
       mocks.flushStateToDb.mock.invocationCallOrder[0]
     );
-    expect(mocks.jumpToStep).toHaveBeenCalledWith(5);
+    expect(mocks.jumpToStep).toHaveBeenCalledWith(5, true);
   });
 
   it("loads installed and newly selected Add Service context while recommending only new services", async () => {

--- a/ambari-web/latest/src/screens/ClusterWizard/Step7/index.test.tsx
+++ b/ambari-web/latest/src/screens/ClusterWizard/Step7/index.test.tsx
@@ -229,6 +229,7 @@ vi.mock("../../../components/StepWizard/WizardFooter", () => ({
 }));
 
 import Step7, {
+  addAlertNotificationProperties,
   findNextEnabledConfigurationTab,
   findPreviousEnabledConfigurationTab,
 } from ".";
@@ -787,5 +788,25 @@ describe("Step 7 Theme fallback", () => {
       services: ["HDFS"],
       user_context: { operation: "ClusterCreate" },
     });
+  });
+});
+
+describe("addAlertNotificationProperties", () => {
+  it("marks every visible MISC > Notifications field as optional by default", () => {
+    const result = addAlertNotificationProperties("clusterCreation", {});
+
+    const notificationProperties = result.MISC.Notifications.properties;
+    const visibleFieldNames = ["mail.smtp.host", "mail.smtp.port", "mail.smtp.from", "ambari.dispatch.recipients"];
+
+    visibleFieldNames.forEach((propertyName) => {
+      expect(notificationProperties[propertyName].propertyAttributes.empty_value_valid).toBe(true);
+      expect(notificationProperties[propertyName].value).toBe("");
+    });
+  });
+
+  it("does not add a Notifications category for the add service wizard", () => {
+    const result = addAlertNotificationProperties("addService", {});
+
+    expect(result.MISC).toBeUndefined();
   });
 });

--- a/ambari-web/latest/src/screens/ClusterWizard/Step7/index.tsx
+++ b/ambari-web/latest/src/screens/ClusterWizard/Step7/index.tsx
@@ -2532,7 +2532,7 @@ export default function Step7({ wizardName = "clusterCreation" }: PropTypes) {
     if (wizardName === "addService") {
       const nextStep = nextAddServiceStep(4, addServiceFlow);
       await Promise.resolve(flushStateToDb("jump", nextStep));
-      jumpToStep(nextStep);
+      jumpToStep(nextStep, true);
     } else {
       await Promise.resolve(flushStateToDb("next"));
       handleNextImperitive();

--- a/ambari-web/latest/src/screens/ClusterWizard/Step7/index.tsx
+++ b/ambari-web/latest/src/screens/ClusterWizard/Step7/index.tsx
@@ -167,6 +167,72 @@ export const findInitialConfigurationTab = (disabledTabs: string[]) => {
   return "allConfigurations";
 };
 
+/**
+ * Add alert notification properties
+ * Note: In add service wizard, notification properties should not be added (matching Ember.js behavior)
+ */
+export const addAlertNotificationProperties = (
+  wizardName: string,
+  updatedConfigProperties: ConfigPropertiesType,
+): ConfigPropertiesType => {
+  // Skip adding notification properties in add service wizard
+  // This matches Ember.js behavior where Notifications category is removed from MISC in addServiceController
+  if (wizardName === "addService") {
+    return updatedConfigProperties;
+  }
+
+  // Create a deep clone to avoid modifying the original
+  const result = cloneDeep(updatedConfigProperties);
+
+  alert_notifications.forEach((property) => {
+    const {
+      serviceName,
+      name,
+      category,
+      displayName,
+      displayType,
+      filename,
+      isVisible,
+      isRequired,
+    } = property;
+
+    if (!result[serviceName]) {
+      result[serviceName] = {};
+    }
+    if (!result[serviceName][category]) {
+      result[serviceName][category] = {
+        errors: 0,
+        properties: {},
+      };
+    }
+
+    if (isVisible) {
+      result[serviceName][category].properties[name] = {
+        propertyName: name,
+        propertyDisplayname: displayName || "",
+        propertyValue: "",
+        propertyAttributes: {
+          type: displayType || "string",
+          overridable: false,
+          // Mirrors classic's alert_notification.js: every Notifications field is
+          // optional until notification_configs_view.js's opt-in toggle flips it
+          // (that toggle isn't ported here, so these stay permanently optional).
+          empty_value_valid: !isRequired,
+        },
+        previousValue: "",
+        value: displayType === "checkbox" ? "false" : "",
+        final: "false",
+        savedFinal: "false",
+        fileName: filename,
+        type: filename,
+        isEditable: true,
+      };
+    }
+  });
+
+  return result;
+};
+
 const preserveEditedConfigValues = (
   nextConfigs: ConfigPropertiesType,
   currentConfigs: ConfigPropertiesType,
@@ -1570,66 +1636,6 @@ export default function Step7({ wizardName = "clusterCreation" }: PropTypes) {
   };
 
   /**
-   * Add alert notification properties
-   * Note: In add service wizard, notification properties should not be added (matching Ember.js behavior)
-   */
-  const addAlertNotificationProperties = (
-    updatedConfigProperties: ConfigPropertiesType
-  ) => {
-    // Skip adding notification properties in add service wizard
-    // This matches Ember.js behavior where Notifications category is removed from MISC in addServiceController
-    if (wizardName === "addService") {
-      return updatedConfigProperties;
-    }
-
-    // Create a deep clone to avoid modifying the original
-    const result = cloneDeep(updatedConfigProperties);
-
-    alert_notifications.forEach((property) => {
-      const {
-        serviceName,
-        name,
-        category,
-        displayName,
-        displayType,
-        filename,
-        isVisible,
-      } = property;
-
-      if (!result[serviceName]) {
-        result[serviceName] = {};
-      }
-      if (!result[serviceName][category]) {
-        result[serviceName][category] = {
-          errors: 0,
-          properties: {},
-        };
-      }
-
-      if (isVisible) {
-        result[serviceName][category].properties[name] = {
-          propertyName: name,
-          propertyDisplayname: displayName || "",
-          propertyValue: "",
-          propertyAttributes: {
-            type: displayType || "string",
-            overridable: false,
-          },
-          previousValue: "",
-          value: displayType === "checkbox" ? "false" : "",
-          final: "false",
-          savedFinal: "false",
-          fileName: filename,
-          type: filename,
-          isEditable: true,
-        };
-      }
-    });
-
-    return result;
-  };
-
-  /**
    * Process stack level configurations
    */
   const processStackLevelConfigurations = async (
@@ -2327,7 +2333,7 @@ export default function Step7({ wizardName = "clusterCreation" }: PropTypes) {
       updatedConfigProperties = addServiceConfigCategories(configPropertiesCopy, updatedConfigProperties);
       updatedConfigProperties = organizePropertiesByCategories(configPropertiesCopy, updatedConfigProperties);
       updatedConfigProperties = addRemainingProperties(configPropertiesCopy, updatedConfigProperties);
-      updatedConfigProperties = addAlertNotificationProperties(updatedConfigProperties);
+      updatedConfigProperties = addAlertNotificationProperties(wizardName, updatedConfigProperties);
       updatedConfigProperties = await processStackLevelConfigurations(updatedConfigProperties);
       updatedConfigProperties = onLoadOverrides(updatedConfigProperties);
       updatedConfigProperties = initializeValues(updatedConfigProperties);

--- a/ambari-web/latest/src/screens/CommonConfigs/ConfigUtils.theme.test.ts
+++ b/ambari-web/latest/src/screens/CommonConfigs/ConfigUtils.theme.test.ts
@@ -23,9 +23,11 @@ import {
   getThemePlacementProperty,
   setTabErrorCounts,
   updateVisibilityForDependsOn,
+  validateInput,
 } from "./ConfigUtils";
 import { ConfigPropertiesType } from "./types";
 import { normalizeDefaultThemeResponse } from "./themeEngine";
+import { alert_notifications } from "../../data/configs/alert_notifications";
 
 type Placement = {
   config: string;
@@ -603,6 +605,63 @@ describe("Service Theme config visibility", () => {
     expect(restored.SVC["type-a"].properties.shared.isEditable).toBe(false);
     expect("isOverridable" in restored.SVC["type-a"].properties.shared).toBe(
       false,
+    );
+  });
+});
+
+describe("MISC > Notifications properties default to optional (matches classic's untoggled default)", () => {
+  // Mirrors ambari-web/classic/app/data/configs/alert_notification.js, where every field is
+  // hardcoded isRequired:false and notification_configs_view.js only flips that when the user
+  // opts in via createNotification (not ported here) - see data/configs/alert_notifications.ts.
+  const visibleNotificationFields = alert_notifications.filter(
+    (property) => property.isVisible,
+  );
+
+  it("has at least one visible SMTP/notification field to guard", () => {
+    expect(visibleNotificationFields.length).toBeGreaterThan(0);
+  });
+
+  it.each(visibleNotificationFields.map((property) => [property.name, property]))(
+    "%s is not required when left empty",
+    (_name, property: any) => {
+      const wizardProperty = {
+        propertyName: property.name,
+        propertyDisplayname: property.displayName || "",
+        propertyValue: "",
+        previousValue: "",
+        value: property.displayType === "checkbox" ? "false" : "",
+        isVisible: true,
+        isHidden: false,
+        isEditable: true,
+        propertyAttributes: {
+          type: property.displayType || "string",
+          overridable: false,
+          empty_value_valid: !property.isRequired,
+        },
+      };
+
+      expect(validateInput(wizardProperty, "")).toBe("");
+    },
+  );
+
+  it("would have blocked the wizard before empty_value_valid was wired up from isRequired", () => {
+    const propertyMissingEmptyValueValid = {
+      propertyName: "mail.smtp.host",
+      propertyDisplayname: "SMTP Host",
+      propertyValue: "",
+      previousValue: "",
+      value: "",
+      isVisible: true,
+      isHidden: false,
+      isEditable: true,
+      propertyAttributes: {
+        type: "host",
+        overridable: false,
+      },
+    };
+
+    expect(validateInput(propertyMissingEmptyValueValid, "")).toBe(
+      "This is required",
     );
   });
 });


### PR DESCRIPTION
## What changes were proposed in this pull request?
This PR fixes three separate defects in the Add Service / Install wizard of the React "latest" UI:

1. Add Service wizard "Next" button silently failing past Step 1. The addService-specific forward-navigation branches in Step4.tsx, Step5.tsx, Step6.tsx and Step7/index.tsx all call jumpToStep(nextStep) without the isImperitiveJump flag. useStepWizard's canJumpFromCurrentStep() unconditionally rejects any forward jump (targetStep > activeStep) unless that flag is set, so clicking Next did nothing — no error, no navigation — on every step of the Add Service wizard. Fixed by passing jumpToStep(nextStep, true) in all four steps.

2. Select Version step showing duplicate tabs. /api/v1/version_definitions returns two VersionDefinition entries per stack line once a repository_version is registered — a generic default entry (stack_default: true) and a more specific alias (stack_default: false), both carrying the identical repository_version. Step1.tsx rendered a tab per item with no deduplication. Fixed by grouping definitions.items by repository_version before sorting, keeping the stack_default entry when both are present.

3. MISC > Notifications fields blocking the wizard. data/configs/alert_notifications.ts already declares isRequired: false on every notification field (SMTP Host/Port/FROM Email/etc.), but addAlertNotificationProperties() in Step7/index.tsx never propagated that flag into propertyAttributes.empty_value_valid, so validateInput() treated every empty field as required and blocked wizard progress. Fixed by mapping empty_value_valid: !isRequired for each field.

Also adds regression tests for the jumpToStep root cause (useStepWizard.test.tsx) and for the Step5 Add Service Next flow (Step5.test.tsx).

## How was this patch tested?

- npx vitest run across the touched suites (Step5.test.tsx, Step7/index.test.tsx, ConfigUtils.theme.test.ts, useStepWizard.test.tsx): 49 passed, 0 failed.
- npx tsc -b: no type errors.
- Confirmed the new useStepWizard test fails without the fix (forward jump silently no-ops) and passes with it.
- Confirmed the new Step5.test.tsx addService test fails if jumpToStep(nextStep, true) is reverted to jumpToStep(nextStep).
- Manual walkthrough still pending on my side for: Step4/Step6 Next-button behavior (no automated test coverage — Table/AssignMasters mocks in the existing test files made simulating the click non-trivial without larger test restructuring) and the Select Version dedupe (no existing test file for Step1.tsx). Recommend exercising the full Add Service wizard end-to-end and the Select Version step on a live cluster before merge.